### PR TITLE
Add scrollbar to console text pane

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -384,7 +384,7 @@ export class PipelineConsole extends React.Component<
       paddingLeft: "8px",
       textAlign: "left",
       height: "calc(100vh - 300px)",
-      overflowY: "scroll",
+      overflowY: "auto",
     };
 
     return (
@@ -407,7 +407,7 @@ export class PipelineConsole extends React.Component<
               />
             </div>
             
-            <div>
+            <div style={paneStyle}>
               {this.renderStageDetails()}
               {this.renderStepDetails()}
               {this.renderConsoleOutput()}


### PR DESCRIPTION
Adds a separate scrollbar to the console text pane - means stages/steps are still in view when scrolling through console text.

Also, hide scrollbar when not in use.

No overflow:
![Screenshot 2022-10-18 at 09 57 57](https://user-images.githubusercontent.com/4447764/196385562-96237bbb-e637-4114-ac3f-c62fce2a6ad5.png)

Scrolled to bottom of console text:
![Screenshot 2022-10-18 at 09 58 15](https://user-images.githubusercontent.com/4447764/196385663-68a93b08-4386-48eb-b67d-7abab4c902ec.png)



<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- x ] Ensure that the pull request title represents the desired changelog entry

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
