### PR TITLE
Stop unique key warnings in React.

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
@@ -64,18 +64,17 @@ const StepTreeItem = withStyles((theme: Theme) =>
 const getTreeItemsFromStepList = (stepsItems: StepInfo[]) => {
   return stepsItems.map((stepItemData) => {
     return (
-      <div>
-        <StepTreeItem
-          key={stepItemData.id}
-          nodeId={String(stepItemData.id)}
-          label={
-            <StepStatus
-              status={decodeResultValue(stepItemData.state)}
-              text={stepItemData.name.replace(/[^ -~]+/g, "")}
-            />
-          }
-        />
-      </div>
+      <StepTreeItem
+        key={stepItemData.id}
+        nodeId={String(stepItemData.id)}
+        label={
+          <StepStatus
+            status={decodeResultValue(stepItemData.state)}
+            text={stepItemData.name.replace(/[^ -~]+/g, "")}
+            key={`status-${stepItemData.id}`}
+          />
+        }
+      />
     );
   });
 };
@@ -106,24 +105,23 @@ const getTreeItemsFromStage = (stageItems: StageInfo[], steps: StepInfo[]) => {
       children = [...children, ...stepsItems];
     }
     return (
-      <div>
-        <StageTreeItem
-          key={stageItemData.id}
-          nodeId={String(stageItemData.id)}
-          label={
-            <StepStatus
-              status={decodeResultValue(stageItemData.state)}
-              text={stageItemData.name}
-            />
-          }
-          children={children}
-          classes={{
-            label: stageItemData.synthetic
-              ? "pgv-graph-node--synthetic"
-              : undefined,
-          }}
-        />
-      </div>
+      <StageTreeItem
+        key={stageItemData.id}
+        nodeId={String(stageItemData.id)}
+        label={
+          <StepStatus
+            status={decodeResultValue(stageItemData.state)}
+            text={stageItemData.name}
+            key={`status-${stageItemData.id}`}
+          />
+        }
+        children={children}
+        classes={{
+          label: stageItemData.synthetic
+            ? "pgv-graph-node--synthetic"
+            : undefined,
+        }}
+      />
     );
   });
 };
@@ -165,6 +163,7 @@ export class DataTreeView extends React.Component {
         expanded={this.props.expanded}
         selected={this.props.selected}
         onNodeToggle={this.props.onNodeToggle}
+        key="console-tree-view"
       >
         {getTreeItemsFromStage(this.props.stages, this.props.steps)}
       </TreeView>


### PR DESCRIPTION
Remove divs around TreeItems and add key to status labels.

 my previous change, the divs around the TreeItems snuck back in and reintroduced the missing key warnings 😬. This removes them again.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
