### PR TITLE
Add links to previous and next builds to pipeline graph and console views

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -310,3 +310,8 @@ div.split-pane {
 a {
   cursor: pointer !important;
 }
+
+.app-details__prev_next {
+  color: inherit !important;
+  text-decoration: none !important;
+}

--- a/src/main/frontend/pipeline-graph-view/app.scss
+++ b/src/main/frontend/pipeline-graph-view/app.scss
@@ -52,3 +52,10 @@
   height: 20px !important;
   color: currentColor !important;
 }
+
+.app-details__prev_next {
+  a, a:hover, a:focus, a:active {
+    color: inherit !important;
+    text-decoration: none !important;
+  }
+}

--- a/src/main/frontend/pipeline-graph-view/app.scss
+++ b/src/main/frontend/pipeline-graph-view/app.scss
@@ -54,8 +54,6 @@
 }
 
 .app-details__prev_next {
-  a, a:hover, a:focus, a:active {
-    color: inherit !important;
-    text-decoration: none !important;
-  }
+  color: inherit !important;
+  text-decoration: none !important;
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -43,7 +43,30 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
   }
 
   public String getBuildDisplayName() {
+    return run.getDisplayName();
+  }
+
+  public String getFullBuildDisplayName() {
     return run.getFullDisplayName();
+  }
+
+  public String getFullProjectName() {
+    return run.getParent().getFullName();
+  }
+
+  private String getBuildNumber(WorkflowRun run) {
+    if (run != null) {
+      return String.valueOf(run.getNumber());
+    }
+    return null;
+  }
+
+  public String getPreviousBuildNumber() {
+    return getBuildNumber(run.getPreviousBuild());
+  }
+
+  public String getNextBuildNumber() {
+    return getBuildNumber(run.getNextBuild());
   }
 
   public BallColor getIconColor() {

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -50,8 +50,8 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
     return run.getFullDisplayName();
   }
 
-  public String getFullProjectName() {
-    return run.getParent().getFullName();
+  public String getFullProjectDisplayName() {
+    return run.getParent().getFullDisplayName();
   }
 
   private String getBuildNumber(WorkflowRun run) {

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewAction/index.jelly
@@ -2,14 +2,26 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:p="/lib/pipeline-graph-view">
-  <l:layout title="${%Graph} [${it.buildDisplayName}]" type="one-column">
+  <l:layout title="${%Graph} [${it.fullBuildDisplayName}]" type="one-column">
     <l:main-panel>
       <div class="jenkins-app-bar">
         <div class="jenkins-app-bar__content">
           <h1>
-            <l:icon alt="${it.iconColor.description}" class="${it.buildStatusIconClassName} icon-xlg"
-                    tooltip="${it.iconColor.description}"/>
+            <l:icon alt="${it.iconColor.description}"
+              class="${it.buildStatusIconClassName} icon-xlg"
+              tooltip="${it.iconColor.description}" />
+            ${it.fullProjectName}
+          <j:if test="${it.previousBuildNumber!=null}">
+                <a href="../../${it.previousBuildNumber}/pipeline-graph" style="text-decoration:none; color:inherit;">
+                  <l:icon class="symbol-chevron-back-outline plugin-ionicons-api icon-md" tooltip="${%Previous Build}" />
+              </a>
+            </j:if>
             ${it.buildDisplayName}
+          <j:if test="${it.nextBuildNumber!=null}">
+                <a href="../../${it.nextBuildNumber}/pipeline-graph" style="text-decoration:none; color:inherit;">
+                  <l:icon class="symbol-chevron-forward-outline plugin-ionicons-api icon-md" tooltip="${%Next Build}"/>
+              </a>
+            </j:if>
           </h1>
         </div>
         <div class="jenkins-app-bar__controls">

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewAction/index.jelly
@@ -12,13 +12,13 @@
               tooltip="${it.iconColor.description}" />
             ${it.fullProjectDisplayName}
             <j:if test="${it.previousBuildNumber!=null}">
-              <a href="../../${it.previousBuildNumber}/pipeline-graph" style="text-decoration:none; color:inherit;">
+              <a href="../../${it.previousBuildNumber}/pipeline-graph" class="app-details__prev_next">
                 <l:icon class="symbol-chevron-back-outline plugin-ionicons-api icon-md" tooltip="${%Previous Build}" />
               </a>
             </j:if>
             ${it.buildDisplayName}
             <j:if test="${it.nextBuildNumber!=null}">
-              <a href="../../${it.nextBuildNumber}/pipeline-graph" style="text-decoration:none; color:inherit;">
+              <a href="../../${it.nextBuildNumber}/pipeline-graph" class="app-details__prev_next">
                 <l:icon class="symbol-chevron-forward-outline plugin-ionicons-api icon-md" tooltip="${%Next Build}"/>
               </a>
             </j:if>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewAction/index.jelly
@@ -11,15 +11,15 @@
               class="${it.buildStatusIconClassName} icon-xlg"
               tooltip="${it.iconColor.description}" />
             ${it.fullProjectName}
-          <j:if test="${it.previousBuildNumber!=null}">
-                <a href="../../${it.previousBuildNumber}/pipeline-graph" style="text-decoration:none; color:inherit;">
-                  <l:icon class="symbol-chevron-back-outline plugin-ionicons-api icon-md" tooltip="${%Previous Build}" />
+            <j:if test="${it.previousBuildNumber!=null}">
+              <a href="../../${it.previousBuildNumber}/pipeline-graph" style="text-decoration:none; color:inherit;">
+                <l:icon class="symbol-chevron-back-outline plugin-ionicons-api icon-md" tooltip="${%Previous Build}" />
               </a>
             </j:if>
             ${it.buildDisplayName}
-          <j:if test="${it.nextBuildNumber!=null}">
-                <a href="../../${it.nextBuildNumber}/pipeline-graph" style="text-decoration:none; color:inherit;">
-                  <l:icon class="symbol-chevron-forward-outline plugin-ionicons-api icon-md" tooltip="${%Next Build}"/>
+            <j:if test="${it.nextBuildNumber!=null}">
+              <a href="../../${it.nextBuildNumber}/pipeline-graph" style="text-decoration:none; color:inherit;">
+                <l:icon class="symbol-chevron-forward-outline plugin-ionicons-api icon-md" tooltip="${%Next Build}"/>
               </a>
             </j:if>
           </h1>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewAction/index.jelly
@@ -10,7 +10,7 @@
             <l:icon alt="${it.iconColor.description}"
               class="${it.buildStatusIconClassName} icon-xlg"
               tooltip="${it.iconColor.description}" />
-            ${it.fullProjectName}
+            ${it.fullProjectDisplayName}
             <j:if test="${it.previousBuildNumber!=null}">
               <a href="../../${it.previousBuildNumber}/pipeline-graph" style="text-decoration:none; color:inherit;">
                 <l:icon class="symbol-chevron-back-outline plugin-ionicons-api icon-md" tooltip="${%Previous Build}" />

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -10,13 +10,13 @@
                         <l:icon alt="${it.iconColor.description}" class="${it.buildStatusIconClassName} icon-xlg" tooltip="${it.iconColor.description}"/>
                         ${it.fullProjectDisplayName}
                         <j:if test="${it.previousBuildNumber!=null}">
-                            <a href="../../${it.previousBuildNumber}/pipeline-console" style="text-decoration:none; color:inherit;">
+                            <a href="../../${it.previousBuildNumber}/pipeline-console" class="app-details__prev_next">
                                 <l:icon class="symbol-chevron-back-outline plugin-ionicons-api icon-md" tooltip="${%Previous Build}"/>
                             </a>
                         </j:if>
                         ${it.buildDisplayName}
                         <j:if test="${it.nextBuildNumber!=null}">
-                            <a href="../../${it.nextBuildNumber}/pipeline-console" style="text-decoration:none; color:inherit;">
+                            <a href="../../${it.nextBuildNumber}/pipeline-console" class="app-details__prev_next">
                                 <l:icon class="symbol-chevron-forward-outline plugin-ionicons-api icon-md" tooltip="${%Next Build}"/>
                             </a>
                         </j:if>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -8,7 +8,7 @@
                 <div class="jenkins-app-bar__content">
                     <h1>
                         <l:icon alt="${it.iconColor.description}" class="${it.buildStatusIconClassName} icon-xlg" tooltip="${it.iconColor.description}"/>
-                        ${it.fullProjectName}
+                        ${it.fullProjectDisplayName}
                         <j:if test="${it.previousBuildNumber!=null}">
                             <a href="../../${it.previousBuildNumber}/pipeline-console" style="text-decoration:none; color:inherit;">
                                 <l:icon class="symbol-chevron-back-outline plugin-ionicons-api icon-md" tooltip="${%Previous Build}"/>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -8,7 +8,18 @@
                 <div class="jenkins-app-bar__content">
                     <h1>
                         <l:icon alt="${it.iconColor.description}" class="${it.buildStatusIconClassName} icon-xlg" tooltip="${it.iconColor.description}"/>
+                        ${it.fullProjectName}
+                        <j:if test="${it.previousBuildNumber!=null}">
+                            <a href="../../${it.previousBuildNumber}/pipeline-console" style="text-decoration:none; color:inherit;">
+                                <l:icon class="symbol-chevron-back-outline plugin-ionicons-api icon-md" tooltip="${%Previous Build}"/>
+                            </a>
+                        </j:if>
                         ${it.buildDisplayName}
+                        <j:if test="${it.nextBuildNumber!=null}">
+                            <a href="../../${it.nextBuildNumber}/pipeline-console" style="text-decoration:none; color:inherit;">
+                                <l:icon class="symbol-chevron-forward-outline plugin-ionicons-api icon-md" tooltip="${%Next Build}"/>
+                            </a>
+                        </j:if>
                     </h1>
                 </div>
                 <div class="jenkins-app-bar__controls">


### PR DESCRIPTION
Modified the `index.jelly` files of the `PipelineGraphViewAction` and `PipelineConsoleViewAction` to include links to the previous and next builds.

Implements https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/211.

![issue-212](https://user-images.githubusercontent.com/551572/218959794-18546392-386a-4d1e-97c0-b5336dd469e0.gif)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
