### PR TITLE
Change markup to get monospaced console output

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -64,13 +64,13 @@ export class PipelineConsole extends React.Component {
             <div className="console-output">
               <pre className="console-pane">
                 {lineChunks.map((line, index) => (
-                  <p key={index}>
+                  <div key={index}>
                     {React.createElement(
                       Linkify,
                       { options: { className: "line ansi-color" } },
                       line
                     )}
-                  </p>
+                  </div>
                 ))}
               </pre>
             </div>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue

There are styles for the `<p>` tag that make console output sans-serif. Using `<div>` results in monospace font.

Before
![console-before](https://user-images.githubusercontent.com/1105305/133171798-11560c1e-75c1-444b-9cbe-74295049937a.png)

After
![console-after](https://user-images.githubusercontent.com/1105305/133171806-1a3efa13-ba47-4e95-8175-5e026fd99710.png)
