### PR TITLE
Add right margin to timestamp

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -250,6 +250,10 @@ div.console-output-line {
   display: flex;
 }
 
+span.timestamp {
+  margin-right: 15px;
+}
+
 div.stage-detail-group {
   vertical-align: auto;
   border-radius: 10px;


### PR DESCRIPTION
Added a `margin-right` to timestamps to stop them from touching with other text.
![Screenshot 2022-11-25 at 16 24 40](https://user-images.githubusercontent.com/4447764/204025119-7084faa7-951c-4852-a2e6-3d279fa67f1a.png)
Fixes #200 

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
