### PR TITLE
Fix tree representation for scripted parallel stages

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
@@ -177,8 +177,9 @@ public class PipelineGraphApi {
             // If a node encloses another node, it means it's a tree parent, so the first ancestor
             // ID we find
             // which matches an enclosing node then it's the stages tree parent.
+            List<String> enclosingIds = stageNode.getAllEnclosingIds();
             for (String ancestorId : ancestors) {
-              if (stageNode.getAllEnclosingIds().contains(ancestorId)) {
+              if (enclosingIds.contains(ancestorId)) {
                 treeParentId = ancestorId;
                 break;
               }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeGraphVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeGraphVisitor.java
@@ -735,7 +735,12 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor {
               firstBranch.getId(), (parallel == null ? "(none)" : parallel.getId())));
     }
 
-    String firstNodeId = firstBranch.getId();
+    String syntheticNodeId =
+        firstBranch.getNode().getParents().stream()
+            .map((node) -> node.getId())
+            .findFirst()
+            .orElseGet(
+                () -> createSyntheticStageId(firstBranch.getId(), PARALLEL_SYNTHETIC_STAGE_NAME));
     List<FlowNode> parents;
     if (parallel != null) {
       parents = parallel.getNode().getParents();
@@ -743,10 +748,7 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor {
       parents = new ArrayList<>();
     }
     FlowNode syntheticNode =
-        new FlowNode(
-            firstBranch.getNode().getExecution(),
-            createSyntheticStageId(firstNodeId, PARALLEL_SYNTHETIC_STAGE_NAME),
-            parents) {
+        new FlowNode(firstBranch.getNode().getExecution(), syntheticNodeId, parents) {
           @Override
           public void save() throws IOException {
             // no-op to avoid JENKINS-45892 violations from serializing the synthetic FlowNode.

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
@@ -132,4 +132,18 @@ public class PipelineGraphApiTest {
                 "Skipped stage,",
                 "Parallel Stage 2[Branch A,Branch B,Branch C[Nested 1,Nested 2]]")));
   }
+
+  @Test
+  public void createTree_scriptedParallel() throws Exception {
+    WorkflowRun run =
+        TestUtils.createAndRunJob(
+            j, "scriptedParallel", "scriptedParallel.jenkinsfile", Result.SUCCESS);
+    PipelineGraphApi api = new PipelineGraphApi(run);
+    PipelineGraph graph = api.createTree();
+
+    List<PipelineStage> stages = graph.getStages();
+
+    String stagesString = TestUtils.collectStagesAsString(stages, PipelineStage::getName);
+    assertThat(stagesString, is("A,Parallel[B[BA,BB],C[CA,CB]],D[E[EA,EB],F[FA,FB]],G"));
+  }
 }

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/scriptedParallel.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/scriptedParallel.jenkinsfile
@@ -1,0 +1,44 @@
+stage('A') {
+    echo ''
+}
+parallel(
+    B: {
+        stage('BA') {
+            echo ''
+        }
+        stage('BB') {
+            echo ''
+        }
+    },
+    C: {
+        stage('CA') {
+            echo ''
+        }
+        stage('CB') {
+            echo ''
+        }
+    },
+)
+stage('D') {
+    parallel(
+        E: {
+            stage('EA') {
+                echo ''
+            }
+            stage('EB') {
+                echo ''
+            }
+        },
+        F: {
+            stage('FA') {
+                echo ''
+            }
+            stage('FB') {
+                echo ''
+            }
+        },
+    )
+}
+stage('G') {
+    echo ''
+}


### PR DESCRIPTION
Use node parent ID for synthetic parallel node so that it has a valid ID which we will be able to get the node for from execution in `PipelineGraphApi`'s `createTree()` later on.  In an unlikely event of this failing, still fallback to ID generation based on appending "-parallel-synthetic" to the ID of first parallel node.