### PR TITLE
Java 11 in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,17 +33,13 @@ If you are a newcomer contributor and have any questions, please do not hesitate
 
 Prerequisites: _Java_ and _Maven_.
 
-- Ensure Java 8 or 11 is available.
+- Ensure Java 11 or 17 is available.
 
   ```console	
   $ java -version	
-  ```	
-  - Use the alternate Java 8.	
-
-  ```console	
-  $ export JAVA_HOME=`/usr/libexec/java_home -v 1.8`	
-  $ echo $JAVA_HOME	
-  /Library/Java/JavaVirtualMachines/jdk1.8.0_252.jdk/Contents/Home
+  openjdk version "11.0.18" 2023-01-17
+  OpenJDK Runtime Environment Temurin-11.0.18+10 (build 11.0.18+10)
+  OpenJDK 64-Bit Server VM Temurin-11.0.18+10 (build 11.0.18+10, mixed mode)
   ```	
 
 - Ensure Maven >= 3.8.1 is installed and included in the PATH environment variable.


### PR DESCRIPTION
## Use Java 11 in the contributing guide

Java 11 is required for Jenkins 2.361.1 and newer.  Use it in the contributing guide instead of Java 8.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
