### PR TITLE
Remove unused '.svg-icon' css class from Console.

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -281,11 +281,6 @@ div.stage-detail-group {
   white-space: nowrap;
 }
 
-.svg-icon {
-  color: var(--step-text-color) !important;
-  fill: var(--step-text-color) !important;
-}
-
 .step-content {
   padding: 0px !important;
   padding-bottom: 0px !important;


### PR DESCRIPTION
This was used when I was tried adding status icons to steps, but that was removed due to scaling issues.
<img width="247" alt="Screenshot 2023-02-22 at 08 54 50" src="https://user-images.githubusercontent.com/4447764/220570547-e1d0c1a7-5920-4714-a486-fc3797cd0064.png">

Fixes #218 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
