### PR TITLE
Add scrollbar to list of steps in Console view

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -229,11 +229,12 @@ export class PipelineConsole extends React.Component<
   render() {
     const splitPaneStyle: React.CSSProperties = {
       position: "relative",
-      height: "100%",
     };
     const paneStyle: React.CSSProperties = {
       paddingLeft: "8px",
       textAlign: "left",
+      height: "calc(100vh - 300px)",
+      overflowY: "scroll",
     };
 
     const lineChunks = this.state.consoleText


### PR DESCRIPTION
Added set the size of the parent pane of the TreeView in the console made it scrollable.

Fixes: #143

<img width="1307" alt="Screenshot 2022-10-17 at 16 44 43" src="https://user-images.githubusercontent.com/4447764/196222814-d470bcc7-472a-4356-836e-408a883291ea.png">
