### PR TITLE
Convert blue ocean icons to jenkins icons for the pipeline graph

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/StatusIcons.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/StatusIcons.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { Result } from "../PipelineGraphModel";
-import { SvgSpinner } from "./SvgSpinner";
 import { SvgStatus } from "./SvgStatus";
 
 export const nodeStrokeWidth = 3.5; // px.
@@ -10,13 +9,10 @@ export function getGroupForResult(
   result: Result,
   percentage: number,
   radius: number
-): React.ReactElement<SvgSpinner> | React.ReactElement<SvgStatus> {
+): React.ReactElement<SvgStatus> {
   switch (result) {
     case Result.running:
     case Result.queued:
-      return (
-        <SvgSpinner radius={radius} result={result} percentage={percentage} />
-      );
     case Result.not_built:
     case Result.skipped:
     case Result.success:
@@ -35,3 +31,26 @@ export function getGroupForResult(
 function badResult(x: never) {
   console.error("Unexpected Result value", x);
 }
+
+export const getClassForResult = (result: Result) => {
+  // These come from the themes icons.less
+  switch (result) {
+    case Result.aborted:
+      return "icon-aborted";
+    case Result.unstable:
+      return "icon-yellow";
+    case Result.failure:
+      return "icon-red";
+    case Result.success:
+      return "icon-blue";
+    case Result.running:
+    case Result.queued:
+      return "icon-grey";
+    case Result.not_built:
+    case Result.paused:
+    case Result.skipped:
+    case Result.unknown:
+    default:
+      return "icon-nobuilt";
+  }
+};

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/StatusIcons.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/StatusIcons.tsx
@@ -46,9 +46,10 @@ export const getClassForResult = (result: Result) => {
     case Result.running:
     case Result.queued:
       return "icon-grey";
+    case Result.skipped:
+      return "icon-skipped";
     case Result.not_built:
     case Result.paused:
-    case Result.skipped:
     case Result.unknown:
     default:
       return "icon-nobuilt";

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/SvgStatus.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/SvgStatus.tsx
@@ -1,8 +1,6 @@
 import * as React from "react";
-
 import { Result } from "../PipelineGraphModel";
-
-import { nodeStrokeWidth } from "./StatusIcons";
+import { getClassForResult } from "./StatusIcons";
 
 // These were mostly taken from SVG and pre-translated
 const questionMarkPath =
@@ -15,15 +13,7 @@ const questionMarkPath =
   "C-0.660,-3.76 -1.21,-3.47 -1.52,-2.87 C-1.69,-2.54 -1.79,-2.07 -1.81,-1.45 L-3.09,-1.45 " +
   "C-3.09,-2.48 -2.80,-3.31 -2.21,-3.94 L-2.21,-3.94 Z";
 
-const hollowCirclePath =
-  "M 0,-6 A 6,6 0 0 1 0,6 A 6,6 0 0 1 0,-6 m 0,1.3 A 4,4 0 0 0 0,4.7 A 4,4 0 0 0 0,-4.7";
-
-const checkMarkPoints =
-  "-2.00 2.80 -4.80 0.00 -5.73 0.933 -2.00 4.67 6.00 -3.33 5.07 -4.27";
-
-const crossPoints =
-  "4.67 -3.73 3.73 -4.67 0 -0.94 -3.73 -4.67 -4.67 -3.73 -0.94 0 -4.67 3.73 -3.73 4.67 0 0.94 " +
-  "3.73 4.67 4.67 3.73 0.94 0";
+const imagesPath = "/jenkins/images";
 
 interface Props {
   result: Result;
@@ -32,105 +22,151 @@ interface Props {
 
 export class SvgStatus extends React.PureComponent<Props> {
   render() {
+    const baseWrapperClasses = "build-status-icon__wrapper icon-md";
     const { result, radius = 12 } = this.props;
+    const diameter = radius * 2;
+    const iconOuterClassName =
+      result === Result.running ? "in-progress" : "static";
+    const iconSuffix = result === Result.running ? "-anime" : "";
 
-    if (result === Result.not_built || result === Result.skipped) {
-      // Basic grey circle
-
-      const innerRadius = radius - 0.5 * nodeStrokeWidth; // No "inside" stroking in SVG
-
-      return (
-        <g>
-          <circle
-            cx="0"
-            cy="0"
-            r={radius}
-            className="halo"
-            strokeWidth={nodeStrokeWidth}
-          />
-          <circle
-            cx="0"
-            cy="0"
-            r={innerRadius}
-            strokeWidth={nodeStrokeWidth}
-            className="PWGx-svgResultStatusOutline"
-          />
+    return (
+      <g
+        className={`${baseWrapperClasses} ${getClassForResult(
+          result
+        )}${iconSuffix}`}
+      >
+        <g
+          className="build-status-icon__outer"
+          style={{ transform: `translate(0,0)` }}
+        >
+          <svg
+            focusable="false"
+            className="svg-icon "
+            width={diameter}
+            height={diameter}
+            x={-radius}
+            y={-radius}
+          >
+            <use
+              className="svg-icon"
+              style={{ transformOrigin: "50% 50%" }}
+              href={`${imagesPath}/build-status/build-status-sprite.svg#build-status-${iconOuterClassName}`}
+            />
+          </svg>
         </g>
-      );
-    } else {
-      // Otherwise solid-bg circle with a glyph on it
-
-      return (
-        <g className="PWGx-svgResultStatusSolid">
-          <circle
-            cx="0"
-            cy="0"
-            r={radius}
-            className="halo"
-            strokeWidth={nodeStrokeWidth}
-          />
-          <circle
-            cx="0"
-            cy="0"
-            r={radius}
-            className={`statusColor circle-bg ${result}`}
-          />
-          {getGlyphFor(result)}
-        </g>
-      );
-    }
+        {getGlyphFor(result)}
+      </g>
+    );
   }
 }
 
 /**
-    Returns a glyph (as <g>) for specified result type. Centered at 0,0, scaled for 24px icons.
+ Returns a glyph (as <g>) for specified result type. Centered at 0,0, scaled for 24px icons.
  */
-function getGlyphFor(result: Result) {
+function getGlyphFor(result: Result, radius: number = 12) {
   // NB: If we start resizing these things, we'll need to use radius/12 to
   // generate a "scale" transform for the group
-
+  const diameter = radius * 2;
   switch (result) {
     case Result.aborted:
       return (
-        <g className="PWGx-result-status-glyph">
-          <polygon points="-5 -1 5 -1 5 1 -5 1" />
-        </g>
+        <svg
+          x={-radius}
+          y={-radius}
+          width={diameter}
+          height={diameter}
+          focusable="false"
+          className={`svg-icon icon-md`}
+        >
+          <use
+            href={`${imagesPath}/build-status/build-status-sprite.svg#last-aborted`}
+          />
+        </svg>
       );
     case Result.paused:
       // "||"
       // 8px 9.3px
       return (
-        <g className="PWGx-result-status-glyph">
+        <svg
+          x={-radius}
+          y={-radius}
+          width={diameter}
+          height={diameter}
+          focusable="false"
+          className={`svg-icon icon-md`}
+          viewBox={`${-radius} ${-radius} ${diameter} ${diameter}`}
+        >
           <polygon points="-4,-4.65 -4,4.65 -4,4.65 -1.5,4.65 -1.5,-4.65" />
           <polygon points="4,-4.65 1.5,-4.65 1.5,-4.65 1.5,4.65 4,4.65" />
-        </g>
+        </svg>
       );
     case Result.unstable:
       // "!"
       return (
-        <g className="PWGx-result-status-glyph">
-          <polygon points="-1 -5 1 -5 1 1 -1 1" />
-          <polygon points="-1 3 1 3 1 5 -1 5" />
-        </g>
+        <svg
+          x={-radius}
+          y={-radius}
+          width={diameter}
+          height={diameter}
+          focusable="false"
+          className={`svg-icon icon-md`}
+        >
+          <use
+            href={`${imagesPath}/build-status/build-status-sprite.svg#last-unstable`}
+          />
+        </svg>
       );
     case Result.success:
       // check-mark
       return (
-        <g className="PWGx-result-status-glyph">
-          <polygon points={checkMarkPoints} />
-        </g>
+        <svg
+          x={-radius}
+          y={-radius}
+          width={diameter}
+          height={diameter}
+          focusable="false"
+          className={`svg-icon icon-md`}
+        >
+          <use
+            href={`${imagesPath}/build-status/build-status-sprite.svg#last-successful`}
+          />
+        </svg>
       );
     case Result.failure:
       // "X"
       return (
-        <g className="PWGx-result-status-glyph">
-          <polygon points={crossPoints} />
-        </g>
+        <svg
+          x={-radius}
+          y={-radius}
+          width={diameter}
+          height={diameter}
+          focusable="false"
+          className={`svg-icon icon-md`}
+        >
+          <use
+            href={`${imagesPath}/build-status/build-status-sprite.svg#last-failed`}
+          />
+        </svg>
       );
-    case Result.not_built: // Handled directly by SvgStatus component above
-    case Result.skipped: // Handled directly by SvgStatus component above
-    case Result.queued: // Handled by spinner
-    case Result.running: // Handled by spinner
+    case Result.not_built:
+      return (
+        <svg
+          x={-radius}
+          y={-radius}
+          width={diameter}
+          height={diameter}
+          focusable="false"
+          className={`svg-icon icon-md`}
+        >
+          <use
+            href={`${imagesPath}/build-status/build-status-sprite.svg#never-built`}
+          />
+        </svg>
+      );
+    case Result.skipped:
+    case Result.queued:
+    case Result.running:
+      return null;
     case Result.unknown:
       break; // Continue on to the "unknown render"
 
@@ -139,9 +175,16 @@ function getGlyphFor(result: Result) {
   }
   // "?" for Result.unknown or for bad input
   return (
-    <g className="PWGx-result-status-glyph">
+    <svg
+      className={`svg-icon icon-md`}
+      x={-radius}
+      y={-radius}
+      width={diameter}
+      height={diameter}
+      viewBox={`${-radius} ${-radius} ${diameter} ${diameter}`}
+    >
       <path d={questionMarkPath} />
-    </g>
+    </svg>
   );
 }
 

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/SvgStatus.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/SvgStatus.tsx
@@ -18,7 +18,7 @@ interface Props {
   radius: number;
 }
 
-const getImagesPath = () => `${document.head.dataset.imagesurl}`;
+const imagesPath = document.head.dataset.imagesurl;
 
 export class SvgStatus extends React.PureComponent<Props> {
   render() {
@@ -50,7 +50,7 @@ export class SvgStatus extends React.PureComponent<Props> {
             <use
               className="svg-icon"
               style={{ transformOrigin: "50% 50%" }}
-              href={`${getImagesPath()}/build-status/build-status-sprite.svg#build-status-${iconOuterClassName}`}
+              href={`${imagesPath}/build-status/build-status-sprite.svg#build-status-${iconOuterClassName}`}
             />
           </svg>
         </g>
@@ -79,7 +79,7 @@ function getGlyphFor(result: Result, radius: number = 12) {
           className={`svg-icon icon-md`}
         >
           <use
-            href={`${getImagesPath()}/build-status/build-status-sprite.svg#last-aborted`}
+            href={`${imagesPath}/build-status/build-status-sprite.svg#last-aborted`}
           />
         </svg>
       );
@@ -112,7 +112,7 @@ function getGlyphFor(result: Result, radius: number = 12) {
           className={`svg-icon icon-md`}
         >
           <use
-            href={`${getImagesPath()}/build-status/build-status-sprite.svg#last-unstable`}
+            href={`${imagesPath}/build-status/build-status-sprite.svg#last-unstable`}
           />
         </svg>
       );
@@ -128,7 +128,7 @@ function getGlyphFor(result: Result, radius: number = 12) {
           className={`svg-icon icon-md`}
         >
           <use
-            href={`${getImagesPath()}/build-status/build-status-sprite.svg#last-successful`}
+            href={`${imagesPath}/build-status/build-status-sprite.svg#last-successful`}
           />
         </svg>
       );
@@ -144,7 +144,7 @@ function getGlyphFor(result: Result, radius: number = 12) {
           className={`svg-icon icon-md`}
         >
           <use
-            href={`${getImagesPath()}/build-status/build-status-sprite.svg#last-failed`}
+            href={`${imagesPath}/build-status/build-status-sprite.svg#last-failed`}
           />
         </svg>
       );
@@ -159,7 +159,7 @@ function getGlyphFor(result: Result, radius: number = 12) {
           className={`svg-icon icon-md`}
         >
           <use
-            href={`${getImagesPath()}/build-status/build-status-sprite.svg#never-built`}
+            href={`${imagesPath}/build-status/build-status-sprite.svg#never-built`}
           />
         </svg>
       );

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/SvgStatus.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/SvgStatus.tsx
@@ -13,12 +13,12 @@ const questionMarkPath =
   "C-0.660,-3.76 -1.21,-3.47 -1.52,-2.87 C-1.69,-2.54 -1.79,-2.07 -1.81,-1.45 L-3.09,-1.45 " +
   "C-3.09,-2.48 -2.80,-3.31 -2.21,-3.94 L-2.21,-3.94 Z";
 
-const imagesPath = "/jenkins/images";
-
 interface Props {
   result: Result;
   radius: number;
 }
+
+const getImagesPath = () => `${document.head.dataset.imagesurl}`;
 
 export class SvgStatus extends React.PureComponent<Props> {
   render() {
@@ -50,7 +50,7 @@ export class SvgStatus extends React.PureComponent<Props> {
             <use
               className="svg-icon"
               style={{ transformOrigin: "50% 50%" }}
-              href={`${imagesPath}/build-status/build-status-sprite.svg#build-status-${iconOuterClassName}`}
+              href={`${getImagesPath()}/build-status/build-status-sprite.svg#build-status-${iconOuterClassName}`}
             />
           </svg>
         </g>
@@ -79,7 +79,7 @@ function getGlyphFor(result: Result, radius: number = 12) {
           className={`svg-icon icon-md`}
         >
           <use
-            href={`${imagesPath}/build-status/build-status-sprite.svg#last-aborted`}
+            href={`${getImagesPath()}/build-status/build-status-sprite.svg#last-aborted`}
           />
         </svg>
       );
@@ -112,7 +112,7 @@ function getGlyphFor(result: Result, radius: number = 12) {
           className={`svg-icon icon-md`}
         >
           <use
-            href={`${imagesPath}/build-status/build-status-sprite.svg#last-unstable`}
+            href={`${getImagesPath()}/build-status/build-status-sprite.svg#last-unstable`}
           />
         </svg>
       );
@@ -128,7 +128,7 @@ function getGlyphFor(result: Result, radius: number = 12) {
           className={`svg-icon icon-md`}
         >
           <use
-            href={`${imagesPath}/build-status/build-status-sprite.svg#last-successful`}
+            href={`${getImagesPath()}/build-status/build-status-sprite.svg#last-successful`}
           />
         </svg>
       );
@@ -144,7 +144,7 @@ function getGlyphFor(result: Result, radius: number = 12) {
           className={`svg-icon icon-md`}
         >
           <use
-            href={`${imagesPath}/build-status/build-status-sprite.svg#last-failed`}
+            href={`${getImagesPath()}/build-status/build-status-sprite.svg#last-failed`}
           />
         </svg>
       );
@@ -159,7 +159,7 @@ function getGlyphFor(result: Result, radius: number = 12) {
           className={`svg-icon icon-md`}
         >
           <use
-            href={`${imagesPath}/build-status/build-status-sprite.svg#never-built`}
+            href={`${getImagesPath()}/build-status/build-status-sprite.svg#never-built`}
           />
         </svg>
       );

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/styles/PipelineGraphWidget.scss
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/styles/PipelineGraphWidget.scss
@@ -9,6 +9,16 @@ circle.halo {
   fill: none;
 }
 
+.icon-skipped {
+  color: $graph-connector-grey;
+  fill: $graph-connector-grey;
+
+  .svg-icon {
+    color: $graph-connector-grey;
+    fill: $graph-connector-grey;
+  }
+}
+
 .PWGx-result-status-glyph {
   stroke: none;
   fill: #fff;

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/styles/PipelineGraphWidget.scss
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/styles/PipelineGraphWidget.scss
@@ -153,5 +153,4 @@ circle.halo {
 
 .PWGx-pipeline-selection-highlight circle {
   fill: none;
-  stroke: $selection-highlight;
 }


### PR DESCRIPTION
- Convert blue ocean icons to jenkins icons for the pipeline graph
- update the skipped icon
- use dynamic imagesurl var

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

<img width="1618" alt="image" src="https://user-images.githubusercontent.com/5103752/198838473-487c5c90-4ca8-4b96-b28b-3a71684a91bd.png">


I am not sure if new tests are needed or if visuals are tested. 

Fixes #11 
Fixes #173

### Aborted, Running
Before:
https://user-images.githubusercontent.com/5103752/197560337-10e6ce1e-ea9b-469a-8d3c-5eb5d19a4628.mov

After: 
https://user-images.githubusercontent.com/5103752/197560378-84666132-aa3c-46ad-a472-34508ccae722.mov

### Success, Paused, Unstable
Before:
https://user-images.githubusercontent.com/5103752/197560548-f177c19f-6bb8-4be0-b731-408b70a7ce3d.mov

After:
https://user-images.githubusercontent.com/5103752/197560608-361d3094-20ca-483a-8807-732c8a2950ce.mov

### Unknown icons
Before:
<img width="1123" alt="image" src="https://user-images.githubusercontent.com/5103752/197559771-46eece99-21c9-4532-852d-04bbc35114e8.png">

After:
<img width="1116" alt="image" src="https://user-images.githubusercontent.com/5103752/197559954-bf8f5c06-24d3-48ef-91e3-4720e4d58a03.png">


