### PR TITLE
Provide full text in tooltip of truncated labels

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/TruncatingLabel.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/TruncatingLabel.tsx
@@ -103,7 +103,7 @@ export class TruncatingLabel extends React.Component<Props> {
       <div
         style={mergedStyle}
         className={"TruncatingLabel " + className}
-        title={this.innerText}
+        title={this.completeText}
       >
         {this.innerText}
       </div>


### PR DESCRIPTION
Happens with long stage names

Anyone see an issue with it?

Before:
<img width="183" alt="image" src="https://user-images.githubusercontent.com/21194782/221369747-64939bcb-1eae-4f69-8435-4fe97d0a5838.png">

After:
<img width="189" alt="image" src="https://user-images.githubusercontent.com/21194782/221369724-8c71e1eb-1148-43ac-92cf-14280cba7cfb.png">
