### PR TITLE
Add display url provider integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.16</version>
+        <version>4.18</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -16,7 +16,7 @@
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/pipeline-graph-view-plugin</gitHubRepo>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.263.4</jenkins.version>
+        <jenkins.version>2.277.1</jenkins.version>
         <java.level>8</java.level>
         <node.version>15.9.0</node.version>
         <npm.version>7.5.6</npm.version>
@@ -29,8 +29,8 @@
             <dependency>
                 <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.263.x</artifactId>
-                <version>25</version>
+                <artifactId>bom-2.277.x</artifactId>
+                <version>807.v6d348e44c987</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -111,16 +111,6 @@
             <version>1.3.2</version>
         </dependency>
     </dependencies>
-
-    
-    <!-- If you want this to appear on the plugin site page:
-    <developers>
-      <developer>
-        <id>bhacker</id>
-        <name>Bob Q. Hacker</name>
-        <email>bhacker@nowhere.net</email>
-      </developer>
-    </developers> -->
 
     <licenses>
         <license>

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphDisplayURLProvider.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphDisplayURLProvider.java
@@ -1,0 +1,29 @@
+package io.jenkins.plugins.pipelinegraphview;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.Run;
+import org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider;
+
+@Extension
+public class PipelineGraphDisplayURLProvider extends ClassicDisplayURLProvider {
+
+    @Override
+    @NonNull
+    public String getDisplayName() {
+        return "Pipeline Graph";
+    }
+
+    @Override
+    @NonNull
+    public String getName() {
+        return "pipeline-graph";
+    }
+
+    @Override
+    @NonNull
+    public String getRunURL(Run<?, ?> run) {
+        return getRoot() + Util.encode(run.getUrl()) + "pipeline-graph";
+    }
+}


### PR DESCRIPTION
This allows a user to go to their profile and set 'Pipeline Graph' as their default display url.

i.e. clicking a link in GitHub will take you to the pipeline graph

![image](https://user-images.githubusercontent.com/21194782/118940495-add2f680-b948-11eb-8054-177de58c270f.png)

Relates to https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/4