### PR TITLE
Adds polling to have live updates

### DIFF
--- a/src/main/frontend/pipeline-graph/main/PipelineGraph.tsx
+++ b/src/main/frontend/pipeline-graph/main/PipelineGraph.tsx
@@ -18,7 +18,6 @@ import {
 
 import { layoutGraph, sequentialStagesLabelOffset } from './PipelineGraphLayout';
 
-
 type SVGChildren = Array<any>; // Fixme: Maybe refine this? Not sure what should go here, we have working code I can't make typecheck
 
 // Generate a react key for a connection

--- a/src/main/frontend/pipeline-graph/main/support/startPollingPipelineStatus.ts
+++ b/src/main/frontend/pipeline-graph/main/support/startPollingPipelineStatus.ts
@@ -1,0 +1,39 @@
+import { StageInfo } from '../PipelineGraphModel'
+
+interface ApiResult {
+	complete: boolean;
+	stages: Array<StageInfo>;
+}
+
+/**
+ * Starts polling the server to retrieve pipeline status.
+ * Will only stop once the run is finished.
+ */
+export default function startPollingPipelineStatus(
+	onFetchSuccess: (data: ApiResult) => void,
+	onFetchError: (err: Error) => void,
+	onPipelineComplete: () => void,
+	interval = 3000
+) {
+	let isComplete = false;
+
+	async function fetchPipelineData() {
+		try {
+				const res = await fetch('graph')
+				const result = await res.json()
+				onFetchSuccess(result.data);
+				isComplete = result.data.complete;
+		} catch (err) {
+			// TODO: implement exponential backoff of the timeout interval
+			onFetchError(err)
+		}
+		finally {
+				if (isComplete) {
+					onPipelineComplete()
+				} else {
+					setTimeout(() => fetchPipelineData(), interval)
+				}
+		}
+	}
+	fetchPipelineData()
+}

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraph.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraph.java
@@ -5,11 +5,14 @@ import java.util.List;
 public class PipelineGraph {
 
     private List<PipelineStage> stages;
+    private boolean complete = false;
 
-    public PipelineGraph(List<PipelineStage> stages) {
+    public PipelineGraph(List<PipelineStage> stages, boolean isComplete) {
         this.stages = stages;
+        this.complete = isComplete;
     }
 
+    public boolean isComplete() { return complete; }
     public List<PipelineStage> getStages() {
         return stages;
     }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraph.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraph.java
@@ -7,12 +7,14 @@ public class PipelineGraph {
     private List<PipelineStage> stages;
     private boolean complete = false;
 
-    public PipelineGraph(List<PipelineStage> stages, boolean isComplete) {
+    public PipelineGraph(List<PipelineStage> stages, boolean complete) {
         this.stages = stages;
-        this.complete = isComplete;
+        this.complete = complete;
     }
 
-    public boolean isComplete() { return complete; }
+    public boolean isComplete() { 
+        return complete;
+    }
     public List<PipelineStage> getStages() {
         return stages;
     }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphApi.java
@@ -105,7 +105,7 @@ public class PipelineGraphApi {
                 })
                 .filter(stage -> !stagesThatAreChildrenOrNestedStages.contains(stage.getId())).collect(Collectors.toList());
 
-        return new PipelineGraph(stageResults);
+        return new PipelineGraph(stageResults, run.getExecution().isComplete());
     }
 
     private Function<Integer, PipelineStage> mapper(Map<Integer, PipelineStageInternal> stageMap, Map<Integer, List<Integer>> stageToChildrenMap) {


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/10

Set up polling so that the graph is updated live

- Created a polling functions with callbacks for fetch success, error, and pipeline complete.
- Interval can be configured, defaults to 3 second (bit opinionated, don't really have an idea of how long it should be).
- added a `data.complete` boolean field to the JSON payload received from the server.


### Checklist

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
