### PR TITLE
Use ionicons-api version provided by bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
                 <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.346.x</artifactId>
-                <version>1670.v7f165fc7a_079</version>
+                <version>1678.vc1feb_6a_3c0f1</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>ionicons-api</artifactId>
-            <version>31.v4757b_6987003</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/pipeline-graph-view-plugin</gitHubRepo>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.346.1</jenkins.version>
+        <jenkins.version>2.346.3</jenkins.version>
         <node.version>16.18.0</node.version>
         <npm.version>8.19.3</npm.version>
     </properties>


### PR DESCRIPTION
I'm not aware of any version conflict, but if there's one, a release would resolve it.