### PR TITLE
Recurse into child stages to flatten the tree

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.spec.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.spec.ts
@@ -240,5 +240,121 @@ describe("PipelineGraphLayout", () => {
         },
       ]);
     });
+
+    it("returns proper columns (GH#50)", () => {
+      const columns = createNodeColumns(
+        [
+          makeStage(3, "Parallel", [
+            makeParallel(4, "parallel:0", [
+              makeStage(6, "parent:0", [
+                makeStage(9, "child:0"),
+                makeStage(14, "child:1"),
+                makeStage(19, "child:3"),
+              ]),
+            ]),
+          ]),
+          makeStage(29, "parent:1"),
+        ],
+        false
+      );
+
+      expect(columns).toMatchObject([
+        {
+          hasBranchLabels: true,
+          topStage: { name: "Parallel", id: 3 },
+          rows: [
+            [
+              makeNode(6, "parent:0", "parallel:0"),
+              makeNode(9, "child:0", "parent:0"),
+              makeNode(14, "child:1", "parent:0"),
+              makeNode(19, "child:3", "parent:0"),
+            ],
+          ],
+        },
+        {
+          hasBranchLabels: false,
+          topStage: { name: "parent:1", id: 29 },
+          rows: [[makeNode(29, "parent:1")]],
+        },
+      ]);
+    });
+
+    it("returns proper columns (GH#18)", () => {
+      const columns = createNodeColumns(
+          [
+            makeStage(6, "Stage 1"),
+            makeStage(11, "Stage 2"),
+            makeStage(31, "Stage6, When anyOf", [
+              makeStage(12, "Stage 3"),
+              makeStage(33, "Parallel", [
+                makeParallel(36, "Parallel Stage 1", [
+                  makeStage(43, "Parallel Stage 1.1"),
+                  makeStage(61, "Parallel Stage 1.2"),
+                ]),
+                makeParallel(37, "Parallel Stage 2", [
+                  makeStage(45, "Parallel Stage 2.1"),
+                  makeStage(63, "Parallel Stage 2.2"),
+                ]),
+              ]),
+              makeStage(13, "Stage 4", [
+                makeStage(14, "Stage 5", [makeStage(15, "Stage 7")]),
+              ]),
+            ]),
+          ],
+          false
+      );
+
+      expect(columns).toMatchObject([
+        {
+          hasBranchLabels: false,
+          topStage: { name: "Stage 1", id: 6 },
+          rows: [[makeNode(6, "Stage 1")]],
+        },
+        {
+          hasBranchLabels: false,
+          topStage: { name: "Stage 2", id: 11 },
+          rows: [[makeNode(11, "Stage 2")]],
+        },
+        {
+          hasBranchLabels: false,
+          topStage: { name: "Stage6, When anyOf", id: 31 },
+          rows: [[makeNode(31, "Stage6, When anyOf")]],
+        },
+        {
+          hasBranchLabels: false,
+          topStage: { name: "Stage 3", id: 12 },
+          rows: [[makeNode(12, "Stage 3")]],
+        },
+        {
+          hasBranchLabels: true,
+          topStage: { name: "Parallel", id: 33 },
+          rows: [
+            [
+              makeNode(43, "Parallel Stage 1.1", "Parallel Stage 1"),
+              makeNode(61, "Parallel Stage 1.2", "Parallel Stage 1"),
+            ],
+            [
+              makeNode(45, "Parallel Stage 2.1", "Parallel Stage 2"),
+              makeNode(63, "Parallel Stage 2.2", "Parallel Stage 2"),
+            ],
+          ],
+        },
+        {
+          hasBranchLabels: false,
+          topStage: { name: "Stage 4", id: 13 },
+          rows: [[makeNode(13, "Stage 4")]],
+        },
+        {
+          hasBranchLabels: false,
+          topStage: { name: "Stage 5", id: 14 },
+          rows: [[makeNode(14, "Stage 5")]],
+        },
+        {
+          hasBranchLabels: false,
+          topStage: { name: "Stage 7", id: 15 },
+          rows: [[makeNode(15, "Stage 7")]],
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Since we're currently only supporting one level of parallels, recurse in two separate steps: once for all top-level stages up to parallels (fixes #50), and once for all non-parallel stages inside parallels (fixes #18).

Before and after (#18):
![Before (#18)](https://user-images.githubusercontent.com/298203/189524363-96cfe814-f655-4af6-b3b9-b9961263d90e.png)
![After (#18)](https://user-images.githubusercontent.com/298203/189524369-bca037d7-e283-4344-a154-46ed9a7d3b8a.png)


Before and after (#50):
![Before (#50)](https://user-images.githubusercontent.com/298203/189524381-255872a6-a220-413a-8069-d0314cc646d3.png)
![After (#50)](https://user-images.githubusercontent.com/298203/189524387-a8907559-c598-49fc-bf00-54512df2d2a0.png)
