### PR TITLE
Add entrys to steps list for uncaught exceptions

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
@@ -152,6 +152,7 @@ export class ConsoleLogCard extends React.Component<ConsoleLogCardProps> {
       <Card
         className="step-detail-group"
         key={`step-card-${this.props.step.id}`}
+        style={{ marginBottom: "5px" }}
       >
         <CardActionArea
           onClick={this.handleStepToggle}

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
@@ -152,7 +152,6 @@ export class ConsoleLogCard extends React.Component<ConsoleLogCardProps> {
       <Card
         className="step-detail-group"
         key={`step-card-${this.props.step.id}`}
-        style={{ margin: "5px", padding: "5px" }}
       >
         <CardActionArea
           onClick={this.handleStepToggle}
@@ -226,7 +225,7 @@ export class ConsoleLogCard extends React.Component<ConsoleLogCardProps> {
               >
                 <ExpandMoreIcon
                   key={`step-expand-icon-${this.props.step.id}`}
-                  className="svg-icon"
+                  className="svg-icon svg-icon--expand"
                 />
               </ExpandMore>
             </Grid>

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
@@ -56,7 +56,7 @@ export class ConsoleLogCard extends React.Component<ConsoleLogCardProps> {
   }
 
   getTrucatedLogWarning() {
-    if (this.props.step.consoleLines && this.props.step.consoleStartByte != 0) {
+    if (this.props.step.consoleLines && this.props.step.consoleStartByte > 0) {
       return (
         <Grid container>
           <Grid item xs={6} sm className="show-more-console">

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
@@ -173,6 +173,7 @@ export class ConsoleLogCard extends React.Component<ConsoleLogCardProps> {
               container
               xs={16}
               sx={{ display: "block", margin: "auto" }}
+              width="80%"
             >
               <Typography
                 className="log-card-header"

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -281,11 +281,6 @@ div.stage-detail-group {
   white-space: nowrap;
 }
 
-.svg-icon {
-  color: var(--step-text-color) !important;
-  fill: var(--step-text-color) !important;
-}
-
 .step-content {
   padding: 0px !important;
   padding-bottom: 0px !important;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -246,6 +246,10 @@ pre.console-output-line {
   color: currentColor !important;
 }
 
+.svg-icon--expand {
+  color: var(--step-text-color);
+}
+
 // Console styling
 a.console-line-number {
   text-align: right;

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -95,7 +95,7 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
    */
   @GET
   @WebMethod(name = "consoleOutput")
-  public HttpResponse getConsolOutput(StaplerRequest req) throws IOException {
+  public HttpResponse getConsoleOutput(StaplerRequest req) throws IOException {
     String nodeId = req.getParameter("nodeId");
     if (nodeId == null) {
       logger.error("'consoleJson' was not passed 'nodeId'.");
@@ -131,11 +131,11 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
         }
         // if startByte is negative make sure we don't try and get a byte before 0.
         if (startByte < 0) {
-          logger.info(
+          logger.debug(
               "consoleJson - requested negative startByte '" + Long.toString(startByte) + "'.");
           startByte = textLength + startByte;
           if (startByte < 0) {
-            logger.info(
+            logger.debug(
                 "consoleJson - requested negative startByte '"
                     + Long.toString(startByte)
                     + "' out of bounds, setting to 0.");
@@ -143,10 +143,10 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
           }
         }
 
-        logger.info(
+        logger.debug(
             "Returning '"
                 + Long.toString(textLength - startByte)
-                + "' bytes from 'getConsolOutput'.");
+                + "' bytes from 'getConsoleOutput'.");
       } else {
         // If there is no text then set set startByte to 0 - as we have read from the start, there
         // is just nothing there.
@@ -188,10 +188,10 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
 
   private static long parseIntWithDefault(String s, long default_value) {
     try {
-      logger.info("Parsing user provided value of '" + s + "'");
+      logger.debug("Parsing user provided value of '" + s + "'");
       return Long.parseLong(s);
     } catch (NumberFormatException e) {
-      logger.info("Using default value of '" + default_value + "'");
+      logger.debug("Using default value of '" + default_value + "'");
       return default_value;
     }
   }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/FlowNodeWrapper.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/FlowNodeWrapper.java
@@ -59,7 +59,7 @@ public class FlowNodeWrapper {
     STAGE,
     PARALLEL,
     STEP,
-    EXCEPTED_STEP,
+    UNHANDLED_EXCEPTION,
   }
 
   private final FlowNode node;
@@ -123,8 +123,8 @@ public class FlowNodeWrapper {
       return NodeType.PARALLEL;
     } else if (node instanceof AtomNode) {
       return NodeType.STEP;
-    } else if(PipelineNodeUtil.isStepThrewException(node)) {
-      return NodeType.EXCEPTED_STEP;
+    } else if (PipelineNodeUtil.isUnhandledException(node)) {
+      return NodeType.UNHANDLED_EXCEPTION;
     }
     throw new IllegalArgumentException(
         String.format("Unknown FlowNode %s, type: %s", node.getId(), node.getClass()));
@@ -292,5 +292,9 @@ public class FlowNodeWrapper {
 
   public boolean isSynthetic() {
     return PipelineNodeUtil.isSyntheticStage(node);
+  }
+
+  public boolean isUnhandledException() {
+    return PipelineNodeUtil.isUnhandledException(node);
   }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/FlowNodeWrapper.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/FlowNodeWrapper.java
@@ -58,7 +58,8 @@ public class FlowNodeWrapper {
   public enum NodeType {
     STAGE,
     PARALLEL,
-    STEP
+    STEP,
+    EXCEPTED_STEP,
   }
 
   private final FlowNode node;
@@ -122,6 +123,8 @@ public class FlowNodeWrapper {
       return NodeType.PARALLEL;
     } else if (node instanceof AtomNode) {
       return NodeType.STEP;
+    } else if(PipelineNodeUtil.isStepThrewException(node)) {
+      return NodeType.EXCEPTED_STEP;
     }
     throw new IllegalArgumentException(
         String.format("Unknown FlowNode %s, type: %s", node.getId(), node.getClass()));

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
@@ -4,9 +4,16 @@ import com.google.common.base.Predicate;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.AbortException;
+import hudson.console.AnnotatedLargeText;
 import hudson.model.Action;
 import hudson.model.Queue;
 import hudson.model.queue.CauseOfBlockage;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.jenkinsci.plugins.pipeline.StageStatus;
 import org.jenkinsci.plugins.pipeline.SyntheticStage;
 import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
@@ -113,9 +120,8 @@ public class PipelineNodeUtil {
         && node.getAction(ThreadNameAction.class) != null;
   }
 
-  public static boolean isStepThrewException(@Nullable FlowNode node) {
-    return node != null
-        && node.getAction(ErrorAction.class) != null;
+  public static boolean isUnhandledException(@Nullable FlowNode node) {
+    return node != null && node.getAction(ErrorAction.class) != null;
   }
 
   public static String getArgumentsAsString(@Nullable FlowNode node) {
@@ -213,6 +219,78 @@ public class PipelineNodeUtil {
       }
     }
 
+    return false;
+  }
+
+  /* Get the AnnotatedLargeText for a given node.
+   * @param node a possibly null {@link FlowNode}
+   * @return The AnnotatedLargeText object representing the log text for this node, or null.
+   */
+  public static AnnotatedLargeText<? extends FlowNode> getLogText(@Nullable FlowNode node) {
+    if (node != null) {
+      LogAction logAction = node.getAction(LogAction.class);
+      if (logAction != null) {
+        return logAction.getLogText();
+      }
+    }
+    return null;
+  }
+
+  /* Get the generated log text for a given node.
+   * @param log The AnnotatedLargeText object for a given node.
+   * @return The AnnotatedLargeText object representing the log text for this node, or null.
+   */
+  public static String convertLogToString(AnnotatedLargeText<? extends FlowNode> log)
+      throws IOException {
+    return convertLogToString(log, 0L);
+  }
+
+  /* Get the generated log text for a given node.
+   * @param log The AnnotatedLargeText object for a given node.
+   * @param startByte The byte to start parsing from.
+   * @return The AnnotatedLargeText object representing the log text for this node, or null.
+   */
+  public static String convertLogToString(
+      AnnotatedLargeText<? extends FlowNode> log, Long startByte) throws IOException {
+    Writer stringWriter = new StringBuilderWriter();
+    // NOTE: This returns the total length of the console log, not the received bytes.
+    long endByte = log.writeHtmlTo(startByte, stringWriter);
+    return stringWriter.toString();
+  }
+
+  /* The exception text from aa FlowNode.
+   * @param node a possibly null {@link FlowNode}
+   * @return A string representing the exception thrown from this node, or null.
+   */
+  public static String getExceptionText(@Nullable FlowNode node) {
+    if (node != null) {
+      String log = null;
+      ErrorAction error = node.getAction(ErrorAction.class);
+      if (error != null) {
+        Throwable exception = error.getError();
+        if (PipelineNodeUtil.isJenkinsFailureException(exception)) {
+          // If this is a Jenkins exception to mark a build failure then only return the mesage -
+          // the stack trace is unimportant as the message will be attached to the step.
+          log = exception.getMessage();
+        } else {
+          // If this is not a Jenkins failure exception, then we should print everything.
+          log = "Found unhandled " + exception.getClass().getName() + " exception:\n";
+          log += exception.getMessage() + "\n\t";
+          log +=
+              Arrays.stream(exception.getStackTrace())
+                  .map(s -> s.toString())
+                  .collect(Collectors.joining("\n\t"));
+        }
+      }
+      return log;
+    }
+    return null;
+  }
+
+  public static boolean isJenkinsFailureException(Throwable exception) {
+    if (exception instanceof AbortException) {
+      return true;
+    }
     return false;
   }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
@@ -4,6 +4,7 @@ import com.google.common.base.Predicate;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 import hudson.AbortException;
 import hudson.console.AnnotatedLargeText;
 import hudson.model.Action;
@@ -250,12 +251,13 @@ public class PipelineNodeUtil {
    * @param startByte The byte to start parsing from.
    * @return The AnnotatedLargeText object representing the log text for this node, or null.
    */
+  @SuppressWarnings("RV_RETURN_VALUE_IGNORED")
   public static String convertLogToString(
       AnnotatedLargeText<? extends FlowNode> log, Long startByte) throws IOException {
     Writer stringWriter = new StringBuilderWriter();
     // NOTE: This returns the total length of the console log, not the received bytes.
-    @SuppressWarnings("unused")
-    long endByte = log.writeHtmlTo(startByte, stringWriter);
+    
+    log.writeHtmlTo(startByte, stringWriter);
     return stringWriter.toString();
   }
 

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
@@ -10,6 +10,7 @@ import hudson.model.queue.CauseOfBlockage;
 import org.jenkinsci.plugins.pipeline.StageStatus;
 import org.jenkinsci.plugins.pipeline.SyntheticStage;
 import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
+import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.LogAction;
 import org.jenkinsci.plugins.workflow.actions.QueueItemAction;
@@ -110,6 +111,11 @@ public class PipelineNodeUtil {
     return node != null
         && node.getAction(LabelAction.class) != null
         && node.getAction(ThreadNameAction.class) != null;
+  }
+
+  public static boolean isStepThrewException(@Nullable FlowNode node) {
+    return node != null
+        && node.getAction(ErrorAction.class) != null;
   }
 
   public static String getArgumentsAsString(@Nullable FlowNode node) {

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
@@ -256,7 +256,7 @@ public class PipelineNodeUtil {
       AnnotatedLargeText<? extends FlowNode> log, Long startByte) throws IOException {
     Writer stringWriter = new StringBuilderWriter();
     // NOTE: This returns the total length of the console log, not the received bytes.
-    
+
     log.writeHtmlTo(startByte, stringWriter);
     return stringWriter.toString();
   }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
@@ -254,6 +254,7 @@ public class PipelineNodeUtil {
       AnnotatedLargeText<? extends FlowNode> log, Long startByte) throws IOException {
     Writer stringWriter = new StringBuilderWriter();
     // NOTE: This returns the total length of the console log, not the received bytes.
+    @SuppressWarnings("unused")
     long endByte = log.writeHtmlTo(startByte, stringWriter);
     return stringWriter.toString();
   }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
@@ -25,22 +25,25 @@ public class PipelineStepApi {
         stepNodes.stream()
             .map(
                 flowNodeWrapper -> {
-                  String state = flowNodeWrapper.getStatus().getResult().name();
-                  // TODO: Why do we do this? Seems like it will return uppercase for some states
-                  // and lowercase for others?
+                  String state =
+                      flowNodeWrapper.getStatus().getResult().name().toLowerCase(Locale.ROOT);
                   if (flowNodeWrapper.getStatus().getState() != BlueRun.BlueRunState.FINISHED) {
                     state = flowNodeWrapper.getStatus().getState().name().toLowerCase(Locale.ROOT);
                   }
                   String displayName = flowNodeWrapper.getDisplayName();
-                  String stepArguments = flowNodeWrapper.getArgumentsAsString();
-                  if (stepArguments != null && !stepArguments.isEmpty()) {
-                    displayName = stepArguments + " - " + displayName;
-                  }
 
-                  // Use the step label as the displayName if set
-                  String labelDisplayName = flowNodeWrapper.getLabelDisplayName();
-                  if (labelDisplayName != null && !labelDisplayName.isEmpty()) {
-                    displayName = labelDisplayName;
+                  if (flowNodeWrapper.getType() == FlowNodeWrapper.NodeType.UNHANDLED_EXCEPTION) {
+                    displayName = "Pipeline error";
+                  } else {
+                    String stepArguments = flowNodeWrapper.getArgumentsAsString();
+                    if (stepArguments != null && !stepArguments.isEmpty()) {
+                      displayName = stepArguments + " - " + displayName;
+                    }
+                    // Use the step label as the displayName if set
+                    String labelDisplayName = flowNodeWrapper.getLabelDisplayName();
+                    if (labelDisplayName != null && !labelDisplayName.isEmpty()) {
+                      displayName = labelDisplayName;
+                    }
                   }
                   // Remove non-printable chars (e.g. ANSI color codes).
                   logger.debug("DisplayName Before: '" + displayName + "'.");

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
@@ -255,11 +255,10 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
             errorAction.findOrigin(errorAction.getError(), this.execution);
         if (this.nodeThatThrewException) {
           logger.debug(
-            "Found that node '"
-                + this.nodeThatThrewException.getId()
-                + "' threw unhandled exception: "
-                + this.nodeThatThrewException.getDisplayName());
-
+              "Found that node '"
+                  + this.nodeThatThrewException.getId()
+                  + "' threw unhandled exception: "
+                  + this.nodeThatThrewException.getDisplayName());
         }
       }
     }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
@@ -386,7 +386,8 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
 
   private void pushExceptionNodeToStepsMap(FlowNode exceptionNode) {
     long pause = PauseAction.getPauseDuration(exceptionNode);
-    TimingInfo times = StatusAndTiming.computeChunkTiming(run, pause, exceptionNode, exceptionNode, null);
+    TimingInfo times =
+        StatusAndTiming.computeChunkTiming(run, pause, exceptionNode, exceptionNode, null);
     if (times == null) {
       times = new TimingInfo();
     }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
@@ -253,7 +253,7 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
         logger.debug("Found unhandled exception: " + errorAction.getError().getMessage());
         this.nodeThatThrewException =
             errorAction.findOrigin(errorAction.getError(), this.execution);
-        if (this.nodeThatThrewException) {
+        if (this.nodeThatThrewException != null) {
           logger.debug(
               "Found that node '"
                   + this.nodeThatThrewException.getId()

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 import org.jenkinsci.plugins.pipeline.modeldefinition.actions.ExecutionModelAction;
-import org.jenkinsci.plugins.workflow.actions.PersistentAction;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode;
@@ -58,6 +57,9 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
   private InputAction inputAction;
 
   private final boolean declarative;
+
+  private ErrorAction unhandledException;
+  private FlowNode nodeThatThrewException;
 
   private boolean isLastNode;
   private FlowExecution execution;
@@ -237,6 +239,39 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
               .findFirst()
               .orElse(null);
     }
+
+    if (this.isLastNode) {
+      this.isLastNode = false;
+      // Check for an unhandled exception.
+      NodeRunStatus status;
+      ErrorAction errorAction = endNode.getAction(ErrorAction.class);
+      // If this is a Jenkins failure exception, then we don't need to add a new node - it will come
+      // from an existing step.
+      if (errorAction != null
+          && !PipelineNodeUtil.isJenkinsFailureException(errorAction.getError())) {
+        // Store node that threw exception as step so we can find it's parent stage later.
+        logger.info("Found unhandled exception: " + errorAction.getError().getMessage());
+        this.nodeThatThrewException =
+            errorAction.findOrigin(errorAction.getError(), this.execution);
+        logger.info(
+            "Found that node '"
+                + this.nodeThatThrewException.getId()
+                + "' threw unhandled exception: "
+                + this.nodeThatThrewException.getDisplayName());
+      }
+    }
+    // If this the the node that created the unhandled exception.
+    if (this.nodeThatThrewException == endNode) {
+      if (logger.isDebugEnabled()) {
+        logger.info("Found endNode that threw exception.");
+      }
+      pushExceptionNodeToStepsMap(endNode);
+    }
+    // if we're using marker-based (and not block-scoped) stages, add the last node as part of its
+    // contents
+    if (!(endNode instanceof BlockEndNode)) {
+      atomNode(null, endNode, afterChunk, scanner);
+    }
   }
 
   @Override
@@ -288,7 +323,7 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
                 + stepNode.getArgumentsAsString()
                 + ") to stack.");
       }
-      if (!stageSteps.contains(stepNode) ) {
+      if (!stageSteps.contains(stepNode)) {
         stageSteps.push(stepNode);
       }
       if (logger.isDebugEnabled()) {
@@ -297,6 +332,13 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
           logger.debug(" - " + step.getArgumentsAsString() + " - " + step.getId());
         }
       }
+    }
+    // If this the the node that created the unhandled exception.
+    if (this.nodeThatThrewException == atomNode) {
+      if (logger.isDebugEnabled()) {
+        logger.info("Found atomNode that threw exception.");
+      }
+      pushExceptionNodeToStepsMap(atomNode);
     }
   }
 
@@ -340,6 +382,35 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
 
     stageSteps.clear();
     stageStepMap.put(stage.getId(), stageStepsList);
+  }
+
+  private void pushExceptionNodeToStepsMap(FlowNode exceptionNode) {
+    long pause = PauseAction.getPauseDuration(exceptionNode);
+    TimingInfo times = StatusAndTiming.computeChunkTiming(run, pause, exceptionNode, exceptionNode, null);
+    if (times == null) {
+      times = new TimingInfo();
+    }
+    NodeRunStatus status;
+    status = new NodeRunStatus(exceptionNode);
+    pause = PauseAction.getPauseDuration(exceptionNode);
+    times = StatusAndTiming.computeChunkTiming(run, pause, exceptionNode, exceptionNode, null);
+    if (times == null) {
+      times = new TimingInfo();
+    }
+    FlowNodeWrapper erroredStep = new FlowNodeWrapper(exceptionNode, status, times, null, run);
+    stepMap.put(erroredStep.getId(), erroredStep);
+    if (logger.isDebugEnabled()) {
+      logger.info(
+          "Found step exception from step: "
+              + erroredStep.getId()
+              + "("
+              + erroredStep.getArgumentsAsString()
+              + ") to stack.\nError:\n"
+              + erroredStep.nodeError());
+    }
+    if (!stageSteps.contains(erroredStep)) {
+      stageSteps.push(erroredStep);
+    }
   }
 
   static class LocalAtomNode extends AtomNode {

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
@@ -250,20 +250,23 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
       if (errorAction != null
           && !PipelineNodeUtil.isJenkinsFailureException(errorAction.getError())) {
         // Store node that threw exception as step so we can find it's parent stage later.
-        logger.info("Found unhandled exception: " + errorAction.getError().getMessage());
+        logger.debug("Found unhandled exception: " + errorAction.getError().getMessage());
         this.nodeThatThrewException =
             errorAction.findOrigin(errorAction.getError(), this.execution);
-        logger.info(
+        if (this.nodeThatThrewException) {
+          logger.debug(
             "Found that node '"
                 + this.nodeThatThrewException.getId()
                 + "' threw unhandled exception: "
                 + this.nodeThatThrewException.getDisplayName());
+
+        }
       }
     }
     // If this the the node that created the unhandled exception.
     if (this.nodeThatThrewException == endNode) {
       if (logger.isDebugEnabled()) {
-        logger.info("Found endNode that threw exception.");
+        logger.debug("Found endNode that threw exception.");
       }
       pushExceptionNodeToStepsMap(endNode);
     }
@@ -291,10 +294,6 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
     if (atomNode instanceof StepAtomNode
         && !PipelineNodeUtil.isSkippedStage(
             currentStage)) { // if skipped stage, we don't collect its steps
-
-      if (times == null) {
-        times = new TimingInfo();
-      }
 
       if (PipelineNodeUtil.isPausedForInputStep((StepAtomNode) atomNode, inputAction)) {
         status = new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.PAUSED);
@@ -336,7 +335,7 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
     // If this the the node that created the unhandled exception.
     if (this.nodeThatThrewException == atomNode) {
       if (logger.isDebugEnabled()) {
-        logger.info("Found atomNode that threw exception.");
+        logger.debug("Found atomNode that threw exception.");
       }
       pushExceptionNodeToStepsMap(atomNode);
     }
@@ -401,7 +400,7 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
     FlowNodeWrapper erroredStep = new FlowNodeWrapper(exceptionNode, status, times, null, run);
     stepMap.put(erroredStep.getId(), erroredStep);
     if (logger.isDebugEnabled()) {
-      logger.info(
+      logger.debug(
           "Found step exception from step: "
               + erroredStep.getId()
               + "("

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
@@ -311,7 +311,10 @@ public class PipelineStepApiTest {
     // long time)
     WorkflowRun run =
         TestUtils.createAndRunJob(
-            j, "githubIssue213_callsUnknownVariable", "callsUnknownVariable.jenkinsfile", Result.FAILURE);
+            j,
+            "githubIssue213_callsUnknownVariable",
+            "callsUnknownVariable.jenkinsfile",
+            Result.FAILURE);
 
     PipelineStepApi api = new PipelineStepApi(run);
 
@@ -323,6 +326,9 @@ public class PipelineStepApiTest {
     assertThat(errorStep.getName(), is("Pipeline error"));
     FlowNode node = run.getExecution().getNode(String.valueOf(errorStep.getId()));
     String errorText = PipelineNodeUtil.getExceptionText(node);
-    assertThat(errorText, startsWith("Found unhandled groovy.lang.MissingPropertyException exception:\nNo such property: undefined for class: groovy.lang.Binding"));
+    assertThat(
+        errorText,
+        startsWith(
+            "Found unhandled groovy.lang.MissingPropertyException exception:\nNo such property: undefined for class: groovy.lang.Binding"));
   }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
@@ -285,27 +285,6 @@ public class PipelineStepApiTest {
   }
 
   @Test
-  public void githubIssue213RegressionTest_stepThrowsException() throws Exception {
-    // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
-    // long time)
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "githubIssue213_failingStep", "pipelineFailingStep.jenkinsfile", Result.FAILURE);
-
-    PipelineStepApi api = new PipelineStepApi(run);
-
-    String failureStage = TestUtils.getNodesByDisplayName(run, "failure").get(0).getId();
-
-    List<PipelineStep> steps = api.getSteps(failureStage).getSteps();
-    assertThat(steps, hasSize(1));
-    PipelineStep errorStep = steps.get(0);
-    assertThat(errorStep.getName(), is("exit 1 - Shell Script"));
-    FlowNode node = run.getExecution().getNode(String.valueOf(errorStep.getId()));
-    String errorText = PipelineNodeUtil.getExceptionText(node);
-    assertThat(errorText, is("script returned exit code 1"));
-  }
-
-  @Test
   public void githubIssue213RegressionTest_pipelineCallsUndefinedVar() throws Exception {
     // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
     // long time)

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/callsUnknownVariable.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/callsUnknownVariable.jenkinsfile
@@ -1,0 +1,4 @@
+stage('failure') {
+    echo "This will work"
+    echo "THis won't - calling an undefined variable ${undefined}"
+}

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/pipelineFailingStep.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/pipelineFailingStep.jenkinsfile
@@ -1,5 +1,0 @@
-node {
-    stage('failure') {
-        sh "exit 1"
-    }
-}

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/pipelineFailingStep.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/pipelineFailingStep.jenkinsfile
@@ -1,0 +1,5 @@
+node {
+    stage('failure') {
+        sh "exit 1"
+    }
+}


### PR DESCRIPTION
Some failed steps were getting missing.
Check for ErrorAction in nodes and if present add the node. This will contain some error text and (possibly) an exception.

This is enough for actions that return an AbortException, and to fix #213, but wouldn't include errors like: https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/213#issuecomment-1438666811

To do that we:
Check if the last node (the first one we come to) has an ErrorAction - if so there is an uncaught exception, then:
- Find and record the originating step.
- Check each atomNode and endNode as we go to see if it's the originating node.
-- Once we find the originating step we add that to the `stageSteps` list - it will be mapped to the stage when we hit the start node.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira