### PR TITLE
Append excpetion text to logText

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -127,41 +127,39 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
     long endByte = 0L;
     long textLength;
     String text = "";
-    // If this is an exception, return the exception text (inc. stacktrace).
+    AnnotatedLargeText<? extends FlowNode> logText = getLogForNode(nodeId);
+
+    if (logText != null) {
+      textLength = logText.length();
+      // postitive startByte
+      if (requestStartByte > textLength) {
+        // Avoid resource leak.
+        logger.error("consoleJson - user requested startByte larger than console output.");
+        return null;
+      }
+      // if startByte is negative make sure we don't try and get a byte before 0.
+      if (requestStartByte < 0L) {
+        logger.debug("consoleJson - requested negative startByte '" + requestStartByte + "'.");
+        startByte = textLength + requestStartByte;
+        if (startByte < 0L) {
+          logger.debug(
+              "consoleJson - requested negative startByte '"
+                  + requestStartByte
+                  + "' out of bounds, starting at 0.");
+          startByte = 0L;
+        }
+      } else {
+        startByte = requestStartByte;
+      }
+      logger.debug("Returning '" + (textLength - startByte) + "' bytes from 'getConsoleOutput'.");
+      text = PipelineNodeUtil.convertLogToString(logText, startByte);
+      endByte = textLength;
+    }
+    // If has an exception, return the exception text (inc. stacktrace).
     if (isUnhandledException(nodeId)) {
       // Set logText to exception text. This is a little hacky - maybe it would be better update the
       // frontend to handle steps and exceptions differently?
-      text = getNodeExceptionText(nodeId);
-      endByte = text.length();
-    } else {
-      AnnotatedLargeText<? extends FlowNode> logText = getLogForNode(nodeId);
-
-      if (logText != null) {
-        textLength = logText.length();
-        // postitive startByte
-        if (requestStartByte > textLength) {
-          // Avoid resource leak.
-          logger.error("consoleJson - user requested startByte larger than console output.");
-          return null;
-        }
-        // if startByte is negative make sure we don't try and get a byte before 0.
-        if (requestStartByte < 0L) {
-          logger.debug("consoleJson - requested negative startByte '" + requestStartByte + "'.");
-          startByte = textLength + requestStartByte;
-          if (startByte < 0L) {
-            logger.debug(
-                "consoleJson - requested negative startByte '"
-                    + requestStartByte
-                    + "' out of bounds, starting at 0.");
-            startByte = 0L;
-          }
-        } else {
-          startByte = requestStartByte;
-        }
-        logger.debug("Returning '" + (textLength - startByte) + "' bytes from 'getConsoleOutput'.");
-        text = PipelineNodeUtil.convertLogToString(logText, startByte);
-        endByte = textLength;
-      }
+      text += getNodeExceptionText(nodeId);
     }
     HashMap<String, Object> response = new HashMap<>();
     response.put("text", text);


### PR DESCRIPTION
Fix for re-opened #224 
Before we assumed that a step was either an exception or a valid step. This is true for `error` but isn't true for `bat/sh` steps that raise an exception - e.g. calling `exit 1`.
Now we check all steps for log text and exceptions (and append exception text to any log text). 

![Screenshot 2023-03-07 at 10 05 07](https://user-images.githubusercontent.com/4447764/223390071-faba01fc-7ae6-41c0-8215-dfc5677672ce.png)


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
