### PR TITLE
Set the step display name to only the label if set

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/FlowNodeWrapper.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/FlowNodeWrapper.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.graph.AtomNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -104,6 +105,14 @@ public class FlowNodeWrapper {
 
   public @NonNull String getDisplayName() {
     return displayName;
+  }
+
+  public @CheckForNull String getLabelDisplayName() {
+    LabelAction labelAction = node.getAction(LabelAction.class);
+    if (labelAction != null) {
+      return labelAction.getDisplayName();
+    }
+    return null;
   }
 
   private static NodeType getNodeType(FlowNode node) {

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
@@ -38,6 +38,12 @@ public class PipelineStepApi {
                   if (stepArguments != null && !stepArguments.isEmpty()) {
                     displayName = stepArguments + " - " + displayName;
                   }
+
+                  // Use the step label as the displayName if set
+                  String labelDisplayName = flowNodeWrapper.getLabelDisplayName();
+                  if (labelDisplayName != null && !labelDisplayName.isEmpty()) {
+                    displayName = labelDisplayName;
+                  }
                   // Remove non-printable chars (e.g. ANSI color codes).
                   logger.debug("DisplayName Before: '" + displayName + "'.");
                   displayName = cleanTextContent(displayName);


### PR DESCRIPTION
Don't include the step arguments in a step display name if a label is defined for the step.

Fix for https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/144.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

Below is another example of the issue being resolved. Some of my build scripts require boiler plate steps to initialize the environment. Those steps end up making the console view challenging to read.

Pipeline:
```
node {
    stage("Build") {
        bat("echo step1")
        def step2 = $/
    		@echo off
    		if "%SomePath%" == "" echo Error 'SomePath' must be defined in the environment. && exit /b 1
    		echo cd /d %SomePath%
    		cd /d %SomePath%
    		echo path\to\init.bat
    		call path\to\init.bat
    		echo step2
        /$
        bat(script: step2, label: "step2")
    }
}
```

Before:
![image](https://user-images.githubusercontent.com/551572/197067081-0a1f1087-242d-4f4c-b7f2-fe90aa1bb8a4.png)

After:
![image](https://user-images.githubusercontent.com/551572/197066298-ad8f30ed-2e6f-4fe2-a3d1-2615a9dcab8f.png)

Ideally the step display name would still include the `- Windows Batch Script` to be consistent with steps that don't define a label.

That suffix is the type display name which is the default value returned for step's display name if no label is defined [FlowNode.java#L258](https://github.com/jenkinsci/workflow-api-plugin/blob/8005c684bac63d6193195d8f868a051f508e7f30/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java#L258).

Unfortunately the type display name isn't public: [FlowNode.java#L321)](https://github.com/jenkinsci/workflow-api-plugin/blob/8005c684bac63d6193195d8f868a051f508e7f30/src/main/java/org/jenkinsci/plugins/workflow/graph/FlowNode.java#L321.
