### PR TITLE
Truncate logs to last 150KB

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -1,11 +1,12 @@
 package io.jenkins.plugins.pipelinegraphview.consoleview;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import hudson.console.AnnotatedLargeText;
 import io.jenkins.plugins.pipelinegraphview.utils.AbstractPipelineViewAction;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineStepApi;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineStepList;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.Writer;
 import org.jenkinsci.plugins.workflow.actions.LogAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -13,10 +14,14 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.WebMethod;
+import org.kohsuke.stapler.framework.io.CharSpool;
+import org.kohsuke.stapler.framework.io.LineEndNormalizingWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
+  public static final long LOG_THRESHOLD = 150 * 1024; // 150KB
+
   private static final Logger logger = LoggerFactory.getLogger(PipelineConsoleViewAction.class);
   private final WorkflowRun target;
   private final PipelineStepApi stepApi;
@@ -68,19 +73,50 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
     String nodeId = req.getParameter("nodeId");
     if (nodeId != null) {
       logger.debug("getConsoleOutput was passed node id '" + nodeId + "'.");
-      String nodeConsoleText = getLogForNode(nodeId);
-      if (nodeConsoleText != null) {
-        rsp.getWriter().append(nodeConsoleText);
+      CharSpool spool = new CharSpool();
+      AnnotatedLargeText<? extends FlowNode> logText = getLogForNode(nodeId);
+
+      if (logText != null) {
+        long offset;
+        if (logText.length() > LOG_THRESHOLD) {
+          offset = logText.length() - LOG_THRESHOLD;
+        } else {
+          offset = 0;
+        }
+
+        long receivedBytes = logText.writeLogTo(offset, spool);
+        logger.debug("Received " + receivedBytes + " of console output.");
+
+        Writer writer = createWriter(req, rsp, logText.length());
+
+        if (offset > 0) {
+          writer
+              .append(
+                  "Output is truncated for performance, only showing the last 150KB of logs for this step...")
+              .append("\n");
+        }
+
+        spool.writeTo(new LineEndNormalizingWriter(writer));
       } else {
         rsp.getWriter().append("No console output for node: ").append(nodeId);
       }
     } else {
-      logger.debug("getConsoleOutput was ot passed nodeId.");
+      logger.debug("getConsoleOutput was not passed nodeId.");
       rsp.getWriter().append("Error getting console text");
     }
   }
 
-  private String getLogForNode(String nodeId) throws IOException {
+  private Writer createWriter(StaplerRequest req, StaplerResponse rsp, long size)
+      throws IOException {
+    // when sending big text, try compression. don't bother if it's small
+    if (size > 4096) {
+      return rsp.getCompressedWriter(req);
+    } else {
+      return rsp.getWriter();
+    }
+  }
+
+  private AnnotatedLargeText<? extends FlowNode> getLogForNode(String nodeId) throws IOException {
     FlowExecution execution = target.getExecution();
     if (execution != null) {
       logger.debug("getConsoleOutput found execution.");
@@ -89,11 +125,7 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
         logger.debug("getConsoleOutput found node.");
         LogAction log = node.getAction(LogAction.class);
         if (log != null) {
-          ByteArrayOutputStream oututStream = new ByteArrayOutputStream();
-          Long receivedBytes = log.getLogText().writeLogTo(0, oututStream);
-          logger.debug("Received " + receivedBytes + " of console output.");
-          // Assuming logs are is UFT-8. This seems to be what LogStorage does.
-          return oututStream.toString("UTF-8").trim();
+          return log.getLogText();
         }
       }
     }


### PR DESCRIPTION
see https://github.com/jenkinsci/blueocean-plugin/blob/c7b3227de742140ba470690eaf6f701f9a07c006/blueocean-rest/README.md#fetching-logs

I haven't implemented fetch all in this PR.

fixes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/39

We should create a new issue when merging to allow getting all logs, but this may be covered by https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/20