### PR TITLE
Remove parallel branches from graph if they weren't run

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeGraphVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeGraphVisitor.java
@@ -306,6 +306,10 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor {
         nextStage.addParent(stage);
         stage.addEdge(nextStage);
       }
+      for (FlowNodeWrapper p : parallelBranches) {
+        nodes.remove(p);
+        nodeMap.remove(p.getId(), p);
+      }
     }
     parallelBranches.clear();
     if (!parallelNestedStages) {

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
@@ -108,4 +108,22 @@ public class PipelineGraphApiTest {
                 "{Stage 2,false},",
                 "{Post Actions,true}")));
   }
+
+  @Issue("GH#87")
+  @Test
+  public void createTree_skippedParallel() throws Exception {
+    WorkflowRun run =
+        TestUtils.createAndRunJob(
+            j, "skippedParallel", "skippedParallel.jenkinsfile", Result.SUCCESS);
+    PipelineGraphApi api = new PipelineGraphApi(run);
+    PipelineGraph graph = api.createTree();
+
+    List<PipelineStage> stages = graph.getStages();
+
+    String stagesString =
+        TestUtils.collectStagesAsString(
+            stages,
+            (PipelineStage stage) -> String.format("{%s,%s}", stage.getName(), stage.getState()));
+    assertThat(stagesString, is("{Stage 1,SUCCESS},{Parallel stage,skipped},{Stage 2,SUCCESS}"));
+  }
 }

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/skippedParallel.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/skippedParallel.jenkinsfile
@@ -1,0 +1,32 @@
+pipeline {
+  agent any
+  stages {
+    stage('Stage 1') {
+      steps {
+        echo 'Stage 1'
+      }
+    }
+    stage('Parallel stage') {
+      when {
+        expression { false }
+      }
+      parallel {
+        stage('Parallel Stage 1') {
+          steps {
+            echo 'Parallel Stage 1'
+          }
+        }
+        stage('Parallel Stage 2') {
+          steps {
+            echo 'Parallel Stage 2'
+          }
+        }
+      }
+    }
+    stage('Stage 2') {
+      steps {
+        echo 'Stage 2'
+      }
+    }
+  }
+}


### PR DESCRIPTION
In `handleChunkDone()`, we're clearing out `parallelBranches` but the nodes stay listed and show up detached. Not yet sure what that `parallelNestedStages` logic is about (the whole visitor is quite convoluted), but current change works in my tests.

Fixes #87.