### PR TITLE
Break long text lines in console

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -193,6 +193,7 @@ div.console-output-line-anchor {
 
 pre.console-pane {
   background-color: var(--card-background);
+  word-break: break-word;
 }
 
 div.console-output-line {


### PR DESCRIPTION
Added `word-break: break-word;` to break long words in console.


Before:
<img width="1020" alt="Screenshot 2022-10-17 at 16 01 26" src="https://user-images.githubusercontent.com/4447764/196213409-4e91e7ca-ac40-41a7-98c6-9058096895d9.png">

After:
<img width="1029" alt="Screenshot 2022-10-17 at 16 01 01" src="https://user-images.githubusercontent.com/4447764/196213358-4c3008f8-f4d8-477a-90a8-6c054002681f.png">

Fixes #141

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
