### PR TITLE
Redirect to logs page on node graph click

### DIFF
--- a/src/main/frontend/pipeline-graph-view/app.tsx
+++ b/src/main/frontend/pipeline-graph-view/app.tsx
@@ -1,8 +1,6 @@
 import * as React from "react";
 import {
   FunctionComponent,
-  useEffect,
-  useState /*, useEffect, useState */,
 } from "react";
 
 import { PipelineGraph } from "./pipeline-graph/main";
@@ -10,13 +8,8 @@ import { PipelineGraph } from "./pipeline-graph/main";
 import "./app.scss";
 import "./pipeline-graph/styles/main.scss";
 
-// @ts-ignore
-// const rootUrl = rootURL;
-// @ts-ignore
-// const csrfCrumb = crumb.value;
-
 function handleNodeClick(nodeName: string, id: number) {
-  alert(`clicked ${nodeName} ${id}`);
+  window.location.href = '../pipeline-console?selected-node=' + id
 }
 
 const App: FunctionComponent = () => {


### PR DESCRIPTION
I'm working on auto-expanding, but having a bit of difficulty, I need to know the parent IDs as well and when I try expand dynamically I get:

> Material-UI: A component is changing the default expanded state of an uncontrolled TreeView after being initialized. To suppress this warning opt to use a controlled TreeView.

Part of https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/40