### PR TITLE
Expand tree view to a reasonable step by default

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -178,7 +178,7 @@ export class PipelineConsole extends React.Component<
             stages: result.data.stages,
           },
           () => {
-            this.handleUrlParams();
+            this.selectNode();
           }
         );
       });
@@ -195,7 +195,7 @@ export class PipelineConsole extends React.Component<
             steps: step_result.data.steps,
           },
           () => {
-            this.handleUrlParams();
+            this.selectNode();
           }
         );
       })
@@ -219,8 +219,8 @@ export class PipelineConsole extends React.Component<
     }
   }
 
-  handleUrlParams() {
-    console.debug(`In handleUrlParams.`);
+  selectNode() {
+    console.debug(`In selectNode.`);
     let params = new URLSearchParams(document.location.search.substring(1));
     let selected = params.get("selected-node") || "";
     if (selected) {
@@ -325,7 +325,7 @@ export class PipelineConsole extends React.Component<
 
   // Determines the default selected step in the tree view based
   getDefaultSelectedStep(steps: StepInfo[]) {
-    let selectedStep = null;
+    let selectedStep = steps.find(step => step !== undefined)
     for (let i = 0; i < steps.length; i++) {
       let step = steps[i];
       let stepResult = step.state.toLowerCase() as Result;


### PR DESCRIPTION
If no `selected-node` url param is specified, determine if another step node should be expanded to and selected by default.

Steps with `running`, `queued` or `paused` states are given priority. Otherwise the step with the first occurrence of the worst result out of `unstable`, `failure` and `aborted` is selected.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
