### PR TITLE
Expand pipeline logs based on clicked graph node

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
@@ -168,6 +168,8 @@ export class DataTreeView extends React.Component {
   }
 
   componentDidMount() {
+    let params = new URLSearchParams(document.location.search.substring(1));
+    let selectedNode = params.get("selected-node") || "";
     fetch("tree")
       .then((res) => res.json())
       .then((result) => {
@@ -175,7 +177,7 @@ export class DataTreeView extends React.Component {
         this.setState(
           {
             stages: result.data.stages,
-            expanded: this.getNodeHeirarchy("15", result.data.stages),
+            expanded: this.getNodeHeirarchy(selectedNode, result.data.stages),
           },
           () => {
             this.state.stages.forEach((stageData) => {

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React, { useEffect, useState } from "react";
 
 import TreeView from "@material-ui/lab/TreeView";
 
@@ -76,7 +76,7 @@ const getTreeItemsFromStepList = (stepsItems: StepInfo[]) => {
 
 const getTreeItemsFromStage = (
   stageItems: StageInfo[],
-  stageSteps: Map<String, StepInfo[]>
+  stageSteps: Map<string, StepInfo[]>
 ) => {
   return stageItems.map((stageItemData) => {
     let children: JSX.Element[] = [];
@@ -106,7 +106,8 @@ interface DataTreeViewProps {
 
 interface State {
   stages: Array<StageInfo>;
-  steps: Map<String, StepInfo[]>;
+  steps: Map<string, StepInfo[]>;
+  expanded: Array<string>;
 }
 
 export class DataTreeView extends React.Component {
@@ -118,7 +119,15 @@ export class DataTreeView extends React.Component {
     this.state = {
       stages: [],
       steps: new Map(),
+      expanded: [],
     };
+    this.handleToggle = this.handleToggle.bind(this);
+  }
+
+  handleToggle(event: React.ChangeEvent<{}>, nodeIds: string[]): void {
+    this.setState({
+      expanded: nodeIds,
+    });
   }
 
   getStepsForStageTree(stage: StageInfo): void {
@@ -166,6 +175,7 @@ export class DataTreeView extends React.Component {
         this.setState(
           {
             stages: result.data.stages,
+            expanded: this.getNodeHeirarchy("15", result.data.stages),
           },
           () => {
             this.state.stages.forEach((stageData) => {
@@ -188,7 +198,8 @@ export class DataTreeView extends React.Component {
         defaultCollapseIcon={<ExpandMoreIcon />}
         defaultExpandIcon={<ChevronRightIcon />}
         onNodeSelect={this.props.onActionNodeSelect}
-        expanded={this.getNodeHeirarchy("15", this.state.stages)}
+        expanded={this.state.expanded}
+        onNodeToggle={this.handleToggle}
       >
         {getTreeItemsFromStage(this.state.stages, this.state.steps)}
       </TreeView>

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
@@ -12,7 +12,6 @@ import {
 import TreeItem, { TreeItemProps } from "@material-ui/lab/TreeItem";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import ChevronRightIcon from "@material-ui/icons/ChevronRight";
-//import { useParams } from "react-router-dom";
 import {
   StageInfo,
   Result,
@@ -149,14 +148,14 @@ export class DataTreeView extends React.Component {
     }
   }
 
-  getNodeHeirarchy(nodeId: string, stages: StageInfo[]): Array<string> {
+  getNodeHierarchy(nodeId: string, stages: StageInfo[]): Array<string> {
     for (let i = 0; i < stages.length; i++) { 
       let stage = stages[i];
       if (String(stage.id) == nodeId) {
         // Found the node, so start a list of expanded nodes - it will be this and it's ancestors.
         return [String(stage.id)];
       } else if (stage.children && stage.children.length > 0) {
-        let expandedNodes = this.getNodeHeirarchy(nodeId, stage.children);
+        let expandedNodes = this.getNodeHierarchy(nodeId, stage.children);
         if (expandedNodes.length > 0) {
           // Our child is expanded, so we need to be expanded too.
           expandedNodes.push(String(stage.id));
@@ -177,7 +176,7 @@ export class DataTreeView extends React.Component {
         this.setState(
           {
             stages: result.data.stages,
-            expanded: this.getNodeHeirarchy(selectedNode, result.data.stages),
+            expanded: this.getNodeHierarchy(selectedNode, result.data.stages),
           },
           () => {
             this.state.stages.forEach((stageData) => {
@@ -194,7 +193,6 @@ export class DataTreeView extends React.Component {
   }
 
   render() {
-    console.log(this.getNodeHeirarchy("15", this.state.stages))
     return (
       <TreeView
         defaultCollapseIcon={<ExpandMoreIcon />}

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
@@ -12,6 +12,7 @@ import {
 import TreeItem, { TreeItemProps } from "@material-ui/lab/TreeItem";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import ChevronRightIcon from "@material-ui/icons/ChevronRight";
+//import { useParams } from "react-router-dom";
 import {
   StageInfo,
   Result,
@@ -139,6 +140,24 @@ export class DataTreeView extends React.Component {
     }
   }
 
+  getNodeHeirarchy(nodeId: string, stages: StageInfo[]): Array<string> {
+    for (let i = 0; i < stages.length; i++) { 
+      let stage = stages[i];
+      if (String(stage.id) == nodeId) {
+        // Found the node, so start a list of expanded nodes - it will be this and it's ancestors.
+        return [String(stage.id)];
+      } else if (stage.children && stage.children.length > 0) {
+        let expandedNodes = this.getNodeHeirarchy(nodeId, stage.children);
+        if (expandedNodes.length > 0) {
+          // Our child is expanded, so we need to be expanded too.
+          expandedNodes.push(String(stage.id));
+          return expandedNodes;
+        }
+      }
+    }
+    return [];
+  }
+
   componentDidMount() {
     fetch("tree")
       .then((res) => res.json())
@@ -163,11 +182,13 @@ export class DataTreeView extends React.Component {
   }
 
   render() {
+    console.log(this.getNodeHeirarchy("15", this.state.stages))
     return (
       <TreeView
         defaultCollapseIcon={<ExpandMoreIcon />}
         defaultExpandIcon={<ChevronRightIcon />}
         onNodeSelect={this.props.onActionNodeSelect}
+        expanded={this.getNodeHeirarchy("15", this.state.stages)}
       >
         {getTreeItemsFromStage(this.state.stages, this.state.steps)}
       </TreeView>


### PR DESCRIPTION
Allow control to expand a set of nodes on load (whilst allowing the user to toggle nodes from then on).

This doesn't read the `selected-node` variable added by @timja - I assume that's easy, but couldn't see an easy way 😅 .
