### PR TITLE
Fix Node SvgStatus rendering

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsoleModel.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsoleModel.tsx
@@ -4,6 +4,8 @@ import { Result } from "../../../pipeline-graph-view/pipeline-graph/main/Pipelin
 export {
   Result,
   decodeResultValue,
+} from "../../../pipeline-graph-view/pipeline-graph/main/PipelineGraphModel";
+export type {
   StageInfo,
 } from "../../../pipeline-graph-view/pipeline-graph/main/PipelineGraphModel";
 

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/SvgStatus.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/SvgStatus.tsx
@@ -30,19 +30,24 @@ export class SvgStatus extends React.PureComponent<Props> {
     const iconOuterClassName =
       result === Result.running ? "in-progress" : "static";
     const iconSuffix = result === Result.running ? "-anime" : "";
-    const style = { ...{ width: diameter, height: diameter } };
     return (
       <g
         className={`${baseWrapperClasses} ${getClassForResult(
           result
         )}${iconSuffix}`}
-        style={style}
       >
         <g
           className="build-status-icon__outer"
-          style={outerStyle ?? { transform: `translate(0,0)` }}
+          style={outerStyle ?? { transform: `translate(0, 0)` }}
         >
-          <svg focusable="false" className="svg-icon " x={-radius} y={-radius}>
+          <svg
+            focusable="false"
+            className="svg-icon "
+            x={-radius}
+            y={-radius}
+            width={diameter}
+            height={diameter}
+          >
             <use
               className="svg-icon"
               style={{ transformOrigin: "50% 50%" }}
@@ -50,7 +55,7 @@ export class SvgStatus extends React.PureComponent<Props> {
             />
           </svg>
         </g>
-        {getGlyphFor(result, radius, style)}
+        {getGlyphFor(result, radius)}
       </g>
     );
   }
@@ -59,11 +64,7 @@ export class SvgStatus extends React.PureComponent<Props> {
 /**
  Returns a glyph (as <g>) for specified result type. Centered at 0,0, scaled for 24px icons.
  */
-function getGlyphFor(
-  result: Result,
-  radius: number,
-  style: React.CSSProperties
-) {
+function getGlyphFor(result: Result, radius: number) {
   // NB: If we start resizing these things, we'll need to use radius/12 to
   // generate a "scale" transform for the group
   const diameter = radius * 2;
@@ -73,9 +74,10 @@ function getGlyphFor(
         <svg
           x={-radius}
           y={-radius}
+          width={diameter}
+          height={diameter}
           focusable="false"
           className={`svg-icon icon-md`}
-          style={{ ...style, ...{ width: diameter, height: diameter } }}
         >
           <use
             href={`${imagesPath}/build-status/build-status-sprite.svg#last-aborted`}
@@ -89,10 +91,11 @@ function getGlyphFor(
         <svg
           x={-radius}
           y={-radius}
+          width={diameter}
+          height={diameter}
           focusable="false"
           className={`svg-icon icon-md`}
           viewBox={`${-radius} ${-radius} ${"100%"} ${"100%"}`}
-          style={{ ...style, ...{ width: diameter, height: diameter } }}
         >
           <polygon points="-4,-4.65 -4,4.65 -4,4.65 -1.5,4.65 -1.5,-4.65" />
           <polygon points="4,-4.65 1.5,-4.65 1.5,-4.65 1.5,4.65 4,4.65" />
@@ -104,9 +107,10 @@ function getGlyphFor(
         <svg
           x={-radius}
           y={-radius}
+          width={diameter}
+          height={diameter}
           focusable="false"
           className={`svg-icon icon-md`}
-          style={{ ...style, ...{ width: diameter, height: diameter } }}
         >
           <use
             href={`${imagesPath}/build-status/build-status-sprite.svg#last-unstable`}
@@ -119,9 +123,10 @@ function getGlyphFor(
         <svg
           x={-radius}
           y={-radius}
+          width={diameter}
+          height={diameter}
           focusable="false"
           className={`svg-icon icon-md`}
-          style={{ ...style, ...{ width: diameter, height: diameter } }}
         >
           <use
             href={`${imagesPath}/build-status/build-status-sprite.svg#last-successful`}
@@ -134,9 +139,10 @@ function getGlyphFor(
         <svg
           x={-radius}
           y={-radius}
+          width={diameter}
+          height={diameter}
           focusable="false"
           className={`svg-icon icon-md`}
-          style={{ ...style, ...{ width: diameter, height: diameter } }}
         >
           <use
             href={`${imagesPath}/build-status/build-status-sprite.svg#last-failed`}
@@ -148,9 +154,10 @@ function getGlyphFor(
         <svg
           x={-radius}
           y={-radius}
+          width={diameter}
+          height={diameter}
           focusable="false"
           className={`svg-icon icon-md`}
-          style={{ ...style, ...{ width: diameter, height: diameter } }}
         >
           <use
             href={`${imagesPath}/build-status/build-status-sprite.svg#never-built`}
@@ -173,8 +180,9 @@ function getGlyphFor(
       className={`svg-icon icon-md`}
       x={-radius}
       y={-radius}
+      width={diameter}
+      height={diameter}
       viewBox={`${-radius} ${-radius} ${"100%"} ${"100%"}`}
-      style={{ ...style, ...{ width: diameter, height: diameter } }}
     >
       <path d={questionMarkPath} />
     </svg>

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/SvgStatus.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/SvgStatus.tsx
@@ -30,11 +30,13 @@ export class SvgStatus extends React.PureComponent<Props> {
     const iconOuterClassName =
       result === Result.running ? "in-progress" : "static";
     const iconSuffix = result === Result.running ? "-anime" : "";
+    const style = {width: diameter, height: diameter};
     return (
       <g
         className={`${baseWrapperClasses} ${getClassForResult(
           result
         )}${iconSuffix}`}
+        style={style}
       >
         <g
           className="build-status-icon__outer"
@@ -55,7 +57,7 @@ export class SvgStatus extends React.PureComponent<Props> {
             />
           </svg>
         </g>
-        {getGlyphFor(result, radius)}
+        {getGlyphFor(result, radius, style)}
       </g>
     );
   }
@@ -64,7 +66,11 @@ export class SvgStatus extends React.PureComponent<Props> {
 /**
  Returns a glyph (as <g>) for specified result type. Centered at 0,0, scaled for 24px icons.
  */
-function getGlyphFor(result: Result, radius: number) {
+function getGlyphFor(
+  result: Result,
+  radius: number,
+  style: React.CSSProperties
+) {
   // NB: If we start resizing these things, we'll need to use radius/12 to
   // generate a "scale" transform for the group
   const diameter = radius * 2;
@@ -78,6 +84,7 @@ function getGlyphFor(result: Result, radius: number) {
           height={diameter}
           focusable="false"
           className={`svg-icon icon-md`}
+          style={{ ...style, ...{ width: diameter, height: diameter } }}
         >
           <use
             href={`${imagesPath}/build-status/build-status-sprite.svg#last-aborted`}
@@ -96,6 +103,7 @@ function getGlyphFor(result: Result, radius: number) {
           focusable="false"
           className={`svg-icon icon-md`}
           viewBox={`${-radius} ${-radius} ${"100%"} ${"100%"}`}
+          style={{ ...style, ...{ width: diameter, height: diameter } }}
         >
           <polygon points="-4,-4.65 -4,4.65 -4,4.65 -1.5,4.65 -1.5,-4.65" />
           <polygon points="4,-4.65 1.5,-4.65 1.5,-4.65 1.5,4.65 4,4.65" />
@@ -111,6 +119,7 @@ function getGlyphFor(result: Result, radius: number) {
           height={diameter}
           focusable="false"
           className={`svg-icon icon-md`}
+          style={{ ...style, ...{ width: diameter, height: diameter } }}
         >
           <use
             href={`${imagesPath}/build-status/build-status-sprite.svg#last-unstable`}
@@ -127,6 +136,7 @@ function getGlyphFor(result: Result, radius: number) {
           height={diameter}
           focusable="false"
           className={`svg-icon icon-md`}
+          style={{ ...style, ...{ width: diameter, height: diameter } }}
         >
           <use
             href={`${imagesPath}/build-status/build-status-sprite.svg#last-successful`}
@@ -143,6 +153,7 @@ function getGlyphFor(result: Result, radius: number) {
           height={diameter}
           focusable="false"
           className={`svg-icon icon-md`}
+          style={{ ...style, ...{ width: diameter, height: diameter } }}
         >
           <use
             href={`${imagesPath}/build-status/build-status-sprite.svg#last-failed`}
@@ -158,6 +169,7 @@ function getGlyphFor(result: Result, radius: number) {
           height={diameter}
           focusable="false"
           className={`svg-icon icon-md`}
+          style={{ ...style, ...{ width: diameter, height: diameter } }}
         >
           <use
             href={`${imagesPath}/build-status/build-status-sprite.svg#never-built`}
@@ -183,6 +195,7 @@ function getGlyphFor(result: Result, radius: number) {
       width={diameter}
       height={diameter}
       viewBox={`${-radius} ${-radius} ${"100%"} ${"100%"}`}
+      style={{ ...style, ...{ width: diameter, height: diameter } }}
     >
       <path d={questionMarkPath} />
     </svg>


### PR DESCRIPTION
Fixes #241 
Fix the rendering of the node SvgStatus icons on the Graph view.

Stop trying to set size with style. Worked for the Console view but not the Graph view.
The fix works for both views:

Graph View:
<img width="930" alt="Screenshot 2023-03-10 at 20 25 35" src="https://user-images.githubusercontent.com/4447764/224422167-4efefc6a-d92f-480e-b9a2-a1da3dc41c95.png">

Console View:
<img width="528" alt="Screenshot 2023-03-10 at 20 25 29" src="https://user-images.githubusercontent.com/4447764/224422176-2fc447bb-7b59-4f2e-b238-9eec1e73001c.png">

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira