### PR TITLE
Include synthetic stages in graph and console logs

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
@@ -35,6 +35,10 @@ export interface TreeItemData {
   children: TreeItemData[];
 }
 
+interface StageTreeItemProps extends TreeItemProps {
+  synthetic?: boolean;
+}
+
 // Tree Item for stages
 const StageTreeItem = withStyles((theme: Theme) =>
   createStyles({
@@ -49,8 +53,12 @@ const StageTreeItem = withStyles((theme: Theme) =>
       paddingLeft: 18,
       borderLeft: `1px dashed ${fade(theme.palette.text.primary, 0.4)}`,
     },
+    label: {
+      fontStyle: (props: StageTreeItemProps) =>
+        props.synthetic ? "italic" : "inherit",
+    },
   })
-)((props: TreeItemProps) => <TreeItem {...props} />);
+)((props: StageTreeItemProps) => <TreeItem {...props} />);
 
 // Tree Item for steps
 const StepTreeItem = withStyles((theme: Theme) =>
@@ -93,6 +101,7 @@ const getTreeItemsFromStage = (
         nodeId={String(stageItemData.id)}
         label={stageItemData.name}
         children={children}
+        synthetic={stageItemData.synthetic}
       />
     );
   });

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
@@ -53,6 +53,7 @@ export interface StageInfo {
   children: Array<StageInfo>; // Used by the top-most stages with parallel branches
   nextSibling?: StageInfo; // Used within a parallel branch to denote sequential stages
   isSequential?: boolean;
+  synthetic?: boolean;
 }
 
 interface BaseNodeInfo {

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
@@ -77,6 +77,9 @@ export function BigLabel({
   ) {
     classNames.push("selected");
   }
+  if (details.stage && details.stage.synthetic) {
+    classNames.push("synthetic");
+  }
 
   return (
     <TruncatingLabel

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/styles/PipelineGraphWidget.scss
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/styles/PipelineGraphWidget.scss
@@ -142,6 +142,10 @@ circle.halo {
   font-weight: bold;
 }
 
+.PWGx-pipeline-big-label.synthetic {
+  font-style: italic;
+}
+
 .PWGx-pipeline-small-label.selected {
   font-weight: bold;
   margin-top: 3px;

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/FlowNodeWrapper.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/FlowNodeWrapper.java
@@ -277,4 +277,8 @@ public class FlowNodeWrapper {
   public String getArgumentsAsString() {
     return PipelineNodeUtil.getArgumentsAsString(node);
   }
+
+  public boolean isSynthetic() {
+    return PipelineNodeUtil.isSyntheticStage(node);
+  }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
@@ -46,8 +46,8 @@ public class PipelineGraphApi {
                   50, // TODO how ???
                   flowNodeWrapper.getType().name(),
                   flowNodeWrapper
-                      .getDisplayName() // TODO blue ocean uses timing information: "Passed in 0s"
-                  );
+                      .getDisplayName(), // TODO blue ocean uses timing information: "Passed in 0s"
+                  flowNodeWrapper.isSynthetic());
             })
         .collect(Collectors.toList());
   }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeGraphVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeGraphVisitor.java
@@ -137,9 +137,6 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor {
               startNode.getId(), startNode.getDisplayName(), startNode.getDisplayFunctionName()));
     }
 
-    if (PipelineNodeUtil.isSyntheticStage(startNode)) {
-      return;
-    }
     if (NotExecutedNodeAction.isExecuted(startNode)) {
       firstExecuted = startNode;
     }
@@ -174,8 +171,6 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor {
     // if block stage node push it to stack as it may have nested stages
     if (parallelEnds.isEmpty()
         && endNode instanceof StepEndNode
-        && !PipelineNodeUtil.isSyntheticStage(
-            ((StepEndNode) endNode).getStartNode()) // skip synthetic stages
         && PipelineNodeUtil.isStage(((StepEndNode) endNode).getStartNode())) {
 
       // XXX: There seems to be bug in eventing, chunkEnd is sent twice for the same FlowNode
@@ -212,10 +207,6 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor {
               chunk.getFirstNode().getId(),
               chunk.getFirstNode().getDisplayName(),
               chunk.getFirstNode().getDisplayFunctionName()));
-    }
-
-    if (PipelineNodeUtil.isSyntheticStage(chunk.getFirstNode())) {
-      return;
     }
 
     boolean parallelNestedStages = false;

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
@@ -27,14 +27,20 @@ import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 /** @author Vivek Pandey */
 public class PipelineNodeUtil {
 
+  private static final String DECLARATIVE_DISPLAY_NAME_PREFIX = "Declarative: ";
+
   public static String getDisplayName(@NonNull FlowNode node) {
     ThreadNameAction threadNameAction = node.getAction(ThreadNameAction.class);
-    return threadNameAction != null ? threadNameAction.getThreadName() : node.getDisplayName();
+    String name =
+        threadNameAction != null ? threadNameAction.getThreadName() : node.getDisplayName();
+    return isSyntheticStage(node) && name.startsWith(DECLARATIVE_DISPLAY_NAME_PREFIX)
+        ? name.substring(DECLARATIVE_DISPLAY_NAME_PREFIX.length())
+        : name;
   }
 
   public static boolean isStage(FlowNode node) {
     return node != null
-        && ((node.getAction(StageAction.class) != null && !isSyntheticStage(node))
+        && ((node.getAction(StageAction.class) != null)
             || (node.getAction(LabelAction.class) != null
                 && node.getAction(ThreadNameAction.class) == null));
   }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStage.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStage.java
@@ -14,6 +14,7 @@ public class PipelineStage {
   private String seqContainerName;
   private final PipelineStage nextSibling;
   private boolean sequential;
+  private boolean synthetic;
 
   public PipelineStage(
       String id,
@@ -25,7 +26,8 @@ public class PipelineStage {
       String title,
       String seqContainerName,
       PipelineStage nextSibling,
-      boolean sequential) {
+      boolean sequential,
+      boolean synthetic) {
     this.id = id;
     this.name = name;
     this.children = children;
@@ -36,6 +38,7 @@ public class PipelineStage {
     this.seqContainerName = seqContainerName;
     this.nextSibling = nextSibling;
     this.sequential = sequential;
+    this.synthetic = synthetic;
   }
 
   public PipelineStage getNextSibling() {
@@ -78,5 +81,9 @@ public class PipelineStage {
 
   public String getTitle() {
     return title;
+  }
+
+  public boolean isSynthetic() {
+    return synthetic;
   }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStageInternal.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStageInternal.java
@@ -15,6 +15,7 @@ public class PipelineStageInternal {
   private String seqContainerName;
   private PipelineStageInternal nextSibling;
   private boolean sequential;
+  private boolean synthetic;
 
   public PipelineStageInternal(
       String id,
@@ -23,7 +24,8 @@ public class PipelineStageInternal {
       String state,
       int completePercent,
       String type,
-      String title) {
+      String title,
+      boolean synthetic) {
     this.id = id;
     this.name = name;
     this.parents = parents;
@@ -31,6 +33,7 @@ public class PipelineStageInternal {
     this.completePercent = completePercent;
     this.type = type;
     this.title = title;
+    this.synthetic = synthetic;
   }
 
   public boolean isSequential() {
@@ -105,6 +108,14 @@ public class PipelineStageInternal {
     return title;
   }
 
+  public boolean isSynthetic() {
+    return synthetic;
+  }
+
+  public void setSynthetic(boolean synthetic) {
+    this.synthetic = synthetic;
+  }
+
   public PipelineStage toPipelineStage(List<PipelineStage> children) {
     return new PipelineStage(
         id,
@@ -116,6 +127,7 @@ public class PipelineStageInternal {
         title,
         seqContainerName,
         nextSibling != null ? nextSibling.toPipelineStage(Collections.emptyList()) : null,
-        sequential);
+        sequential,
+        synthetic);
   }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
@@ -182,7 +182,7 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
               + " .");
     }
     super.chunkStart(startNode, beforeBlock, scanner);
-    if (PipelineNodeUtil.isStage(startNode) && !PipelineNodeUtil.isSyntheticStage(startNode)) {
+    if (PipelineNodeUtil.isStage(startNode)) {
       stages.push(startNode);
     }
   }
@@ -294,7 +294,7 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
       @NonNull FlowNode atomNode,
       @CheckForNull FlowNode after,
       @NonNull ForkScanner scan) {
-    if (stageStepsCollectionCompleted && !PipelineNodeUtil.isSyntheticStage(currentStage)) {
+    if (stageStepsCollectionCompleted) {
       return;
     }
 

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/syntheticStages.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/syntheticStages.jenkinsfile
@@ -1,0 +1,27 @@
+def checkout(scm) {
+  echo 'Checking out'
+}
+scm = true
+
+pipeline {
+  agent any
+
+  stages {
+    stage('Stage 1') {
+      steps {
+        echo 'Stage 1'
+      }
+    }
+    stage('Stage 2') {
+      steps {
+        echo 'Stage 2'
+      }
+    }
+  }
+
+  post {
+    always {
+      echo 'Done'
+    }
+  }
+}


### PR DESCRIPTION
Strip the "Declarative: " prefix to shorten the label, style as italic.

Before and after (graph):
![Before (graph)](https://user-images.githubusercontent.com/298203/189887586-2bedebfa-6905-4ebe-9bbe-539ae7137cb9.svg)
![After (graph)](https://user-images.githubusercontent.com/298203/189887616-b2b38309-c5c2-44a3-aa9b-e0889be1a81d.svg)

Before and after (console):
![Before (console)](https://user-images.githubusercontent.com/298203/189887663-2a101980-c140-4993-a5cc-905495acfcea.svg)
![After (console)](https://user-images.githubusercontent.com/298203/189887674-914acffb-f52f-4818-8262-7be1cf95abd4.svg)

Fixes #85.