### PR TITLE
Use tree representation for graph layout

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
@@ -76,7 +76,7 @@ export class PipelineGraph extends React.Component {
       onPipelineDataReceived,
       onPollingError,
       onPipelineComplete,
-      this.props.path ?? "graph"
+      this.props.path ?? "tree"
     );
   }
 

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.spec.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.spec.ts
@@ -1,0 +1,244 @@
+import { NodeInfo, Result, StageInfo, StageType } from "./PipelineGraphModel";
+import { createNodeColumns } from "./PipelineGraphLayout";
+
+describe("PipelineGraphLayout", () => {
+  describe("createNodeColumns", () => {
+    const baseStage: StageInfo = {
+      name: "",
+      title: "",
+      state: Result.success,
+      completePercent: 50,
+      id: 0,
+      type: "STAGE",
+      children: [],
+    };
+
+    const makeStage = (
+      id: number,
+      name: string,
+      children: Array<StageInfo> = []
+    ): StageInfo => {
+      return { ...baseStage, id, name, children };
+    };
+
+    const makeParallel = (
+      id: number,
+      name: string,
+      children: Array<StageInfo> = []
+    ): StageInfo => {
+      return {
+        ...baseStage,
+        id,
+        name,
+        children,
+        type: "PARALLEL" as StageType,
+      };
+    };
+
+    const makeNode = (
+      id: number,
+      name: string,
+      seqContainerName: string | undefined = undefined
+    ) => {
+      return {
+        id,
+        name,
+        stage: { id, name },
+        ...(seqContainerName !== undefined ? { seqContainerName } : {}),
+      };
+    };
+
+    it("returns no columns if no stages", () => {
+      const columns = createNodeColumns([], false);
+      expect(columns).toEqual([]);
+    });
+
+    it("returns proper columns (unstableSmokes)", () => {
+      const columns = createNodeColumns(
+        [
+          makeStage(4, "unstable-one"),
+          makeStage(15, "success"),
+          makeStage(20, "unstable-two"),
+          makeStage(26, "failure"),
+        ],
+        false
+      );
+
+      expect(columns).toMatchObject([
+        {
+          hasBranchLabels: false,
+          topStage: { name: "unstable-one", id: 4 },
+          rows: [[makeNode(4, "unstable-one")]],
+        },
+        {
+          hasBranchLabels: false,
+          topStage: { name: "success", id: 15 },
+          rows: [[makeNode(15, "success")]],
+        },
+        {
+          hasBranchLabels: false,
+          topStage: { name: "unstable-two", id: 20 },
+          rows: [[makeNode(20, "unstable-two")]],
+        },
+        {
+          hasBranchLabels: false,
+          topStage: { name: "failure", id: 26 },
+          rows: [[makeNode(26, "failure")]],
+        },
+      ]);
+    });
+
+    it("returns proper columns (complexSmokes)", () => {
+      const columns = createNodeColumns(
+        [
+          makeStage(6, "Non-Parallel Stage"),
+          makeStage(11, "Parallel Stage", [
+            makeParallel(15, "Branch A"),
+            makeParallel(16, "Branch B"),
+            makeParallel(17, "Branch C", [
+              makeStage(25, "Nested 1"),
+              makeStage(38, "Nested 2"),
+            ]),
+          ]),
+          makeStage(49, "Skipped stage"),
+          makeStage(53, "Parallel Stage 2", [
+            makeParallel(57, "Branch A"),
+            makeParallel(58, "Branch B"),
+            makeParallel(59, "Branch C", [
+              makeStage(67, "Nested 1"),
+              makeStage(80, "Nested 2"),
+            ]),
+          ]),
+        ],
+        false
+      );
+
+      expect(columns).toMatchObject([
+        {
+          hasBranchLabels: false,
+          topStage: { name: "Non-Parallel Stage", id: 6 },
+          rows: [[makeNode(6, "Non-Parallel Stage")]],
+        },
+        {
+          hasBranchLabels: true,
+          topStage: { name: "Parallel Stage", id: 11 },
+          rows: [
+            [makeNode(15, "Branch A")],
+            [makeNode(16, "Branch B")],
+            [
+              makeNode(25, "Nested 1", "Branch C"),
+              makeNode(38, "Nested 2", "Branch C"),
+            ],
+          ],
+        },
+        {
+          hasBranchLabels: false,
+          topStage: { name: "Skipped stage", id: 49 },
+          rows: [[makeNode(49, "Skipped stage")]],
+        },
+        {
+          hasBranchLabels: true,
+          topStage: { name: "Parallel Stage 2", id: 53 },
+          rows: [
+            [makeNode(57, "Branch A")],
+            [makeNode(58, "Branch B")],
+            [
+              makeNode(67, "Nested 1", "Branch C"),
+              makeNode(80, "Nested 2", "Branch C"),
+            ],
+          ],
+        },
+      ]);
+    });
+
+    it("returns proper columns (GH#63.1)", () => {
+      const columns = createNodeColumns(
+        [
+          makeStage(6, "Test", [
+            makeParallel(9, "Matrix - PLATFORM = '1'", [
+              makeStage(20, "Stage 1"),
+              makeStage(30, "Stage 2"),
+              makeStage(40, "Stage 3"),
+            ]),
+            makeParallel(10, "Matrix - PLATFORM = '2'", [
+              makeStage(22, "Stage 1"),
+              makeStage(32, "Stage 2"),
+              makeStage(42, "Stage 3"),
+            ]),
+          ]),
+        ],
+        false
+      );
+
+      expect(columns).toMatchObject([
+        {
+          hasBranchLabels: true,
+          topStage: { name: "Test", id: 6 },
+          rows: [
+            [
+              makeNode(20, "Stage 1", "Matrix - PLATFORM = '1'"),
+              makeNode(30, "Stage 2", "Matrix - PLATFORM = '1'"),
+              makeNode(40, "Stage 3", "Matrix - PLATFORM = '1'"),
+            ],
+            [
+              makeNode(22, "Stage 1", "Matrix - PLATFORM = '2'"),
+              makeNode(32, "Stage 2", "Matrix - PLATFORM = '2'"),
+              makeNode(42, "Stage 3", "Matrix - PLATFORM = '2'"),
+            ],
+          ],
+        },
+      ]);
+    });
+
+    it("returns proper columns (GH#63.2)", () => {
+      const columns = createNodeColumns(
+        [
+          makeStage(6, "build and run", [
+            makeParallel(12, "darwin-amd64", [
+              makeStage(24, "build"),
+              makeStage(39, "run"),
+              makeStage(55, "unit test"),
+            ]),
+            makeParallel(11, "linux-amd64", [
+              makeStage(22, "build"),
+              makeStage(36, "run"),
+              makeStage(53, "unit test"),
+              makeStage(64, "load test"),
+              makeStage(71, "deploy to storage"),
+            ]),
+            makeParallel(10, "linux-armv6", [
+              makeStage(20, "build"),
+              makeStage(34, "run"),
+            ]),
+          ]),
+        ],
+        false
+      );
+
+      expect(columns).toMatchObject([
+        {
+          hasBranchLabels: true,
+          topStage: { name: "build and run", id: 6 },
+          rows: [
+            [
+              makeNode(24, "build", "darwin-amd64"),
+              makeNode(39, "run", "darwin-amd64"),
+              makeNode(55, "unit test", "darwin-amd64"),
+            ],
+            [
+              makeNode(22, "build", "linux-amd64"),
+              makeNode(36, "run", "linux-amd64"),
+              makeNode(53, "unit test", "linux-amd64"),
+              makeNode(64, "load test", "linux-amd64"),
+              makeNode(71, "deploy to storage", "linux-amd64"),
+            ],
+            [
+              makeNode(20, "build", "linux-armv6"),
+              makeNode(34, "run", "linux-armv6"),
+            ],
+          ],
+        },
+      ]);
+    });
+  });
+});

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
@@ -53,7 +53,6 @@ export interface StageInfo {
   children: Array<StageInfo>; // Used by the top-most stages with parallel branches
   nextSibling?: StageInfo; // Used within a parallel branch to denote sequential stages
   isSequential?: boolean;
-  seqContainerName?: string; //used within a parallel branch to denote the name of the container of the parallel sequential stages
 }
 
 interface BaseNodeInfo {
@@ -73,6 +72,7 @@ export interface StageNodeInfo extends BaseNodeInfo {
 
   // -- Unique
   stage: StageInfo;
+  seqContainerName?: string; // Used within a parallel branch to denote the name of the container of the parallel sequential stages
 }
 
 export interface PlaceholderNodeInfo extends BaseNodeInfo {


### PR DESCRIPTION
Graph representation doesn't look correct in some cases, so use tree representation instead which appears to be proper. I didn't remove graph API endpoint in this PR as I wasn't sure if there're any plans for it, but it's unused now.

I added some tests in the frontend after the refactoring and not before just to avoid extra work of adjusting the [invalid when using graph endpoint] input test data, so basically rewriting tests that weren't there to begin with. Hopefully that's okay.

Fixes: #63