### PR TITLE
Fix how scripted parallel stages are displayed.

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
@@ -51,6 +51,7 @@ const getTreeItemsFromStage = (stageItems: StageInfo[], steps: StepInfo[]) => {
   // Copy steps so we don't affect props.steps.
   let stepsCopy = [...steps];
   return stageItems.map((stageItemData) => {
+    console.info(`Generating stage item(s) for '${stageItemData.name} - ${stageItemData.id}'.`)
     let children: JSX.Element[] = [];
     let stageSteps = [] as StepInfo[];
     // Handle leaf nodes first.

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
@@ -51,7 +51,7 @@ const getTreeItemsFromStage = (stageItems: StageInfo[], steps: StepInfo[]) => {
   // Copy steps so we don't affect props.steps.
   let stepsCopy = [...steps];
   return stageItems.map((stageItemData) => {
-    console.info(`Generating stage item(s) for '${stageItemData.name} - ${stageItemData.id}'.`)
+    console.debug(`Generating stage item(s) for '${stageItemData.name} - ${stageItemData.id}'.`)
     let children: JSX.Element[] = [];
     let stageSteps = [] as StepInfo[];
     // Handle leaf nodes first.

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
@@ -83,14 +83,14 @@ public class PipelineStepApi {
   }
 
   public PipelineStepList getSteps(String stageId) {
-    PipelineStepVisitor builder = new PipelineStepVisitor(run, null);
+    PipelineStepVisitor builder = new PipelineStepVisitor(run);
     List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
     return new PipelineStepList(parseSteps(stepNodes, stageId));
   }
 
   /* Returns a PipelineStepList, sorted by stageId and Id. */
   public PipelineStepList getAllSteps() {
-    PipelineStepVisitor builder = new PipelineStepVisitor(run, null);
+    PipelineStepVisitor builder = new PipelineStepVisitor(run);
     Map<String, List<FlowNodeWrapper>> stepNodes = builder.getAllSteps();
     PipelineStepList allSteps = new PipelineStepList();
     for (Map.Entry<String, List<FlowNodeWrapper>> entry : stepNodes.entrySet()) {

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
@@ -13,8 +13,6 @@ public class PipelineStepApi {
   private static final Logger logger = LoggerFactory.getLogger(PipelineStepApi.class);
   private final transient WorkflowRun run;
 
-  private static final Object mutex = new Object();
-
   public PipelineStepApi(WorkflowRun run) {
     this.run = run;
   }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
@@ -181,6 +181,7 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
     }
     // Do not add steps to this stage if it's parent is a parallel block  and it's a declarative step - (it should get addded to
     // that instead).
+    // This could be a quirk of how the GraphVisitor works - possible 
     if (PipelineNodeUtil.isParallelBranch(pendingBlocks.peek()) && isDeclarative()) {
       if (logger.isDebugEnabled()) {
         logger.debug(

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
@@ -2,20 +2,17 @@ package io.jenkins.plugins.pipelinegraphview.utils;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
-import io.jenkins.plugins.pipelinegraphview.utils.BlueRun.BlueRunResult;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
+import org.jenkinsci.plugins.pipeline.modeldefinition.actions.ExecutionModelAction;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode;
-import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.AtomNode;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
@@ -35,47 +32,37 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Gives steps inside
- *
- * <p>- Stage boundary: Stage boundary ends where another stage start or this stage block ends -
- * branch boundary: branch block boundary
+ * Gives steps in a given FlowGraph and assigned them to the nearing stage or parallel block
+ * boundary.
  *
  * <p>Original source:
  * https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepVisitor.java
  *
  * @author Vivek Pandey
+ * @author Tim Brown
  */
 public class PipelineStepVisitor extends StandardChunkVisitor {
-  private final FlowNode node;
   private final WorkflowRun run;
 
-  private final ArrayDeque<FlowNodeWrapper> steps = new ArrayDeque<>();
   private final ArrayDeque<FlowNodeWrapper> stageSteps = new ArrayDeque<>();
-  private final ArrayDeque<FlowNodeWrapper> preSteps = new ArrayDeque<>();
-  private final ArrayDeque<FlowNodeWrapper> postSteps = new ArrayDeque<>();
 
   private final Map<String, FlowNodeWrapper> stepMap = new HashMap<>();
   private final Map<String, List<FlowNodeWrapper>> stageStepMap = new HashMap<>();
 
   private final ArrayDeque<FlowNode> pendingBlocks = new ArrayDeque<>();
 
-  private boolean stageStepsCollectionCompleted = false;
-
-  private boolean inStageScope;
-
   private FlowNode currentStage;
 
-  private ArrayDeque<FlowNode> stages = new ArrayDeque<>();
   private InputAction inputAction;
-  private StepEndNode closestEndNode;
-  private StepStartNode agentNode = null;
+
+  private final boolean declarative;
 
   private static final Logger logger = LoggerFactory.getLogger(PipelineStepVisitor.class);
 
-  public PipelineStepVisitor(WorkflowRun run, @Nullable final FlowNode node) {
-    this.node = node;
+  public PipelineStepVisitor(WorkflowRun run) {
     this.run = run;
     this.inputAction = run.getAction(InputAction.class);
+    declarative = run.getAction(ExecutionModelAction.class) != null;
     FlowExecution execution = run.getExecution();
     if (execution != null) {
       try {
@@ -95,16 +82,23 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
     }
   }
 
-  //@Override
-  public void xxxparallelBranchStart(
+  @Override
+  public void parallelBranchStart(
       @NonNull FlowNode parallelStartNode,
       @NonNull FlowNode branchStartNode,
       @NonNull ForkScanner scanner) {
+    FlowNode finishedBlock = null;
     if (!pendingBlocks.isEmpty()) {
+      finishedBlock = pendingBlocks.pop();
       // Finished processing atom nodes in this block
-      FlowNode finishedBlock = pendingBlocks.pop();
       if (logger.isDebugEnabled()) {
-        logger.debug("parallelBranchStart. Removed Node ID: " + finishedBlock.getId() + "(" + finishedBlock.getDisplayName() + "-" + ") from pendingBlocks.");
+        logger.debug(
+            "parallelBranchStart. Removed Node ID: "
+                + finishedBlock.getId()
+                + "("
+                + finishedBlock.getDisplayName()
+                + "-"
+                + ") from pendingBlocks.");
       }
     }
     if (logger.isDebugEnabled()) {
@@ -122,13 +116,33 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
               + " .");
     }
 
-    if (stageStepsCollectionCompleted) { // skip
-      return;
+    if (logger.isDebugEnabled()) {
+      logger.debug("Pushing steps to stage in parallelBranchStart.");
     }
-    if (branchStartNode.equals(node)) {
-      stageStepsCollectionCompleted = true;
-    } else if (PipelineNodeUtil.isParallelBranch(node) && !branchStartNode.equals(node)) {
-      resetSteps();
+    // Record which stage the steps belong to this parallel block.
+    pushStageStepsToMap(branchStartNode);
+  }
+
+  @Override
+  public void parallelBranchEnd(
+      @NonNull FlowNode parallelStartNode,
+      @NonNull FlowNode branchEndNode,
+      @NonNull ForkScanner scanner) {
+    if (branchEndNode instanceof StepEndNode) {
+      FlowNode branchStartNode = ((StepEndNode) branchEndNode).getStartNode();
+      if (logger.isDebugEnabled()) {
+        logger.debug(
+            "Node ID: "
+                + branchStartNode.getId()
+                + " - "
+                + PipelineNodeUtil.isStage(branchStartNode)
+                + " - "
+                + PipelineNodeUtil.isParallelBranch(branchStartNode)
+                + " - "
+                + PipelineNodeUtil.isSyntheticStage(branchStartNode)
+                + " .");
+      }
+      pendingBlocks.push(branchStartNode);
     }
   }
 
@@ -137,6 +151,20 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
       @NonNull FlowNode startNode,
       @CheckForNull FlowNode beforeBlock,
       @NonNull ForkScanner scanner) {
+    super.chunkStart(startNode, beforeBlock, scanner);
+    FlowNode finishedBlock = null;
+    if (!pendingBlocks.isEmpty()) {
+      finishedBlock = pendingBlocks.pop();
+      // Finished processing atom nodes in this block
+      if (logger.isDebugEnabled()) {
+        logger.debug(
+            "chunkStart. Removed Node ID: "
+                + finishedBlock.getId()
+                + "("
+                + finishedBlock.getDisplayName()
+                + "} from pendingBlocks.");
+      }
+    }
     if (logger.isDebugEnabled()) {
       logger.debug(
           "Node ID: "
@@ -151,20 +179,42 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
               + PipelineNodeUtil.isSyntheticStage(startNode)
               + " .");
     }
-    super.chunkStart(startNode, beforeBlock, scanner);
-    if (PipelineNodeUtil.isStage(startNode)) {
-      stages.push(startNode);
+    // Do not add steps to this stage if it's parent is a parallel block (it should get addded to
+    // that instead).
+
+    if (finishedBlock != null) {
+      logger.debug("Finished block:");
+      logger.debug(String.valueOf(PipelineNodeUtil.isParallelBranch(finishedBlock)));
+      logger.debug(String.valueOf(PipelineNodeUtil.isPreSyntheticStage(finishedBlock)));
+      logger.debug(String.valueOf(PipelineNodeUtil.isSyntheticStage(finishedBlock)));
+      logger.debug(String.valueOf(PipelineNodeUtil.isStage(finishedBlock)));
     }
-    if (logger.isDebugEnabled()) {
-      logger.debug("Pushing steps to stage in chunkStart.");
+
+    logger.debug("Next pending block:");
+    logger.debug(String.valueOf(PipelineNodeUtil.isParallelBranch(pendingBlocks.peek())));
+    logger.debug(String.valueOf(PipelineNodeUtil.isPreSyntheticStage(pendingBlocks.peek())));
+    logger.debug(String.valueOf(PipelineNodeUtil.isSyntheticStage(pendingBlocks.peek())));
+    logger.debug(String.valueOf(PipelineNodeUtil.isStage(pendingBlocks.peek())));
+    if (PipelineNodeUtil.isParallelBranch(pendingBlocks.peek()) && isDeclarative()) {
+      if (logger.isDebugEnabled()) {
+        logger.debug(
+            "Not pushing steps to stage '"
+                + startNode.getDisplayName()
+                + "' in chunkStart as parent is parallel block in declarative pipeline.");
+      }
+    } else {
+      if (logger.isDebugEnabled()) {
+        logger.debug("Pushing step to stage in chunkStart.");
+      }
+      // Record which stage the steps belong to.
+      pushStageStepsToMap(startNode);
     }
-    // Record which stage the steps belong to.
-    pushStageStepsToMap(startNode);
   }
 
   @Override
   public void chunkEnd(
       @NonNull FlowNode endNode, @CheckForNull FlowNode afterChunk, @NonNull ForkScanner scanner) {
+    super.chunkEnd(endNode, afterChunk, scanner);
     if (endNode instanceof StepEndNode) {
       FlowNode startNode = ((StepEndNode) endNode).getStartNode();
       if (logger.isDebugEnabled()) {
@@ -183,8 +233,6 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
       }
       pendingBlocks.push(startNode);
     }
-
-    super.chunkEnd(endNode, afterChunk, scanner);
     if (endNode instanceof StepEndNode
         && PipelineNodeUtil.isStage(((StepEndNode) endNode).getStartNode())) {
       currentStage = ((StepEndNode) endNode).getStartNode();
@@ -196,15 +244,6 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
               .findFirst()
               .orElse(null);
     }
-    if (node != null
-        && endNode instanceof StepEndNode
-        && ((StepEndNode) endNode).getStartNode().equals(node)) {
-      this.stageStepsCollectionCompleted = false;
-      this.inStageScope = true;
-    }
-    if (endNode instanceof StepStartNode && PipelineNodeUtil.isAgentStart(endNode)) {
-      agentNode = (StepStartNode) endNode;
-    }
 
     // if we're using marker-based (and not block-scoped) stages, add the last node as part of its
     // contents
@@ -214,72 +253,11 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
   }
 
   @Override
-  protected void handleChunkDone(@NonNull MemoryFlowChunk chunk) {
-    if (!pendingBlocks.isEmpty()) {
-      // Finished processing atom nodes in this block
-      FlowNode finishedBlock = pendingBlocks.pop();
-      if (logger.isDebugEnabled()) {
-        logger.debug("handleChunkDone. Removed Node ID: " + finishedBlock.getId() + "(" + finishedBlock.getDisplayName() + "} from pendingBlocks.");
-      }
-    }
-    if (stageStepsCollectionCompleted) { // if its completed no further action
-      return;
-    }
-
-    if (node != null && chunk.getFirstNode().equals(node)) {
-      stageStepsCollectionCompleted = true;
-      inStageScope = false;
-      final String cause = PipelineNodeUtil.getCauseOfBlockage(chunk.getFirstNode(), agentNode);
-      if (cause != null) {
-        // TODO: This should probably be changed (elsewhere?) to instead just render this directly,
-        // not via a fake step.
-        // Now add a step that indicates blockage cause
-        FlowNode step = new LocalAtomNode(chunk, cause);
-
-        FlowNodeWrapper stepNode =
-            new FlowNodeWrapper(
-                step,
-                new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.QUEUED),
-                // This is a fake AtomNode to help track the cause of a blockage, timing info is
-                // not meaningful.
-                new TimingInfo(0, 0, 0),
-                run);
-        steps.push(stepNode);
-        stepMap.put(step.getId(), stepNode);
-      }
-    }
-
-    // Do not add steps to this stage if it's parent is a parallel block (it should get addded to
-    // that instead).
-    if (!PipelineNodeUtil.isParallelBranch(pendingBlocks.peek())) {
-      if (logger.isDebugEnabled()) {
-        logger.debug("Pushing step to stage in handleChunkDone.");
-      }
-      // Record which stage the steps belong to.
-      pushStageStepsToMap(chunk.getFirstNode());
-    } else {
-      if (logger.isDebugEnabled()) {
-        logger.debug("Not pushing steps to stage '" + pendingBlocks.peek().getDisplayName() + "' in handleChunkDone as parent is parallel block.");
-      }
-    }
-    if (PipelineNodeUtil.isStage(node) && !inStageScope && !chunk.getFirstNode().equals(node)) {
-      resetSteps();
-    }
-  }
-
-  @Override
   public void atomNode(
       @CheckForNull FlowNode before,
       @NonNull FlowNode atomNode,
       @CheckForNull FlowNode after,
       @NonNull ForkScanner scan) {
-    if (stageStepsCollectionCompleted) {
-      return;
-    }
-
-    if (atomNode instanceof StepEndNode) {
-      this.closestEndNode = (StepEndNode) atomNode;
-    }
 
     if (atomNode instanceof StepAtomNode
         && !PipelineNodeUtil.isSkippedStage(
@@ -314,67 +292,24 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
       }
 
       FlowNodeWrapper stepNode = new FlowNodeWrapper(atomNode, status, times, inputStep, run);
-      if (PipelineNodeUtil.isPreSyntheticStage(currentStage)) {
-        preSteps.push(stepNode);
-      } else if (PipelineNodeUtil.isPostSyntheticStage(currentStage)) {
-        postSteps.push(stepNode);
-      } else {
-        if (!steps.contains(stepNode)) {
-          steps.push(stepNode);
-        }
-      }
       stepMap.put(stepNode.getId(), stepNode);
       if (logger.isDebugEnabled()) {
-        logger.debug("Pushing step: " + stepNode.getId() + "(" + stepNode.getArgumentsAsString() + ") to stack.");
+        logger.debug(
+            "Pushing step: "
+                + stepNode.getId()
+                + "("
+                + stepNode.getArgumentsAsString()
+                + ") to stack.");
       }
 
       stageSteps.push(stepNode);
       if (logger.isDebugEnabled()) {
         logger.debug("Steps in stack:");
-        for(FlowNodeWrapper step : stageSteps) {
+        for (FlowNodeWrapper step : stageSteps) {
           logger.debug(" - " + step.getArgumentsAsString());
         }
       }
-
-      // If there is closest block boundary, we capture it's error to the last step encountered and
-      // prepare for next block.
-      // but only if the previous node did not fail
-      if (closestEndNode != null
-          && closestEndNode.getError() != null
-          && new NodeRunStatus(before).result != BlueRunResult.FAILURE) {
-        stepNode.setBlockErrorAction(closestEndNode.getError());
-        closestEndNode = null; // prepare for next block
-      }
     }
-  }
-
-  public List<FlowNodeWrapper> getSteps() {
-    List<FlowNodeWrapper> s = new ArrayList<>();
-    if (node != null) {
-      if (PipelineNodeUtil.isSkippedStage(node)) {
-        return Collections.emptyList();
-      }
-      FlowNode first = null;
-      FlowNode last = null;
-      if (!stages.isEmpty()) {
-        first = stages.getFirst();
-        last = stages.getLast();
-      }
-
-      if (node.equals(first)) {
-        s.addAll(preSteps);
-      }
-      s.addAll(steps);
-      if ((node.equals(last) || PipelineNodeUtil.isSkippedStage(last))) {
-        s.addAll(postSteps);
-      }
-
-    } else {
-      s.addAll(preSteps);
-      s.addAll(steps);
-      s.addAll(postSteps);
-    }
-    return s;
   }
 
   public List<FlowNodeWrapper> getStageSteps(String startNodeId) {
@@ -389,10 +324,8 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
     return stepMap.get(id);
   }
 
-  private void resetSteps() {
-    steps.clear();
-    stepMap.clear();
-    stageSteps.clear();
+  public boolean isDeclarative() {
+    return declarative;
   }
 
   private void pushStageStepsToMap(FlowNode stage) {
@@ -400,13 +333,21 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
         stageStepMap.getOrDefault(stage.getId(), new ArrayList<>());
     for (FlowNodeWrapper step : stageSteps) {
       if (logger.isDebugEnabled()) {
-        logger.debug("Adding step '" + step.getArgumentsAsString() + "' to '" + stage.getId() + "' " + "(" + stage.getDisplayName() + ") .");
+        logger.debug(
+            "Adding step '"
+                + step.getArgumentsAsString()
+                + "' to '"
+                + stage.getId()
+                + "' "
+                + "("
+                + stage.getDisplayName()
+                + ") .");
       }
 
       stageStepsList.add(step);
     }
     if (logger.isDebugEnabled()) {
-      logger.debug("Clearing " + stageSteps.size() + ".");
+      logger.debug("Assigning parent stage for " + stageSteps.size() + " steps.");
     }
 
     stageSteps.clear();

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
@@ -133,37 +133,6 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
   }
 
   @Override
-  public void parallelBranchEnd(
-      @NonNull FlowNode parallelStartNode,
-      @NonNull FlowNode branchEndNode,
-      @NonNull ForkScanner scanner) {
-    if (branchEndNode instanceof StepEndNode) {
-      FlowNode branchStartNode = ((StepEndNode) branchEndNode).getStartNode();
-      if (logger.isDebugEnabled()) {
-        logger.debug(
-            "parallelBranchEnd. Node ID: "
-                + branchStartNode.getId()
-                + " - "
-                + branchStartNode.getDisplayName()
-                + " - "
-                + PipelineNodeUtil.isStage(branchStartNode)
-                + " - "
-                + PipelineNodeUtil.isParallelBranch(branchStartNode)
-                + " - "
-                + PipelineNodeUtil.isSyntheticStage(branchStartNode)
-                + " .");
-      }
-      pendingBlocks.push(branchStartNode);
-    }
-
-    if (!stageStepsCollectionCompleted
-        && PipelineNodeUtil.isParallelBranch(node)
-        && branchEndNode instanceof StepEndNode) {
-      resetSteps();
-    }
-  }
-
-  @Override
   public void chunkStart(
       @NonNull FlowNode startNode,
       @CheckForNull FlowNode beforeBlock,

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
@@ -179,22 +179,8 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
               + PipelineNodeUtil.isSyntheticStage(startNode)
               + " .");
     }
-    // Do not add steps to this stage if it's parent is a parallel block (it should get addded to
+    // Do not add steps to this stage if it's parent is a parallel block  and it's a declarative step - (it should get addded to
     // that instead).
-
-    if (finishedBlock != null) {
-      logger.debug("Finished block:");
-      logger.debug(String.valueOf(PipelineNodeUtil.isParallelBranch(finishedBlock)));
-      logger.debug(String.valueOf(PipelineNodeUtil.isPreSyntheticStage(finishedBlock)));
-      logger.debug(String.valueOf(PipelineNodeUtil.isSyntheticStage(finishedBlock)));
-      logger.debug(String.valueOf(PipelineNodeUtil.isStage(finishedBlock)));
-    }
-
-    logger.debug("Next pending block:");
-    logger.debug(String.valueOf(PipelineNodeUtil.isParallelBranch(pendingBlocks.peek())));
-    logger.debug(String.valueOf(PipelineNodeUtil.isPreSyntheticStage(pendingBlocks.peek())));
-    logger.debug(String.valueOf(PipelineNodeUtil.isSyntheticStage(pendingBlocks.peek())));
-    logger.debug(String.valueOf(PipelineNodeUtil.isStage(pendingBlocks.peek())));
     if (PipelineNodeUtil.isParallelBranch(pendingBlocks.peek()) && isDeclarative()) {
       if (logger.isDebugEnabled()) {
         logger.debug(

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
@@ -179,9 +179,10 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
               + PipelineNodeUtil.isSyntheticStage(startNode)
               + " .");
     }
-    // Do not add steps to this stage if it's parent is a parallel block  and it's a declarative step - (it should get addded to
+    // Do not add steps to this stage if it's parent is a parallel block  and it's a declarative
+    // step - (it should get addded to
     // that instead).
-    // This could be a quirk of how the GraphVisitor works - possible 
+    // This could be a quirk of how the GraphVisitor works - possible
     if (PipelineNodeUtil.isParallelBranch(pendingBlocks.peek()) && isDeclarative()) {
       if (logger.isDebugEnabled()) {
         logger.debug(

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
@@ -190,4 +190,57 @@ public class PipelineStepApiTest {
     assertThat(steps.get(1).getName(), is("In grandchild B - Print Message"));
     assertThat(steps.get(2).getName(), is("In great-grandchild C - Print Message"));
   }
+
+  @Test
+  public void githubIssue92RegressionTest() throws Exception {
+    // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
+    // long time)
+    WorkflowRun run =
+        TestUtils.createAndRunJob(j, "githubIssue92", "githubIssue92.jenkinsfile", Result.SUCCESS);
+
+    PipelineStepApi api = new PipelineStepApi(run);
+    
+    // Linux 8
+    String linux8BranchId = TestUtils.getNodesByDisplayName(run, "linux-8").get(0).getId();
+    String linux8CheckoutId = TestUtils.getNodesByDisplayName(run, "Checkout (linux-8)").get(0).getId();
+    String linux8BuildId = TestUtils.getNodesByDisplayName(run, "Build (linux-8)").get(0).getId();
+    String linux8ArchiveId = TestUtils.getNodesByDisplayName(run, "Archive (linux-8)").get(0).getId();
+    
+    // Linux 11
+    String linux11BranchId = TestUtils.getNodesByDisplayName(run, "linux-11").get(0).getId();
+    String linux11CheckoutId = TestUtils.getNodesByDisplayName(run, "Checkout (linux-11)").get(0).getId();
+    String linux11BuildId = TestUtils.getNodesByDisplayName(run, "Build (linux-11)").get(0).getId();
+    String linux11ArchiveId = TestUtils.getNodesByDisplayName(run, "Archive (linux-11)").get(0).getId();
+
+    String deployStageId = TestUtils.getNodesByDisplayName(run, "Deploy").get(0).getId();
+
+    
+    // Check that the branches do not container steps.
+    assertThat(api.getSteps(linux8BranchId).getSteps(), hasSize(0));
+    assertThat(api.getSteps(linux11BranchId).getSteps(), hasSize(0));
+
+    List<PipelineStep> steps = api.getAllSteps().getSteps();
+
+    assertThat(steps, hasSize(7));
+    assertThat(steps.get(0).getName(), is("Checking out linux-8"));
+    assertThat(steps.get(0).getStageId(), is(linux8CheckoutId));
+
+    assertThat(steps.get(1).getName(), is("Building linux-8"));
+    assertThat(steps.get(1).getStageId(), is(linux8BuildId));
+
+    assertThat(steps.get(2).getName(), is("Archiving linux-8"));
+    assertThat(steps.get(2).getStageId(), is(linux8ArchiveId));
+
+    assertThat(steps.get(3).getName(), is("Checking out linux-8"));
+    assertThat(steps.get(3).getStageId(), is(linux11CheckoutId));
+
+    assertThat(steps.get(4).getName(), is("Building linux-8"));
+    assertThat(steps.get(4).getStageId(), is(linux11BuildId));
+
+    assertThat(steps.get(5).getName(), is("Archiving linux-8"));
+    assertThat(steps.get(5).getStageId(), is(linux11ArchiveId));
+
+    assertThat(steps.get(6).getName(), is("Deploying..."));
+    assertThat(steps.get(6).getStageId(), is(deployStageId));
+  }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
@@ -6,15 +6,12 @@ import static org.hamcrest.Matchers.is;
 
 import hudson.model.Result;
 import java.util.List;
-import java.util.logging.Logger;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class PipelineStepApiTest {
-  private static final Logger LOGGER = Logger.getLogger(PipelineStepApiTest.class.getName());
-
   @Rule public JenkinsRule j = new JenkinsRule();
 
   @Test
@@ -199,48 +196,51 @@ public class PipelineStepApiTest {
         TestUtils.createAndRunJob(j, "githubIssue92", "githubIssue92.jenkinsfile", Result.SUCCESS);
 
     PipelineStepApi api = new PipelineStepApi(run);
-    
+
     // Linux 8
     String linux8BranchId = TestUtils.getNodesByDisplayName(run, "linux-8").get(0).getId();
-    String linux8CheckoutId = TestUtils.getNodesByDisplayName(run, "Checkout (linux-8)").get(0).getId();
+    String linux8CheckoutId =
+        TestUtils.getNodesByDisplayName(run, "Checkout (linux-8)").get(0).getId();
     String linux8BuildId = TestUtils.getNodesByDisplayName(run, "Build (linux-8)").get(0).getId();
-    String linux8ArchiveId = TestUtils.getNodesByDisplayName(run, "Archive (linux-8)").get(0).getId();
-    
+    String linux8ArchiveId =
+        TestUtils.getNodesByDisplayName(run, "Archive (linux-8)").get(0).getId();
+
     // Linux 11
     String linux11BranchId = TestUtils.getNodesByDisplayName(run, "linux-11").get(0).getId();
-    String linux11CheckoutId = TestUtils.getNodesByDisplayName(run, "Checkout (linux-11)").get(0).getId();
+    String linux11CheckoutId =
+        TestUtils.getNodesByDisplayName(run, "Checkout (linux-11)").get(0).getId();
     String linux11BuildId = TestUtils.getNodesByDisplayName(run, "Build (linux-11)").get(0).getId();
-    String linux11ArchiveId = TestUtils.getNodesByDisplayName(run, "Archive (linux-11)").get(0).getId();
+    String linux11ArchiveId =
+        TestUtils.getNodesByDisplayName(run, "Archive (linux-11)").get(0).getId();
 
     String deployStageId = TestUtils.getNodesByDisplayName(run, "Deploy").get(0).getId();
 
-    
-    // Check that the branches do not container steps.
-    assertThat(api.getSteps(linux8BranchId).getSteps(), hasSize(0));
-    assertThat(api.getSteps(linux11BranchId).getSteps(), hasSize(0));
+    List<PipelineStep> steps = api.getSteps(linux8CheckoutId).getSteps();
+    assertThat(steps, hasSize(1));
+    assertThat(steps.get(0).getName(), is("Checking out linux-8 - Print Message"));
 
-    List<PipelineStep> steps = api.getAllSteps().getSteps();
+    steps = api.getSteps(linux8BuildId).getSteps();
+    assertThat(steps, hasSize(1));
+    assertThat(steps.get(0).getName(), is("Building linux-8 - Print Message"));
 
-    assertThat(steps, hasSize(7));
-    assertThat(steps.get(0).getName(), is("Checking out linux-8"));
-    assertThat(steps.get(0).getStageId(), is(linux8CheckoutId));
+    steps = api.getSteps(linux8ArchiveId).getSteps();
+    assertThat(steps, hasSize(1));
+    assertThat(steps.get(0).getName(), is("Archiving linux-8 - Print Message"));
 
-    assertThat(steps.get(1).getName(), is("Building linux-8"));
-    assertThat(steps.get(1).getStageId(), is(linux8BuildId));
+    steps = api.getSteps(linux11CheckoutId).getSteps();
+    assertThat(steps, hasSize(1));
+    assertThat(steps.get(0).getName(), is("Checking out linux-11 - Print Message"));
 
-    assertThat(steps.get(2).getName(), is("Archiving linux-8"));
-    assertThat(steps.get(2).getStageId(), is(linux8ArchiveId));
+    steps = api.getSteps(linux11BuildId).getSteps();
+    assertThat(steps, hasSize(1));
+    assertThat(steps.get(0).getName(), is("Building linux-11 - Print Message"));
 
-    assertThat(steps.get(3).getName(), is("Checking out linux-8"));
-    assertThat(steps.get(3).getStageId(), is(linux11CheckoutId));
+    steps = api.getSteps(linux11ArchiveId).getSteps();
+    assertThat(steps, hasSize(1));
+    assertThat(steps.get(0).getName(), is("Archiving linux-11 - Print Message"));
 
-    assertThat(steps.get(4).getName(), is("Building linux-8"));
-    assertThat(steps.get(4).getStageId(), is(linux11BuildId));
-
-    assertThat(steps.get(5).getName(), is("Archiving linux-8"));
-    assertThat(steps.get(5).getStageId(), is(linux11ArchiveId));
-
-    assertThat(steps.get(6).getName(), is("Deploying..."));
-    assertThat(steps.get(6).getStageId(), is(deployStageId));
+    steps = api.getSteps(deployStageId).getSteps();
+    assertThat(steps, hasSize(1));
+    assertThat(steps.get(0).getName(), is("Deploying... - Print Message"));
   }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
@@ -198,7 +198,6 @@ public class PipelineStepApiTest {
     PipelineStepApi api = new PipelineStepApi(run);
 
     // Linux 8
-    String linux8BranchId = TestUtils.getNodesByDisplayName(run, "linux-8").get(0).getId();
     String linux8CheckoutId =
         TestUtils.getNodesByDisplayName(run, "Checkout (linux-8)").get(0).getId();
     String linux8BuildId = TestUtils.getNodesByDisplayName(run, "Build (linux-8)").get(0).getId();
@@ -206,7 +205,6 @@ public class PipelineStepApiTest {
         TestUtils.getNodesByDisplayName(run, "Archive (linux-8)").get(0).getId();
 
     // Linux 11
-    String linux11BranchId = TestUtils.getNodesByDisplayName(run, "linux-11").get(0).getId();
     String linux11CheckoutId =
         TestUtils.getNodesByDisplayName(run, "Checkout (linux-11)").get(0).getId();
     String linux11BuildId = TestUtils.getNodesByDisplayName(run, "Build (linux-11)").get(0).getId();

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/TestUtils.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/TestUtils.java
@@ -19,8 +19,6 @@ import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable
 import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable.Row;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import io.jenkins.plugins.pipelinegraphview.utils.PipelineStage;
-
 public class TestUtils {
   private static final Logger LOGGER = Logger.getLogger(TestUtils.class.getName());
 

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/TestUtils.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/TestUtils.java
@@ -19,7 +19,7 @@ import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable
 import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable.Row;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import io.jenkins.pipeline.pipelinegraphview.utils.PipelineStage;
+import io.jenkins.plugins.pipelinegraphview.utils.PipelineStage;
 
 public class TestUtils {
   private static final Logger LOGGER = Logger.getLogger(TestUtils.class.getName());

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/TestUtils.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/TestUtils.java
@@ -19,6 +19,8 @@ import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable
 import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable.Row;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import io.jenkins.pipeline.pipelinegraphview.utils.PipelineStage;
+
 public class TestUtils {
   private static final Logger LOGGER = Logger.getLogger(TestUtils.class.getName());
 

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/githubIssue92.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/githubIssue92.jenkinsfile
@@ -19,13 +19,13 @@ node {
 			retry(3) {
 				timeout(time: 60, unit: 'SECONDS') {
 					stage ("Checkout (linux-11)") {
-						echo "Checking out linux-8"
+						echo "Checking out linux-11"
 					}
 					stage ("Build (linux-11)") {
-						echo "Building linux-8"
+						echo "Building linux-11"
 					}
 					stage ("Archive (linux-11)") {
-						echo "Archiving linux-8"
+						echo "Archiving linux-11"
 					}
 				}
 			}

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/githubIssue92.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/githubIssue92.jenkinsfile
@@ -1,0 +1,37 @@
+node {
+	stage("Build all") {
+		parallel "linux-8": {
+			retry(3) {
+				timeout(time: 60, unit: 'SECONDS') {
+					stage ("Checkout (linux-8)") {
+						echo "Checking out linux-8"
+					}
+					stage ("Build (linux-8)") {
+						echo "Building linux-8"
+					}
+					stage ("Archive (linux-8)") {
+						echo "Archiving linux-8"
+					}
+				}
+			}
+		},
+		"linux-11": {
+			retry(3) {
+				timeout(time: 60, unit: 'SECONDS') {
+					stage ("Checkout (linux-11)") {
+						echo "Checking out linux-8"
+					}
+					stage ("Build (linux-11)") {
+						echo "Building linux-8"
+					}
+					stage ("Archive (linux-11)") {
+						echo "Archiving linux-8"
+					}
+				}
+			}
+		}
+	}
+	stage ("Deploy") {
+		echo "Deploying..."
+	}
+}

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/githubIssue92.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/githubIssue92.jenkinsfile
@@ -1,37 +1,37 @@
 node {
-	stage("Build all") {
-		parallel "linux-8": {
-			retry(3) {
-				timeout(time: 60, unit: 'SECONDS') {
-					stage ("Checkout (linux-8)") {
-						echo "Checking out linux-8"
-					}
-					stage ("Build (linux-8)") {
-						echo "Building linux-8"
-					}
-					stage ("Archive (linux-8)") {
-						echo "Archiving linux-8"
-					}
-				}
-			}
-		},
-		"linux-11": {
-			retry(3) {
-				timeout(time: 60, unit: 'SECONDS') {
-					stage ("Checkout (linux-11)") {
-						echo "Checking out linux-11"
-					}
-					stage ("Build (linux-11)") {
-						echo "Building linux-11"
-					}
-					stage ("Archive (linux-11)") {
-						echo "Archiving linux-11"
-					}
-				}
-			}
-		}
-	}
-	stage ("Deploy") {
-		echo "Deploying..."
-	}
+    stage("Build all") {
+        parallel "linux-8": {
+            retry(3) {
+                timeout(time: 60, unit: 'SECONDS') {
+                    stage ("Checkout (linux-8)") {
+                        echo "Checking out linux-8"
+                    }
+                    stage ("Build (linux-8)") {
+                        echo "Building linux-8"
+                    }
+                    stage ("Archive (linux-8)") {
+                        echo "Archiving linux-8"
+                    }
+                }
+            }
+        },
+        "linux-11": {
+            retry(3) {
+                timeout(time: 60, unit: 'SECONDS') {
+                    stage ("Checkout (linux-11)") {
+                        echo "Checking out linux-11"
+                    }
+                    stage ("Build (linux-11)") {
+                        echo "Building linux-11"
+                    }
+                    stage ("Archive (linux-11)") {
+                        echo "Archiving linux-11"
+                    }
+                }
+            }
+        }
+    }
+    stage ("Deploy") {
+        echo "Deploying..."
+    }
 }

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/nestedStages.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/nestedStages.jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent any
     stages {
-        stage("Parennt") {
+        stage("Parent") {
             stages {
                 stage ("Child A") {
                     steps {


### PR DESCRIPTION
Fixes #92 
- Moved the logic to add steps to child stages of parallel branches to chunkStart.

Before:
<img width="1120" alt="Screenshot 2023-02-20 at 10 19 53" src="https://user-images.githubusercontent.com/4447764/220125042-36da9710-7624-4c8a-b284-1695ffc428a8.png">

After:
<img width="907" alt="Screenshot 2023-02-20 at 13 48 36" src="https://user-images.githubusercontent.com/4447764/220125606-8964f3bd-0fd3-4f28-960f-a5372a94450e.png">

Tested with #210 and it seems to be compatible:
Before:
<img width="878" alt="Screenshot 2023-02-20 at 10 16 14" src="https://user-images.githubusercontent.com/4447764/220125123-f10b282c-7c67-4d01-ba38-c2b19ecfff01.png">

After: 
<img width="908" alt="Screenshot 2023-02-20 at 13 41 00" src="https://user-images.githubusercontent.com/4447764/220124964-c0df9a26-d5fc-4b99-a69a-ee29bd8d3c07.png">

Tested with Pipeline:
```
node {
	stage("Build all") {
		parallel "linux-8": {
			retry(3) {
				timeout(time: 60, unit: 'SECONDS') {
					stage ("Checkout (linux-8)") {
						echo "Checking out linux-8"
					}
					stage ("Build (linux-8)") {
						echo "Building linux-8"
					}
					stage ("Archive (linux-8)") {
						echo "Archiving linux-8"
					}
				}
			}
		},
		"linux-11": {
			retry(3) {
				timeout(time: 60, unit: 'SECONDS') {
					stage ("Checkout (linux-11)") {
						echo "Checking out linux-8"
					}
					stage ("Build (linux-11)") {
						echo "Building linux-8"
					}
					stage ("Archive (linux-11)") {
						echo "Archiving linux-8"
					}
				}
			}
		}
	}
	stage ("Deploy") {
		echo "Deploying..."
	}
}
```
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
