### PR TITLE
Fix TreeVisitor for running Pipelines

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
@@ -278,6 +278,7 @@ export class ConsoleLogCard extends React.Component<ConsoleLogCardProps> {
           >
             <div>{this.getTruncatedLogWarning()}</div>
             <Virtuoso
+              style={{maxHeight: "50vh"}}
               totalCount={this.getNumConsoleLines()}
               itemContent={(index: number) => this.renderConsoleLine(index)}
               // This ID comes from PipelineConsole.


### PR DESCRIPTION
Running Pipelines were returning `java.util.NoSuchElementException`. Seems like the Visitor is passed nodes which aren't EndNodes, e.g. `AtomNode`/`StepStartNode` when a stage is running which caused a mismatch in the number of 'childBlockIdStacks' - which caused a null pointer exception.

```
chunkEnd => Node {id: 11, name: Shell Script, isStage: false, isParallelBranch: false, isSynthetic: false}.
handleBlockEndNode => Called {id: 11, name: Shell Script, type: class org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode}.
handleBlockEndNode => Found BlockEndNode {id: 11, name: Shell Script}, pushed new childStack to stack {size: 1}.
handleChunkDone=> {id: 10, name: Stage - 1, function: { (Stage - 1)}
chunkStart => Node ID: {id: 10, name: Stage - 1, isStage: true, isParallelBranch: false, isSynthetic: false}.
handleBlockStartNode => Found BlockStartNode {id: 10, name: Stage - 1}, removed last childStack from stack {size: 0}.
chunkEnd => Node {id: 9, name: Stage : Start, isStage: false, isParallelBranch: false, isSynthetic: false}.
handleBlockEndNode => Called {id: 9, name: Stage : Start, type: class org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode}.
handleBlockEndNode => Found BlockEndNode {id: 9, name: Stage : Start}, pushed new childStack to stack {size: 1}.
handleChunkDone=> {id: 6, name: Hello, function: { (Hello)}
chunkStart => Node ID: {id: 6, name: Hello, isStage: true, isParallelBranch: false, isSynthetic: false}.
handleBlockStartNode => Found BlockStartNode {id: 6, name: Hello}, removed last childStack from stack {size: 0}.
Found we have parsed this node {id: 6, name: Hello} in handleChunkDone, so returning that.
chunkEnd => Node {id: 5, name: Stage : Start, isStage: false, isParallelBranch: false, isSynthetic: false}.
handleBlockEndNode => Called {id: 5, name: Stage : Start, type: class org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode}.
handleBlockEndNode => Found BlockEndNode {id: 5, name: Stage : Start}, pushed new childStack to stack {size: 1}.
Returning 1 steps for node '10'
Returning 1 steps in total
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
