### PR TITLE
Use upstream Spotless configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,173 +1,112 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>4.57</version>
-        <relativePath />
-    </parent>
-    <groupId>io.jenkins.plugins</groupId>
-    <artifactId>pipeline-graph-view</artifactId>
-    <version>${changelist}</version>
-    <packaging>hpi</packaging>
-    <properties>
-        <changelist>999999-SNAPSHOT</changelist>
-        <gitHubRepo>jenkinsci/pipeline-graph-view-plugin</gitHubRepo>
-        <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.361.4</jenkins.version>
-        <node.version>16.18.1</node.version>
-        <npm.version>8.19.4</npm.version>
-    </properties>
-    <name>Pipeline Graph View Plugin</name>
-    <url>https://github.com/jenkinsci/pipeline-graph-view-plugin</url>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>4.59</version>
+    <relativePath />
+  </parent>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>1945.v13a_1306588ff</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+  <groupId>io.jenkins.plugins</groupId>
+  <artifactId>pipeline-graph-view</artifactId>
+  <version>${changelist}</version>
+  <packaging>hpi</packaging>
+  <name>Pipeline Graph View Plugin</name>
+  <url>https://github.com/jenkinsci/pipeline-graph-view-plugin</url>
 
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
+  </scm>
+
+  <properties>
+    <changelist>999999-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/pipeline-graph-view-plugin</gitHubRepo>
+    <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
+    <jenkins.version>2.361.4</jenkins.version>
+    <node.version>16.18.1</node.version>
+    <npm.version>8.19.4</npm.version>
+  </properties>
+
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>ionicons-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>metrics</artifactId>
-        </dependency>
-        <!-- TODO make optional -->
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>github-branch-source</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>pipeline-input-step</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>pipeline-graph-analysis</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-durable-task-step</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkinsci.plugins</groupId>
-            <artifactId>pipeline-model-definition</artifactId>
-        </dependency>
+      <dependency>
+        <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.361.x</artifactId>
+        <version>1945.v13a_1306588ff</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.diffplug.spotless</groupId>
-                <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.35.0</version>
-                <executions>
-                    <execution>
-                        <id>spotless-check</id>
-                        <!-- runs in verify phase by default -->
-                        <goals>
-                            <!-- can be disabled using -Dspotless.check.skip=true -->
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <java>
-                        <googleJavaFormat>
-                            <style>GOOGLE</style>
-                            <!-- Last version that supports Java 8, the plugin does handle this internally
-                                 but it will give different versions based off of the JVM version, not good for CI
-                             -->
-                            <version>1.7</version>
-                        </googleJavaFormat>
-                    </java>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+  <dependencies>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>ionicons-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>github-branch-source</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>metrics</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>pipeline-graph-analysis</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>pipeline-input-step</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
+    </dependency>
+  </dependencies>
 
-    <profiles>
-        <profile>
-            <id>ci-non-windows</id>
-            <activation>
-                <property>
-                    <name>set.changelist</name>
-                </property>
-                <os>
-                    <family>!windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.diffplug.spotless</groupId>
-                        <artifactId>spotless-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>spotless-check</id>
-                                <!-- In CI, run check early in the build -->
-                                <phase>process-sources</phase>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
 
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>https://opensource.org/licenses/MIT</url>
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
-        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-        <url>https://github.com/${gitHubRepo}</url>
-        <tag>${scmTag}</tag>
-    </scm>
-
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphDisplayURLProvider.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphDisplayURLProvider.java
@@ -9,21 +9,21 @@ import org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider;
 @Extension
 public class PipelineGraphDisplayURLProvider extends ClassicDisplayURLProvider {
 
-  @Override
-  @NonNull
-  public String getDisplayName() {
-    return "Pipeline Graph";
-  }
+    @Override
+    @NonNull
+    public String getDisplayName() {
+        return "Pipeline Graph";
+    }
 
-  @Override
-  @NonNull
-  public String getName() {
-    return "pipeline-graph";
-  }
+    @Override
+    @NonNull
+    public String getName() {
+        return "pipeline-graph";
+    }
 
-  @Override
-  @NonNull
-  public String getRunURL(Run<?, ?> run) {
-    return getRoot() + Util.encode(run.getUrl()) + "pipeline-graph";
-  }
+    @Override
+    @NonNull
+    public String getRunURL(Run<?, ?> run) {
+        return getRoot() + Util.encode(run.getUrl()) + "pipeline-graph";
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewAction.java
@@ -11,35 +11,35 @@ import java.util.List;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 public class PipelineGraphViewAction extends AbstractPipelineViewAction {
-  public PipelineGraphViewAction(WorkflowRun target) {
-    super(target);
-  }
-
-  @Override
-  public String getDisplayName() {
-    return "Pipeline Graph";
-  }
-
-  @Override
-  public String getUrlName() {
-    return "pipeline-graph";
-  }
-
-  @SuppressWarnings("unused")
-  public RunDetailsCard getRunDetailsCard() {
-
-    List<RunDetailsItem> runDetailsItems = new ArrayList<>();
-
-    runDetailsItems.addAll(SCMRunDetailsItems.get(run));
-
-    if (!runDetailsItems.isEmpty()) {
-      runDetailsItems.add(new RunDetailsItem.Builder().separator().build());
+    public PipelineGraphViewAction(WorkflowRun target) {
+        super(target);
     }
 
-    CauseRunDetailsItem.get(run).ifPresent(runDetailsItems::add);
+    @Override
+    public String getDisplayName() {
+        return "Pipeline Graph";
+    }
 
-    runDetailsItems.addAll(TimingRunDetailsItems.get(run));
+    @Override
+    public String getUrlName() {
+        return "pipeline-graph";
+    }
 
-    return new RunDetailsCard(runDetailsItems);
-  }
+    @SuppressWarnings("unused")
+    public RunDetailsCard getRunDetailsCard() {
+
+        List<RunDetailsItem> runDetailsItems = new ArrayList<>();
+
+        runDetailsItems.addAll(SCMRunDetailsItems.get(run));
+
+        if (!runDetailsItems.isEmpty()) {
+            runDetailsItems.add(new RunDetailsItem.Builder().separator().build());
+        }
+
+        CauseRunDetailsItem.get(run).ifPresent(runDetailsItems::add);
+
+        runDetailsItems.addAll(TimingRunDetailsItems.get(run));
+
+        return new RunDetailsCard(runDetailsItems);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewActionFactory.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewActionFactory.java
@@ -11,15 +11,15 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 @Extension
 public class PipelineGraphViewActionFactory extends TransientActionFactory<WorkflowRun> {
 
-  @Override
-  public Class<WorkflowRun> type() {
-    return WorkflowRun.class;
-  }
+    @Override
+    public Class<WorkflowRun> type() {
+        return WorkflowRun.class;
+    }
 
-  @NonNull
-  @Override
-  public Collection<? extends Action> createFor(@NonNull WorkflowRun target) {
-    PipelineGraphViewAction a = new PipelineGraphViewAction(target);
-    return Collections.singleton(a);
-  }
+    @NonNull
+    @Override
+    public Collection<? extends Action> createFor(@NonNull WorkflowRun target) {
+        PipelineGraphViewAction a = new PipelineGraphViewAction(target);
+        return Collections.singleton(a);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/Card.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/Card.java
@@ -1,5 +1,5 @@
 package io.jenkins.plugins.pipelinegraphview.cards;
 
 public abstract class Card {
-  public abstract String getTitle();
+    public abstract String getTitle();
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/RunDetailsCard.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/RunDetailsCard.java
@@ -4,18 +4,18 @@ import java.util.List;
 
 public class RunDetailsCard extends Card {
 
-  private List<RunDetailsItem> items;
+    private List<RunDetailsItem> items;
 
-  public RunDetailsCard(List<RunDetailsItem> items) {
-    this.items = items;
-  }
+    public RunDetailsCard(List<RunDetailsItem> items) {
+        this.items = items;
+    }
 
-  public List<RunDetailsItem> getItems() {
-    return items;
-  }
+    public List<RunDetailsItem> getItems() {
+        return items;
+    }
 
-  @Override
-  public String getTitle() {
-    return "Details";
-  }
+    @Override
+    public String getTitle() {
+        return "Details";
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/RunDetailsItem.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/RunDetailsItem.java
@@ -4,71 +4,71 @@ import static java.util.Objects.requireNonNull;
 
 public class RunDetailsItem {
 
-  private final String icon;
-  private final String text;
-  private final String href;
-  private final boolean separator;
+    private final String icon;
+    private final String text;
+    private final String href;
+    private final boolean separator;
 
-  RunDetailsItem(String icon, String text, String href, boolean separator) {
-    this.icon = icon;
-    this.text = text;
-    this.href = href;
-    this.separator = separator;
-  }
-
-  public String getIcon() {
-    return icon;
-  }
-
-  public String getText() {
-    return text;
-  }
-
-  public String getHref() {
-    return href;
-  }
-
-  public boolean isSeparator() {
-    return separator;
-  }
-
-  public static class Builder {
-
-    private String icon;
-    private String text;
-    private String href;
-    private boolean separator;
-
-    public Builder text(String text) {
-      this.text = text;
-      return this;
+    RunDetailsItem(String icon, String text, String href, boolean separator) {
+        this.icon = icon;
+        this.text = text;
+        this.href = href;
+        this.separator = separator;
     }
 
-    public Builder icon(String icon) {
-      this.icon = icon;
-      return this;
+    public String getIcon() {
+        return icon;
     }
 
-    public Builder ionicon(String ionicon) {
-      this.icon = String.format("symbol-%s plugin-ionicons-api", ionicon);
-      return this;
+    public String getText() {
+        return text;
     }
 
-    public Builder href(String href) {
-      this.href = href;
-      return this;
+    public String getHref() {
+        return href;
     }
 
-    public Builder separator() {
-      this.separator = true;
-      return this;
+    public boolean isSeparator() {
+        return separator;
     }
 
-    public RunDetailsItem build() {
-      if (!separator) {
-        requireNonNull(icon);
-      }
-      return new RunDetailsItem(icon, text, href, separator);
+    public static class Builder {
+
+        private String icon;
+        private String text;
+        private String href;
+        private boolean separator;
+
+        public Builder text(String text) {
+            this.text = text;
+            return this;
+        }
+
+        public Builder icon(String icon) {
+            this.icon = icon;
+            return this;
+        }
+
+        public Builder ionicon(String ionicon) {
+            this.icon = String.format("symbol-%s plugin-ionicons-api", ionicon);
+            return this;
+        }
+
+        public Builder href(String href) {
+            this.href = href;
+            return this;
+        }
+
+        public Builder separator() {
+            this.separator = true;
+            return this;
+        }
+
+        public RunDetailsItem build() {
+            if (!separator) {
+                requireNonNull(icon);
+            }
+            return new RunDetailsItem(icon, text, href, separator);
+        }
     }
-  }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/CauseRunDetailsItem.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/CauseRunDetailsItem.java
@@ -12,19 +12,20 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 public class CauseRunDetailsItem {
 
-  public static Optional<RunDetailsItem> get(WorkflowRun run) {
-    CauseAction causeAction = run.getAction(CauseAction.class);
-    List<Cause> causes = causeAction.getCauses();
-    return causes.stream()
-        .filter(cause -> cause instanceof Cause.UserIdCause)
-        .map(userIdCause -> (Cause.UserIdCause) userIdCause)
-        .map(userIdCause -> User.get(userIdCause.getUserId(), false, new HashMap<>()))
-        .filter(Objects::nonNull)
-        // TODO i18n
-        .map(user -> "Manually run by " + user.getDisplayName())
-        .map(
-            startedAt ->
-                new RunDetailsItem.Builder().ionicon("person-outline").text(startedAt).build())
-        .findAny();
-  }
+    public static Optional<RunDetailsItem> get(WorkflowRun run) {
+        CauseAction causeAction = run.getAction(CauseAction.class);
+        List<Cause> causes = causeAction.getCauses();
+        return causes.stream()
+                .filter(cause -> cause instanceof Cause.UserIdCause)
+                .map(userIdCause -> (Cause.UserIdCause) userIdCause)
+                .map(userIdCause -> User.get(userIdCause.getUserId(), false, new HashMap<>()))
+                .filter(Objects::nonNull)
+                // TODO i18n
+                .map(user -> "Manually run by " + user.getDisplayName())
+                .map(startedAt -> new RunDetailsItem.Builder()
+                        .ionicon("person-outline")
+                        .text(startedAt)
+                        .build())
+                .findAny();
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/GitHubBranchSourceRunDetailsItems.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/GitHubBranchSourceRunDetailsItems.java
@@ -13,49 +13,49 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 public class GitHubBranchSourceRunDetailsItems {
 
-  public static String getGitCommit(SCMRevisionAction scmRevisionAction) {
-    PullRequestSCMRevision revision = (PullRequestSCMRevision) scmRevisionAction.getRevision();
-    return revision.getPullHash().substring(0, 7);
-  }
-
-  public static List<RunDetailsItem> getGitInformation(SCMRevisionAction scmRevisionAction) {
-    List<RunDetailsItem> runDetailsItems = new ArrayList<>();
-
-    PullRequestSCMRevision revision = (PullRequestSCMRevision) scmRevisionAction.getRevision();
-
-    // TODO see if there's a way to get this for branch builds, may need to make changes to
-    // github-branch-source-plugin
-    PullRequestSCMHead head = (PullRequestSCMHead) revision.getHead();
-    String sourceOwner = head.getSourceOwner();
-    String sourceRepo = head.getSourceRepo();
-    String sourceBranch = head.getSourceBranch();
-
-    RunDetailsItem gitRepositoryItem =
-        new RunDetailsItem.Builder()
-            .ionicon("logo-github")
-            .text(sourceOwner + "/" + sourceRepo)
-            .build();
-    runDetailsItems.add(gitRepositoryItem);
-
-    RunDetailsItem gitBranchItem =
-        new RunDetailsItem.Builder().ionicon("git-branch-outline").text(sourceBranch).build();
-    runDetailsItems.add(gitBranchItem);
-
-    return runDetailsItems;
-  }
-
-  public static Optional<RunDetailsItem> getGitHubLink(WorkflowRun run) {
-    GitHubLink gitHubLink = run.getParent().getAction(GitHubLink.class);
-    if (gitHubLink != null) {
-      ObjectMetadataAction action = run.getParent().getAction(ObjectMetadataAction.class);
-      RunDetailsItem build =
-          new RunDetailsItem.Builder()
-              .ionicon("git-pull-request-outline")
-              .text(action.getObjectDisplayName())
-              .href(gitHubLink.getUrl())
-              .build();
-      return Optional.of(build);
+    public static String getGitCommit(SCMRevisionAction scmRevisionAction) {
+        PullRequestSCMRevision revision = (PullRequestSCMRevision) scmRevisionAction.getRevision();
+        return revision.getPullHash().substring(0, 7);
     }
-    return Optional.empty();
-  }
+
+    public static List<RunDetailsItem> getGitInformation(SCMRevisionAction scmRevisionAction) {
+        List<RunDetailsItem> runDetailsItems = new ArrayList<>();
+
+        PullRequestSCMRevision revision = (PullRequestSCMRevision) scmRevisionAction.getRevision();
+
+        // TODO see if there's a way to get this for branch builds, may need to make changes to
+        // github-branch-source-plugin
+        PullRequestSCMHead head = (PullRequestSCMHead) revision.getHead();
+        String sourceOwner = head.getSourceOwner();
+        String sourceRepo = head.getSourceRepo();
+        String sourceBranch = head.getSourceBranch();
+
+        RunDetailsItem gitRepositoryItem = new RunDetailsItem.Builder()
+                .ionicon("logo-github")
+                .text(sourceOwner + "/" + sourceRepo)
+                .build();
+        runDetailsItems.add(gitRepositoryItem);
+
+        RunDetailsItem gitBranchItem = new RunDetailsItem.Builder()
+                .ionicon("git-branch-outline")
+                .text(sourceBranch)
+                .build();
+        runDetailsItems.add(gitBranchItem);
+
+        return runDetailsItems;
+    }
+
+    public static Optional<RunDetailsItem> getGitHubLink(WorkflowRun run) {
+        GitHubLink gitHubLink = run.getParent().getAction(GitHubLink.class);
+        if (gitHubLink != null) {
+            ObjectMetadataAction action = run.getParent().getAction(ObjectMetadataAction.class);
+            RunDetailsItem build = new RunDetailsItem.Builder()
+                    .ionicon("git-pull-request-outline")
+                    .text(action.getObjectDisplayName())
+                    .href(gitHubLink.getUrl())
+                    .build();
+            return Optional.of(build);
+        }
+        return Optional.empty();
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/SCMRunDetailsItems.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/SCMRunDetailsItems.java
@@ -10,43 +10,44 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 public class SCMRunDetailsItems {
 
-  public static List<RunDetailsItem> get(WorkflowRun run) {
-    List<RunDetailsItem> runDetailsItems = new ArrayList<>();
-    SCMRevisionAction scmRevisionAction = run.getAction(SCMRevisionAction.class);
+    public static List<RunDetailsItem> get(WorkflowRun run) {
+        List<RunDetailsItem> runDetailsItems = new ArrayList<>();
+        SCMRevisionAction scmRevisionAction = run.getAction(SCMRevisionAction.class);
 
-    boolean githubBranchSourceInstalled = Jenkins.get().getPlugin("github-branch-source") != null;
+        boolean githubBranchSourceInstalled = Jenkins.get().getPlugin("github-branch-source") != null;
 
-    if (scmRevisionAction != null) {
-      String commit = null;
-      if (scmRevisionAction
-              .getRevision()
-              .getClass()
-              .getName()
-              .equals("org.jenkinsci.plugins.github_branch_source.PullRequestSCMRevision")
-          && githubBranchSourceInstalled) {
+        if (scmRevisionAction != null) {
+            String commit = null;
+            if (scmRevisionAction
+                            .getRevision()
+                            .getClass()
+                            .getName()
+                            .equals("org.jenkinsci.plugins.github_branch_source.PullRequestSCMRevision")
+                    && githubBranchSourceInstalled) {
 
-        runDetailsItems.addAll(
-            GitHubBranchSourceRunDetailsItems.getGitInformation(scmRevisionAction));
-        commit = GitHubBranchSourceRunDetailsItems.getGitCommit(scmRevisionAction);
+                runDetailsItems.addAll(GitHubBranchSourceRunDetailsItems.getGitInformation(scmRevisionAction));
+                commit = GitHubBranchSourceRunDetailsItems.getGitCommit(scmRevisionAction);
 
-      } else if (scmRevisionAction.getRevision() instanceof AbstractGitSCMSource.SCMRevisionImpl) {
-        AbstractGitSCMSource.SCMRevisionImpl revision =
-            (AbstractGitSCMSource.SCMRevisionImpl) scmRevisionAction.getRevision();
-        commit = revision.getHash().substring(0, 7);
-      }
+            } else if (scmRevisionAction.getRevision() instanceof AbstractGitSCMSource.SCMRevisionImpl) {
+                AbstractGitSCMSource.SCMRevisionImpl revision =
+                        (AbstractGitSCMSource.SCMRevisionImpl) scmRevisionAction.getRevision();
+                commit = revision.getHash().substring(0, 7);
+            }
 
-      if (githubBranchSourceInstalled) {
-        GitHubBranchSourceRunDetailsItems.getGitHubLink(run).ifPresent(runDetailsItems::add);
-      }
+            if (githubBranchSourceInstalled) {
+                GitHubBranchSourceRunDetailsItems.getGitHubLink(run).ifPresent(runDetailsItems::add);
+            }
 
-      if (commit != null) {
-        RunDetailsItem gitCommitItem =
-            new RunDetailsItem.Builder().ionicon("git-commit-outline").text(commit).build();
+            if (commit != null) {
+                RunDetailsItem gitCommitItem = new RunDetailsItem.Builder()
+                        .ionicon("git-commit-outline")
+                        .text(commit)
+                        .build();
 
-        runDetailsItems.add(gitCommitItem);
-      }
+                runDetailsItems.add(gitCommitItem);
+            }
+        }
+
+        return runDetailsItems;
     }
-
-    return runDetailsItems;
-  }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/TimingRunDetailsItems.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/TimingRunDetailsItems.java
@@ -10,41 +10,35 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 public class TimingRunDetailsItems {
 
-  public static List<RunDetailsItem> get(WorkflowRun run) {
-    List<RunDetailsItem> runDetailsItems = new ArrayList<>();
+    public static List<RunDetailsItem> get(WorkflowRun run) {
+        List<RunDetailsItem> runDetailsItems = new ArrayList<>();
 
-    RunDetailsItem startedItem =
-        new RunDetailsItem.Builder()
-            .ionicon("time-outline")
-            .text(
-                "Started "
-                    + Util.getTimeSpanString(
-                        Math.abs(run.getTime().getTime() - new Date().getTime()))
-                    + " ago")
-            .build();
-    runDetailsItems.add(startedItem);
+        RunDetailsItem startedItem = new RunDetailsItem.Builder()
+                .ionicon("time-outline")
+                .text("Started "
+                        + Util.getTimeSpanString(Math.abs(run.getTime().getTime() - new Date().getTime()))
+                        + " ago")
+                .build();
+        runDetailsItems.add(startedItem);
 
-    TimeInQueueAction timeInQueueAction = run.getAction(TimeInQueueAction.class);
+        TimeInQueueAction timeInQueueAction = run.getAction(TimeInQueueAction.class);
 
-    if (timeInQueueAction != null) {
-      RunDetailsItem queuedItem =
-          new RunDetailsItem.Builder()
-              .ionicon("hourglass-outline")
-              .text(
-                  "Queued " + Util.getTimeSpanString(timeInQueueAction.getQueuingDurationMillis()))
-              .build();
+        if (timeInQueueAction != null) {
+            RunDetailsItem queuedItem = new RunDetailsItem.Builder()
+                    .ionicon("hourglass-outline")
+                    .text("Queued " + Util.getTimeSpanString(timeInQueueAction.getQueuingDurationMillis()))
+                    .build();
 
-      runDetailsItems.add(queuedItem);
+            runDetailsItems.add(queuedItem);
+        }
+
+        RunDetailsItem timerItem = new RunDetailsItem.Builder()
+                .ionicon("timer-outline")
+                .text("Took " + run.getDurationString())
+                .build();
+
+        runDetailsItems.add(timerItem);
+
+        return runDetailsItems;
     }
-
-    RunDetailsItem timerItem =
-        new RunDetailsItem.Builder()
-            .ionicon("timer-outline")
-            .text("Took " + run.getDurationString())
-            .build();
-
-    runDetailsItems.add(timerItem);
-
-    return runDetailsItems;
-  }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -21,187 +21,185 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
-  public static final long LOG_THRESHOLD = 150 * 1024; // 150KB
+    public static final long LOG_THRESHOLD = 150 * 1024; // 150KB
 
-  private static final Logger logger = LoggerFactory.getLogger(PipelineConsoleViewAction.class);
-  private final WorkflowRun target;
-  private final PipelineStepApi stepApi;
+    private static final Logger logger = LoggerFactory.getLogger(PipelineConsoleViewAction.class);
+    private final WorkflowRun target;
+    private final PipelineStepApi stepApi;
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  public PipelineConsoleViewAction(WorkflowRun target) {
-    super(target);
-    this.target = target;
-    this.stepApi = new PipelineStepApi(target);
-  }
-
-  @Override
-  public String getDisplayName() {
-    return "Pipeline Console";
-  }
-
-  @Override
-  public String getUrlName() {
-    return "pipeline-console";
-  }
-
-  @Override
-  public String getIconClassName() {
-    return "symbol-terminal-outline plugin-ionicons-api";
-  }
-
-  // Legacy - leave in case we want to update a sub section of steps (e.g. if a stage is still
-  // running).
-  @GET
-  @WebMethod(name = "steps")
-  public HttpResponse getSteps(StaplerRequest req) throws IOException {
-    String nodeId = req.getParameter("nodeId");
-    if (nodeId != null) {
-      return HttpResponses.okJSON(getSteps(nodeId));
-    } else {
-      return HttpResponses.errorJSON("Error getting console text");
+    public PipelineConsoleViewAction(WorkflowRun target) {
+        super(target);
+        this.target = target;
+        this.stepApi = new PipelineStepApi(target);
     }
-  }
 
-  private JSONObject getSteps(String nodeId) throws IOException {
-    logger.debug("getSteps was passed nodeId '" + nodeId + "'.");
-    PipelineStepList steps = stepApi.getSteps(nodeId);
-    String stepsJson = MAPPER.writeValueAsString(steps);
-    if (logger.isDebugEnabled()) {
-      logger.debug("Steps: '" + stepsJson + "'.");
+    @Override
+    public String getDisplayName() {
+        return "Pipeline Console";
     }
-    return JSONObject.fromObject(stepsJson);
-  }
-  // Return all steps to:
-  // - reduce number of API calls
-  // - remove dependency of getting list of stages in frontend.
-  @GET
-  @WebMethod(name = "allSteps")
-  public HttpResponse getAllSteps(StaplerRequest req) throws IOException {
-    return HttpResponses.okJSON(getAllSteps());
-  }
 
-  // Private method for testing.
-  protected JSONObject getAllSteps() throws IOException {
-    PipelineStepList steps = stepApi.getAllSteps();
-    String stepsJson = MAPPER.writeValueAsString(steps);
-    if (logger.isDebugEnabled()) {
-      logger.debug("Steps: '" + stepsJson + "'.");
+    @Override
+    public String getUrlName() {
+        return "pipeline-console";
     }
-    return JSONObject.fromObject(stepsJson);
-  }
 
-  /*
-   * The default behavior of this functions differs from 'getConsoleOutput' in that it will use LOG_THRESHOLD from the end of the string.
-   * Note: if 'startByte' is negative and falls outside of the console text then we will start from byte 0.
-   * Example:
-   * {
-   *   "startByte": 0,
-   *   "endByte": 13,
-   *   "text": "Hello, world!"
-   * }
-   */
-  @GET
-  @WebMethod(name = "consoleOutput")
-  public HttpResponse getConsoleOutput(StaplerRequest req) throws IOException {
-    String nodeId = req.getParameter("nodeId");
-    if (nodeId == null) {
-      logger.error("'consoleJson' was not passed 'nodeId'.");
-      return HttpResponses.errorJSON("Error getting console json");
+    @Override
+    public String getIconClassName() {
+        return "symbol-terminal-outline plugin-ionicons-api";
     }
-    logger.debug("getConsoleOutput was passed node id '" + nodeId + "'.");
-    // This will be a step, so return it's log output.
-    // startByte to start getting data from. If negative will startByte from end of string with
-    // LOG_THRESHOLD.
-    Long startByte = parseIntWithDefault(req.getParameter("startByte"), -LOG_THRESHOLD);
-    JSONObject data = getConsoleOutputJson(nodeId, startByte);
-    if (data == null) {
-      return HttpResponses.errorJSON("Something went wrong - check Jenkins logs.");
-    }
-    return HttpResponses.okJSON(data);
-  }
 
-  protected JSONObject getConsoleOutputJson(String nodeId, Long requestStartByte)
-      throws IOException {
-    Long startByte = 0L;
-    long endByte = 0L;
-    long textLength;
-    String text = "";
-    AnnotatedLargeText<? extends FlowNode> logText = getLogForNode(nodeId);
-
-    if (logText != null) {
-      textLength = logText.length();
-      // positive startByte
-      if (requestStartByte > textLength) {
-        // Avoid resource leak.
-        logger.error("consoleJson - user requested startByte larger than console output.");
-        return null;
-      }
-      // if startByte is negative make sure we don't try and get a byte before 0.
-      if (requestStartByte < 0L) {
-        logger.debug("consoleJson - requested negative startByte '" + requestStartByte + "'.");
-        startByte = textLength + requestStartByte;
-        if (startByte < 0L) {
-          logger.debug(
-              "consoleJson - requested negative startByte '"
-                  + requestStartByte
-                  + "' out of bounds, starting at 0.");
-          startByte = 0L;
+    // Legacy - leave in case we want to update a sub section of steps (e.g. if a stage is still
+    // running).
+    @GET
+    @WebMethod(name = "steps")
+    public HttpResponse getSteps(StaplerRequest req) throws IOException {
+        String nodeId = req.getParameter("nodeId");
+        if (nodeId != null) {
+            return HttpResponses.okJSON(getSteps(nodeId));
+        } else {
+            return HttpResponses.errorJSON("Error getting console text");
         }
-      } else {
-        startByte = requestStartByte;
-      }
-      logger.debug("Returning '" + (textLength - startByte) + "' bytes from 'getConsoleOutput'.");
-      text = PipelineNodeUtil.convertLogToString(logText, startByte);
-      endByte = textLength;
     }
-    // If has an exception, return the exception text (inc. stacktrace).
-    if (isUnhandledException(nodeId)) {
-      // Set logText to exception text. This is a little hacky - maybe it would be better update the
-      // frontend to handle steps and exceptions differently?
-      text += getNodeExceptionText(nodeId);
-      endByte += text.length();
-    }
-    HashMap<String, Object> response = new HashMap<>();
-    response.put("text", text);
-    response.put("startByte", startByte);
-    response.put("endByte", endByte);
-    return JSONObject.fromObject(response);
-  }
 
-  private AnnotatedLargeText<? extends FlowNode> getLogForNode(String nodeId) throws IOException {
-    FlowExecution execution = target.getExecution();
-    if (execution != null) {
-      logger.debug("getLogForNode found execution.");
-      return PipelineNodeUtil.getLogText(execution.getNode(nodeId));
+    private JSONObject getSteps(String nodeId) throws IOException {
+        logger.debug("getSteps was passed nodeId '" + nodeId + "'.");
+        PipelineStepList steps = stepApi.getSteps(nodeId);
+        String stepsJson = MAPPER.writeValueAsString(steps);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Steps: '" + stepsJson + "'.");
+        }
+        return JSONObject.fromObject(stepsJson);
     }
-    return null;
-  }
+    // Return all steps to:
+    // - reduce number of API calls
+    // - remove dependency of getting list of stages in frontend.
+    @GET
+    @WebMethod(name = "allSteps")
+    public HttpResponse getAllSteps(StaplerRequest req) throws IOException {
+        return HttpResponses.okJSON(getAllSteps());
+    }
 
-  private String getNodeExceptionText(String nodeId) throws IOException {
-    FlowExecution execution = target.getExecution();
-    if (execution != null) {
-      logger.debug("getNodeException found execution.");
-      return PipelineNodeUtil.getExceptionText(execution.getNode(nodeId));
+    // Private method for testing.
+    protected JSONObject getAllSteps() throws IOException {
+        PipelineStepList steps = stepApi.getAllSteps();
+        String stepsJson = MAPPER.writeValueAsString(steps);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Steps: '" + stepsJson + "'.");
+        }
+        return JSONObject.fromObject(stepsJson);
     }
-    return null;
-  }
 
-  private boolean isUnhandledException(String nodeId) throws IOException {
-    FlowExecution execution = target.getExecution();
-    if (execution != null) {
-      return PipelineNodeUtil.isUnhandledException(execution.getNode(nodeId));
+    /*
+     * The default behavior of this functions differs from 'getConsoleOutput' in that it will use LOG_THRESHOLD from the end of the string.
+     * Note: if 'startByte' is negative and falls outside of the console text then we will start from byte 0.
+     * Example:
+     * {
+     *   "startByte": 0,
+     *   "endByte": 13,
+     *   "text": "Hello, world!"
+     * }
+     */
+    @GET
+    @WebMethod(name = "consoleOutput")
+    public HttpResponse getConsoleOutput(StaplerRequest req) throws IOException {
+        String nodeId = req.getParameter("nodeId");
+        if (nodeId == null) {
+            logger.error("'consoleJson' was not passed 'nodeId'.");
+            return HttpResponses.errorJSON("Error getting console json");
+        }
+        logger.debug("getConsoleOutput was passed node id '" + nodeId + "'.");
+        // This will be a step, so return it's log output.
+        // startByte to start getting data from. If negative will startByte from end of string with
+        // LOG_THRESHOLD.
+        Long startByte = parseIntWithDefault(req.getParameter("startByte"), -LOG_THRESHOLD);
+        JSONObject data = getConsoleOutputJson(nodeId, startByte);
+        if (data == null) {
+            return HttpResponses.errorJSON("Something went wrong - check Jenkins logs.");
+        }
+        return HttpResponses.okJSON(data);
     }
-    return false;
-  }
 
-  private static long parseIntWithDefault(String s, long defaultValue) {
-    try {
-      logger.debug("Parsing user provided value of '" + s + "'");
-      return Long.parseLong(s);
-    } catch (NumberFormatException e) {
-      logger.debug("Using default value of '" + defaultValue + "'");
-      return defaultValue;
+    protected JSONObject getConsoleOutputJson(String nodeId, Long requestStartByte) throws IOException {
+        Long startByte = 0L;
+        long endByte = 0L;
+        long textLength;
+        String text = "";
+        AnnotatedLargeText<? extends FlowNode> logText = getLogForNode(nodeId);
+
+        if (logText != null) {
+            textLength = logText.length();
+            // positive startByte
+            if (requestStartByte > textLength) {
+                // Avoid resource leak.
+                logger.error("consoleJson - user requested startByte larger than console output.");
+                return null;
+            }
+            // if startByte is negative make sure we don't try and get a byte before 0.
+            if (requestStartByte < 0L) {
+                logger.debug("consoleJson - requested negative startByte '" + requestStartByte + "'.");
+                startByte = textLength + requestStartByte;
+                if (startByte < 0L) {
+                    logger.debug("consoleJson - requested negative startByte '"
+                            + requestStartByte
+                            + "' out of bounds, starting at 0.");
+                    startByte = 0L;
+                }
+            } else {
+                startByte = requestStartByte;
+            }
+            logger.debug("Returning '" + (textLength - startByte) + "' bytes from 'getConsoleOutput'.");
+            text = PipelineNodeUtil.convertLogToString(logText, startByte);
+            endByte = textLength;
+        }
+        // If has an exception, return the exception text (inc. stacktrace).
+        if (isUnhandledException(nodeId)) {
+            // Set logText to exception text. This is a little hacky - maybe it would be better update the
+            // frontend to handle steps and exceptions differently?
+            text += getNodeExceptionText(nodeId);
+            endByte += text.length();
+        }
+        HashMap<String, Object> response = new HashMap<>();
+        response.put("text", text);
+        response.put("startByte", startByte);
+        response.put("endByte", endByte);
+        return JSONObject.fromObject(response);
     }
-  }
+
+    private AnnotatedLargeText<? extends FlowNode> getLogForNode(String nodeId) throws IOException {
+        FlowExecution execution = target.getExecution();
+        if (execution != null) {
+            logger.debug("getLogForNode found execution.");
+            return PipelineNodeUtil.getLogText(execution.getNode(nodeId));
+        }
+        return null;
+    }
+
+    private String getNodeExceptionText(String nodeId) throws IOException {
+        FlowExecution execution = target.getExecution();
+        if (execution != null) {
+            logger.debug("getNodeException found execution.");
+            return PipelineNodeUtil.getExceptionText(execution.getNode(nodeId));
+        }
+        return null;
+    }
+
+    private boolean isUnhandledException(String nodeId) throws IOException {
+        FlowExecution execution = target.getExecution();
+        if (execution != null) {
+            return PipelineNodeUtil.isUnhandledException(execution.getNode(nodeId));
+        }
+        return false;
+    }
+
+    private static long parseIntWithDefault(String s, long defaultValue) {
+        try {
+            logger.debug("Parsing user provided value of '" + s + "'");
+            return Long.parseLong(s);
+        } catch (NumberFormatException e) {
+            logger.debug("Using default value of '" + defaultValue + "'");
+            return defaultValue;
+        }
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionFactory.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionFactory.java
@@ -11,15 +11,15 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 @Extension
 public class PipelineConsoleViewActionFactory extends TransientActionFactory<WorkflowRun> {
 
-  @Override
-  public Class<WorkflowRun> type() {
-    return WorkflowRun.class;
-  }
+    @Override
+    public Class<WorkflowRun> type() {
+        return WorkflowRun.class;
+    }
 
-  @NonNull
-  @Override
-  public Collection<? extends Action> createFor(@NonNull WorkflowRun target) {
-    PipelineConsoleViewAction a = new PipelineConsoleViewAction(target);
-    return Collections.singleton(a);
-  }
+    @NonNull
+    @Override
+    public Collection<? extends Action> createFor(@NonNull WorkflowRun target) {
+        PipelineConsoleViewAction a = new PipelineConsoleViewAction(target);
+        return Collections.singleton(a);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction.java
@@ -21,81 +21,81 @@ import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.verb.GET;
 
 public class MultiPipelineGraphViewAction implements Action, IconSpec {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  private static final int MaxNumberOfElements = 10;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final int MaxNumberOfElements = 10;
 
-  private final WorkflowJob target;
+    private final WorkflowJob target;
 
-  public MultiPipelineGraphViewAction(WorkflowJob target) {
-    this.target = target;
-  }
-
-  public String getJobDisplayName() {
-    return target.getFullDisplayName();
-  }
-
-  public boolean isBuildable() {
-    return target.isBuildable();
-  }
-
-  public Permission getPermission() {
-    return target.BUILD;
-  }
-
-  public Permission getConfigurePermission() {
-    return target.CONFIGURE;
-  }
-
-  @GET
-  @WebMethod(name = "tree")
-  public HttpResponse getGraph(StaplerRequest req) throws JsonProcessingException {
-    String runId = req.getParameter("runId");
-    WorkflowRun run = target.getBuildByNumber(Integer.parseInt(runId));
-    PipelineGraphApi api = new PipelineGraphApi(run);
-    JSONObject graph = createGraphJson(api.createTree());
-    return HttpResponses.okJSON(graph);
-  }
-
-  protected JSONObject createGraphJson(PipelineGraph pipelineGraph) throws JsonProcessingException {
-    String graph = OBJECT_MAPPER.writeValueAsString(pipelineGraph);
-    return JSONObject.fromObject(graph);
-  }
-
-  @GET
-  @WebMethod(name = "runs")
-  public HttpResponse getRuns() throws JsonProcessingException {
-    RunList<WorkflowRun> runs = target.getBuilds();
-    List<PipelineRun> pipelineRuns = new ArrayList<>();
-    for (WorkflowRun run : runs) {
-      pipelineRuns.add(new PipelineRun(run));
-      if (pipelineRuns.size() >= MaxNumberOfElements) break;
+    public MultiPipelineGraphViewAction(WorkflowJob target) {
+        this.target = target;
     }
-    JSONArray graph = createJson(pipelineRuns);
-    return HttpResponses.okJSON(graph);
-  }
 
-  protected JSONArray createJson(List<PipelineRun> pipelineRuns) throws JsonProcessingException {
-    String graph = OBJECT_MAPPER.writeValueAsString(pipelineRuns);
-    return JSONArray.fromObject(graph);
-  }
+    public String getJobDisplayName() {
+        return target.getFullDisplayName();
+    }
 
-  @Override
-  public String getIconFileName() {
-    return null;
-  }
+    public boolean isBuildable() {
+        return target.isBuildable();
+    }
 
-  @Override
-  public String getDisplayName() {
-    return "Stages";
-  }
+    public Permission getPermission() {
+        return target.BUILD;
+    }
 
-  @Override
-  public String getUrlName() {
-    return "multi-pipeline-graph";
-  }
+    public Permission getConfigurePermission() {
+        return target.CONFIGURE;
+    }
 
-  @Override
-  public String getIconClassName() {
-    return "symbol-layers-outline plugin-ionicons-api";
-  }
+    @GET
+    @WebMethod(name = "tree")
+    public HttpResponse getGraph(StaplerRequest req) throws JsonProcessingException {
+        String runId = req.getParameter("runId");
+        WorkflowRun run = target.getBuildByNumber(Integer.parseInt(runId));
+        PipelineGraphApi api = new PipelineGraphApi(run);
+        JSONObject graph = createGraphJson(api.createTree());
+        return HttpResponses.okJSON(graph);
+    }
+
+    protected JSONObject createGraphJson(PipelineGraph pipelineGraph) throws JsonProcessingException {
+        String graph = OBJECT_MAPPER.writeValueAsString(pipelineGraph);
+        return JSONObject.fromObject(graph);
+    }
+
+    @GET
+    @WebMethod(name = "runs")
+    public HttpResponse getRuns() throws JsonProcessingException {
+        RunList<WorkflowRun> runs = target.getBuilds();
+        List<PipelineRun> pipelineRuns = new ArrayList<>();
+        for (WorkflowRun run : runs) {
+            pipelineRuns.add(new PipelineRun(run));
+            if (pipelineRuns.size() >= MaxNumberOfElements) break;
+        }
+        JSONArray graph = createJson(pipelineRuns);
+        return HttpResponses.okJSON(graph);
+    }
+
+    protected JSONArray createJson(List<PipelineRun> pipelineRuns) throws JsonProcessingException {
+        String graph = OBJECT_MAPPER.writeValueAsString(pipelineRuns);
+        return JSONArray.fromObject(graph);
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Stages";
+    }
+
+    @Override
+    public String getUrlName() {
+        return "multi-pipeline-graph";
+    }
+
+    @Override
+    public String getIconClassName() {
+        return "symbol-layers-outline plugin-ionicons-api";
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewActionFactory.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewActionFactory.java
@@ -11,15 +11,15 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 @Extension
 public class MultiPipelineGraphViewActionFactory extends TransientActionFactory<WorkflowJob> {
 
-  @Override
-  public Class<WorkflowJob> type() {
-    return WorkflowJob.class;
-  }
+    @Override
+    public Class<WorkflowJob> type() {
+        return WorkflowJob.class;
+    }
 
-  @NonNull
-  @Override
-  public Collection<? extends Action> createFor(@NonNull WorkflowJob target) {
-    MultiPipelineGraphViewAction a = new MultiPipelineGraphViewAction(target);
-    return Collections.singleton(a);
-  }
+    @NonNull
+    @Override
+    public Collection<? extends Action> createFor(@NonNull WorkflowJob target) {
+        MultiPipelineGraphViewAction a = new MultiPipelineGraphViewAction(target);
+        return Collections.singleton(a);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/PipelineRun.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/PipelineRun.java
@@ -4,19 +4,19 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 public class PipelineRun {
 
-  private String id;
-  private String displayName;
+    private String id;
+    private String displayName;
 
-  public PipelineRun(WorkflowRun run) {
-    this.id = run.getId();
-    this.displayName = run.getDisplayName();
-  }
+    public PipelineRun(WorkflowRun run) {
+        this.id = run.getId();
+        this.displayName = run.getDisplayName();
+    }
 
-  public String getId() {
-    return id;
-  }
+    public String getId() {
+        return id;
+    }
 
-  public String getDisplayName() {
-    return displayName;
-  }
+    public String getDisplayName() {
+        return displayName;
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -18,119 +18,118 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.WebMethod;
 
 public abstract class AbstractPipelineViewAction implements Action, IconSpec {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  private static final Logger LOGGER = Logger.getLogger(AbstractPipelineViewAction.class.getName());
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Logger LOGGER = Logger.getLogger(AbstractPipelineViewAction.class.getName());
 
-  protected final transient PipelineGraphApi api;
-  protected final transient WorkflowRun run;
+    protected final transient PipelineGraphApi api;
+    protected final transient WorkflowRun run;
 
-  public AbstractPipelineViewAction(WorkflowRun target) {
-    this.api = new PipelineGraphApi(target);
-    this.run = target;
-  }
-
-  public boolean isBuildable() {
-    return run.getParent().isBuildable();
-  }
-
-  public Permission getPermission() {
-    return run.getParent().BUILD;
-  }
-
-  public Permission getConfigurePermission() {
-    return run.getParent().CONFIGURE;
-  }
-
-  public String getBuildDisplayName() {
-    return run.getDisplayName();
-  }
-
-  public String getFullBuildDisplayName() {
-    return run.getFullDisplayName();
-  }
-
-  public String getFullProjectDisplayName() {
-    return run.getParent().getFullDisplayName();
-  }
-
-  private String getBuildNumber(WorkflowRun run) {
-    if (run != null) {
-      return String.valueOf(run.getNumber());
-    }
-    return null;
-  }
-
-  public String getPreviousBuildNumber() {
-    return getBuildNumber(run.getPreviousBuild());
-  }
-
-  public String getNextBuildNumber() {
-    return getBuildNumber(run.getNextBuild());
-  }
-
-  public BallColor getIconColor() {
-    return run.getIconColor();
-  }
-
-  public String getBuildStatusIconClassName() {
-    return run.getBuildStatusIconClassName();
-  }
-
-  protected JSONObject createJson(PipelineGraph pipelineGraph) throws JsonProcessingException {
-    String graph = OBJECT_MAPPER.writeValueAsString(pipelineGraph);
-    return JSONObject.fromObject(graph);
-  }
-
-  @WebMethod(name = "tree")
-  public HttpResponse getTree() throws JsonProcessingException {
-    JSONObject graph = createJson(api.createTree());
-
-    return HttpResponses.okJSON(graph);
-  }
-
-  @WebMethod(name = "replay")
-  public HttpResponse replayRun(StaplerRequest req) {
-
-    JSONObject result = new JSONObject();
-
-    Integer estimatedNextBuildNumber;
-    try {
-      estimatedNextBuildNumber = api.replay();
-    } catch (ExecutionException | InterruptedException | TimeoutException e) {
-      LOGGER.log(Level.SEVERE, "Failed to queue item", e);
-      return HttpResponses.errorJSON("failed to queue item: " + e.getMessage());
+    public AbstractPipelineViewAction(WorkflowRun target) {
+        this.api = new PipelineGraphApi(target);
+        this.run = target;
     }
 
-    if (estimatedNextBuildNumber == null) {
-      return HttpResponses.errorJSON("failed to get next build number");
+    public boolean isBuildable() {
+        return run.getParent().isBuildable();
     }
 
-    result.put(
-        "url",
-        appendTrailingSlashIfRequired(req.getContextPath())
-            + run.getUrl()
-                .replace("/" + run.getNumber() + "/", "/" + estimatedNextBuildNumber + "/")
-            + "pipeline-graph/");
-
-    result.put("success", true);
-    return HttpResponses.okJSON(result);
-  }
-
-  private static String appendTrailingSlashIfRequired(String string) {
-    if (string.endsWith("/")) {
-      return string;
+    public Permission getPermission() {
+        return run.getParent().BUILD;
     }
 
-    return string + "/";
-  }
+    public Permission getConfigurePermission() {
+        return run.getParent().CONFIGURE;
+    }
 
-  @Override
-  public String getIconFileName() {
-    return null;
-  }
+    public String getBuildDisplayName() {
+        return run.getDisplayName();
+    }
 
-  @Override
-  public String getIconClassName() {
-    return "symbol-file-tray-stacked-outline plugin-ionicons-api";
-  }
+    public String getFullBuildDisplayName() {
+        return run.getFullDisplayName();
+    }
+
+    public String getFullProjectDisplayName() {
+        return run.getParent().getFullDisplayName();
+    }
+
+    private String getBuildNumber(WorkflowRun run) {
+        if (run != null) {
+            return String.valueOf(run.getNumber());
+        }
+        return null;
+    }
+
+    public String getPreviousBuildNumber() {
+        return getBuildNumber(run.getPreviousBuild());
+    }
+
+    public String getNextBuildNumber() {
+        return getBuildNumber(run.getNextBuild());
+    }
+
+    public BallColor getIconColor() {
+        return run.getIconColor();
+    }
+
+    public String getBuildStatusIconClassName() {
+        return run.getBuildStatusIconClassName();
+    }
+
+    protected JSONObject createJson(PipelineGraph pipelineGraph) throws JsonProcessingException {
+        String graph = OBJECT_MAPPER.writeValueAsString(pipelineGraph);
+        return JSONObject.fromObject(graph);
+    }
+
+    @WebMethod(name = "tree")
+    public HttpResponse getTree() throws JsonProcessingException {
+        JSONObject graph = createJson(api.createTree());
+
+        return HttpResponses.okJSON(graph);
+    }
+
+    @WebMethod(name = "replay")
+    public HttpResponse replayRun(StaplerRequest req) {
+
+        JSONObject result = new JSONObject();
+
+        Integer estimatedNextBuildNumber;
+        try {
+            estimatedNextBuildNumber = api.replay();
+        } catch (ExecutionException | InterruptedException | TimeoutException e) {
+            LOGGER.log(Level.SEVERE, "Failed to queue item", e);
+            return HttpResponses.errorJSON("failed to queue item: " + e.getMessage());
+        }
+
+        if (estimatedNextBuildNumber == null) {
+            return HttpResponses.errorJSON("failed to get next build number");
+        }
+
+        result.put(
+                "url",
+                appendTrailingSlashIfRequired(req.getContextPath())
+                        + run.getUrl().replace("/" + run.getNumber() + "/", "/" + estimatedNextBuildNumber + "/")
+                        + "pipeline-graph/");
+
+        result.put("success", true);
+        return HttpResponses.okJSON(result);
+    }
+
+    private static String appendTrailingSlashIfRequired(String string) {
+        if (string.endsWith("/")) {
+            return string;
+        }
+
+        return string + "/";
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getIconClassName() {
+        return "symbol-file-tray-stacked-outline plugin-ionicons-api";
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/BlueRun.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/BlueRun.java
@@ -1,33 +1,33 @@
 package io.jenkins.plugins.pipelinegraphview.utils;
 
 public class BlueRun {
-  public enum BlueRunState {
-    QUEUED,
-    RUNNING,
-    PAUSED,
-    SKIPPED,
-    NOT_BUILT,
-    FINISHED
-  }
+    public enum BlueRunState {
+        QUEUED,
+        RUNNING,
+        PAUSED,
+        SKIPPED,
+        NOT_BUILT,
+        FINISHED
+    }
 
-  public enum BlueRunResult {
-    /** Build completed successfully */
-    SUCCESS,
+    public enum BlueRunResult {
+        /** Build completed successfully */
+        SUCCESS,
 
-    UNSTABLE,
+        UNSTABLE,
 
-    /** Build failed */
-    FAILURE,
+        /** Build failed */
+        FAILURE,
 
-    /**
-     * In multi stage build (maven2), a build step might not execute due to failure in previous step
-     */
-    NOT_BUILT,
+        /**
+         * In multi stage build (maven2), a build step might not execute due to failure in previous step
+         */
+        NOT_BUILT,
 
-    /** Unknown status */
-    UNKNOWN,
+        /** Unknown status */
+        UNKNOWN,
 
-    /** Aborted run */
-    ABORTED,
-  }
+        /** Aborted run */
+        ABORTED,
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/FlowNodeWrapper.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/FlowNodeWrapper.java
@@ -23,278 +23,278 @@ import org.jenkinsci.plugins.workflow.support.steps.input.InputStep;
 /** @author Vivek Pandey */
 public class FlowNodeWrapper {
 
-  /**
-   * Checks to see if `this` and `that` probably represent the same underlying pipeline graph node
-   * as far as the user is concerned. This is sloppier than an exact name and ID match because
-   * {@link PipelineNodeGraphVisitor} as of 2019-05-17 can return some nodes with different IDs
-   * during a build as opposed to once the build is complete. As such we check name, type, and
-   * firstParent. But we need to check firstParent the same way for the same reason.
-   *
-   * @param that
-   * @return
-   */
-  public boolean probablySameNode(@Nullable FlowNodeWrapper that) {
+    /**
+     * Checks to see if `this` and `that` probably represent the same underlying pipeline graph node
+     * as far as the user is concerned. This is sloppier than an exact name and ID match because
+     * {@link PipelineNodeGraphVisitor} as of 2019-05-17 can return some nodes with different IDs
+     * during a build as opposed to once the build is complete. As such we check name, type, and
+     * firstParent. But we need to check firstParent the same way for the same reason.
+     *
+     * @param that
+     * @return
+     */
+    public boolean probablySameNode(@Nullable FlowNodeWrapper that) {
 
-    if (that == null) {
-      return false;
+        if (that == null) {
+            return false;
+        }
+
+        if (this.type != that.type) {
+            return false;
+        }
+
+        if (!this.displayName.equals(that.displayName)) {
+            return false;
+        }
+
+        final FlowNodeWrapper thisParent = this.getFirstParent();
+        if (thisParent != null) {
+            return thisParent.probablySameNode(that.getFirstParent());
+        } else {
+            return that.getFirstParent() == null;
+        }
     }
 
-    if (this.type != that.type) {
-      return false;
+    public enum NodeType {
+        STAGE,
+        PARALLEL,
+        STEP,
+        UNHANDLED_EXCEPTION,
     }
 
-    if (!this.displayName.equals(that.displayName)) {
-      return false;
+    private final FlowNode node;
+    private final NodeRunStatus status;
+    private final TimingInfo timingInfo;
+    public final List<FlowNodeWrapper> edges = new ArrayList<>();
+    public final NodeType type;
+    private final String displayName;
+    private final InputStep inputStep;
+    private final WorkflowRun run;
+    private String causeOfFailure;
+
+    private List<FlowNodeWrapper> parents = new ArrayList<>();
+
+    private ErrorAction blockErrorAction;
+    private Collection<Action> pipelineActions;
+
+    public FlowNodeWrapper(
+            @NonNull FlowNode node,
+            @NonNull NodeRunStatus status,
+            @NonNull TimingInfo timingInfo,
+            @NonNull WorkflowRun run) {
+        this(node, status, timingInfo, null, run);
     }
 
-    final FlowNodeWrapper thisParent = this.getFirstParent();
-    if (thisParent != null) {
-      return thisParent.probablySameNode(that.getFirstParent());
-    } else {
-      return that.getFirstParent() == null;
+    public FlowNodeWrapper(
+            @NonNull FlowNode node,
+            @NonNull NodeRunStatus status,
+            @NonNull TimingInfo timingInfo,
+            @Nullable InputStep inputStep,
+            @NonNull WorkflowRun run) {
+        this.node = node;
+        this.status = status;
+        this.timingInfo = timingInfo;
+        this.type = getNodeType(node);
+        this.displayName = PipelineNodeUtil.getDisplayName(node);
+        this.inputStep = inputStep;
+        this.run = run;
     }
-  }
 
-  public enum NodeType {
-    STAGE,
-    PARALLEL,
-    STEP,
-    UNHANDLED_EXCEPTION,
-  }
-
-  private final FlowNode node;
-  private final NodeRunStatus status;
-  private final TimingInfo timingInfo;
-  public final List<FlowNodeWrapper> edges = new ArrayList<>();
-  public final NodeType type;
-  private final String displayName;
-  private final InputStep inputStep;
-  private final WorkflowRun run;
-  private String causeOfFailure;
-
-  private List<FlowNodeWrapper> parents = new ArrayList<>();
-
-  private ErrorAction blockErrorAction;
-  private Collection<Action> pipelineActions;
-
-  public FlowNodeWrapper(
-      @NonNull FlowNode node,
-      @NonNull NodeRunStatus status,
-      @NonNull TimingInfo timingInfo,
-      @NonNull WorkflowRun run) {
-    this(node, status, timingInfo, null, run);
-  }
-
-  public FlowNodeWrapper(
-      @NonNull FlowNode node,
-      @NonNull NodeRunStatus status,
-      @NonNull TimingInfo timingInfo,
-      @Nullable InputStep inputStep,
-      @NonNull WorkflowRun run) {
-    this.node = node;
-    this.status = status;
-    this.timingInfo = timingInfo;
-    this.type = getNodeType(node);
-    this.displayName = PipelineNodeUtil.getDisplayName(node);
-    this.inputStep = inputStep;
-    this.run = run;
-  }
-
-  public WorkflowRun getRun() {
-    return run;
-  }
-
-  public @NonNull String getDisplayName() {
-    return displayName;
-  }
-
-  public @CheckForNull String getLabelDisplayName() {
-    LabelAction labelAction = node.getAction(LabelAction.class);
-    if (labelAction != null) {
-      return labelAction.getDisplayName();
+    public WorkflowRun getRun() {
+        return run;
     }
-    return null;
-  }
 
-  private static NodeType getNodeType(FlowNode node) {
-    if (PipelineNodeUtil.isStage(node)) {
-      return NodeType.STAGE;
-    } else if (PipelineNodeUtil.isParallelBranch(node)) {
-      return NodeType.PARALLEL;
-    } else if (node instanceof AtomNode) {
-      return NodeType.STEP;
-    } else if (PipelineNodeUtil.isUnhandledException(node)) {
-      return NodeType.UNHANDLED_EXCEPTION;
+    public @NonNull String getDisplayName() {
+        return displayName;
     }
-    throw new IllegalArgumentException(
-        String.format("Unknown FlowNode %s, type: %s", node.getId(), node.getClass()));
-  }
 
-  public @NonNull NodeRunStatus getStatus() {
-    if (hasBlockError()) {
-      if (isBlockErrorInterruptedWithAbort()) {
-        return new NodeRunStatus(BlueRunResult.ABORTED, BlueRunState.FINISHED);
-      } else {
-        return new NodeRunStatus(BlueRunResult.FAILURE, BlueRunState.FINISHED);
-      }
+    public @CheckForNull String getLabelDisplayName() {
+        LabelAction labelAction = node.getAction(LabelAction.class);
+        if (labelAction != null) {
+            return labelAction.getDisplayName();
+        }
+        return null;
     }
-    return status;
-  }
 
-  public @NonNull TimingInfo getTiming() {
-    return timingInfo;
-  }
-
-  public @NonNull String getId() {
-    return node.getId();
-  }
-
-  public @NonNull FlowNode getNode() {
-    return node;
-  }
-
-  public NodeType getType() {
-    return type;
-  }
-
-  public void addEdge(FlowNodeWrapper edge) {
-    this.edges.add(edge);
-  }
-
-  public void addEdges(List<FlowNodeWrapper> edges) {
-    this.edges.addAll(edges);
-  }
-
-  public void addParent(FlowNodeWrapper parent) {
-    parents.add(parent);
-  }
-
-  public void addParents(Collection<FlowNodeWrapper> parents) {
-    this.parents.addAll(parents);
-  }
-
-  public @CheckForNull FlowNodeWrapper getFirstParent() {
-    return parents.size() > 0 ? parents.get(0) : null;
-  }
-
-  public @NonNull List<FlowNodeWrapper> getParents() {
-    return parents;
-  }
-
-  public String getCauseOfFailure() {
-    return causeOfFailure;
-  }
-
-  public void setCauseOfFailure(String causeOfFailure) {
-    this.causeOfFailure = causeOfFailure;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (!(obj instanceof FlowNodeWrapper)) {
-      return false;
+    private static NodeType getNodeType(FlowNode node) {
+        if (PipelineNodeUtil.isStage(node)) {
+            return NodeType.STAGE;
+        } else if (PipelineNodeUtil.isParallelBranch(node)) {
+            return NodeType.PARALLEL;
+        } else if (node instanceof AtomNode) {
+            return NodeType.STEP;
+        } else if (PipelineNodeUtil.isUnhandledException(node)) {
+            return NodeType.UNHANDLED_EXCEPTION;
+        }
+        throw new IllegalArgumentException(
+                String.format("Unknown FlowNode %s, type: %s", node.getId(), node.getClass()));
     }
-    return node.equals(((FlowNodeWrapper) obj).node);
-  }
 
-  public @CheckForNull InputStep getInputStep() {
-    return inputStep;
-  }
-
-  @Override
-  public int hashCode() {
-    return node.hashCode();
-  }
-
-  @Override
-  public String toString() {
-    return getClass().getName()
-        + "[id="
-        + node.getId()
-        + ",displayName="
-        + this.displayName
-        + ",type="
-        + this.type
-        + "]";
-  }
-
-  boolean hasBlockError() {
-    return blockErrorAction != null && blockErrorAction.getError() != null;
-  }
-
-  String blockError() {
-    if (hasBlockError()) {
-      return blockErrorAction.getError().getMessage();
+    public @NonNull NodeRunStatus getStatus() {
+        if (hasBlockError()) {
+            if (isBlockErrorInterruptedWithAbort()) {
+                return new NodeRunStatus(BlueRunResult.ABORTED, BlueRunState.FINISHED);
+            } else {
+                return new NodeRunStatus(BlueRunResult.FAILURE, BlueRunState.FINISHED);
+            }
+        }
+        return status;
     }
-    return null;
-  }
 
-  @CheckForNull
-  String nodeError() {
-    ErrorAction errorAction = node.getError();
-    if (errorAction != null) {
-      return errorAction.getError().getMessage();
+    public @NonNull TimingInfo getTiming() {
+        return timingInfo;
     }
-    return null;
-  }
 
-  boolean isBlockErrorInterruptedWithAbort() {
-    if (hasBlockError()) {
-      Throwable error = blockErrorAction.getError();
-      if (error instanceof FlowInterruptedException) {
-        FlowInterruptedException interrupted = (FlowInterruptedException) error;
-        return interrupted.getResult().equals(Result.ABORTED);
-      }
+    public @NonNull String getId() {
+        return node.getId();
     }
-    return false;
-  }
 
-  boolean isLoggable() {
-    return PipelineNodeUtil.isLoggable.apply(node);
-  }
-
-  public void setBlockErrorAction(ErrorAction blockErrorAction) {
-    this.blockErrorAction = blockErrorAction;
-  }
-
-  /**
-   * Returns Action instances that were attached to the associated FlowNode, or to any of its
-   * children not represented in the graph. Filters by class to mimic Item.getActions(class).
-   */
-  public <T extends Action> Collection<T> getPipelineActions(Class<T> clazz) {
-    if (pipelineActions == null) {
-      return Collections.emptyList();
+    public @NonNull FlowNode getNode() {
+        return node;
     }
-    ArrayList<T> filtered = new ArrayList<>();
-    for (Action a : pipelineActions) {
-      if (clazz.isInstance(a)) {
-        filtered.add(clazz.cast(a));
-      }
+
+    public NodeType getType() {
+        return type;
     }
-    return filtered;
-  }
 
-  /**
-   * Returns Action instances that were attached to the associated FlowNode, or to any of its
-   * children not represented in the graph.
-   */
-  public Collection<Action> getPipelineActions() {
-    return Collections.unmodifiableCollection(this.pipelineActions);
-  }
+    public void addEdge(FlowNodeWrapper edge) {
+        this.edges.add(edge);
+    }
 
-  public void setPipelineActions(Collection<Action> pipelineActions) {
-    this.pipelineActions = pipelineActions;
-  }
+    public void addEdges(List<FlowNodeWrapper> edges) {
+        this.edges.addAll(edges);
+    }
 
-  public String getArgumentsAsString() {
-    return PipelineNodeUtil.getArgumentsAsString(node);
-  }
+    public void addParent(FlowNodeWrapper parent) {
+        parents.add(parent);
+    }
 
-  public boolean isSynthetic() {
-    return PipelineNodeUtil.isSyntheticStage(node);
-  }
+    public void addParents(Collection<FlowNodeWrapper> parents) {
+        this.parents.addAll(parents);
+    }
 
-  public boolean isUnhandledException() {
-    return PipelineNodeUtil.isUnhandledException(node);
-  }
+    public @CheckForNull FlowNodeWrapper getFirstParent() {
+        return parents.size() > 0 ? parents.get(0) : null;
+    }
+
+    public @NonNull List<FlowNodeWrapper> getParents() {
+        return parents;
+    }
+
+    public String getCauseOfFailure() {
+        return causeOfFailure;
+    }
+
+    public void setCauseOfFailure(String causeOfFailure) {
+        this.causeOfFailure = causeOfFailure;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof FlowNodeWrapper)) {
+            return false;
+        }
+        return node.equals(((FlowNodeWrapper) obj).node);
+    }
+
+    public @CheckForNull InputStep getInputStep() {
+        return inputStep;
+    }
+
+    @Override
+    public int hashCode() {
+        return node.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getName()
+                + "[id="
+                + node.getId()
+                + ",displayName="
+                + this.displayName
+                + ",type="
+                + this.type
+                + "]";
+    }
+
+    boolean hasBlockError() {
+        return blockErrorAction != null && blockErrorAction.getError() != null;
+    }
+
+    String blockError() {
+        if (hasBlockError()) {
+            return blockErrorAction.getError().getMessage();
+        }
+        return null;
+    }
+
+    @CheckForNull
+    String nodeError() {
+        ErrorAction errorAction = node.getError();
+        if (errorAction != null) {
+            return errorAction.getError().getMessage();
+        }
+        return null;
+    }
+
+    boolean isBlockErrorInterruptedWithAbort() {
+        if (hasBlockError()) {
+            Throwable error = blockErrorAction.getError();
+            if (error instanceof FlowInterruptedException) {
+                FlowInterruptedException interrupted = (FlowInterruptedException) error;
+                return interrupted.getResult().equals(Result.ABORTED);
+            }
+        }
+        return false;
+    }
+
+    boolean isLoggable() {
+        return PipelineNodeUtil.isLoggable.apply(node);
+    }
+
+    public void setBlockErrorAction(ErrorAction blockErrorAction) {
+        this.blockErrorAction = blockErrorAction;
+    }
+
+    /**
+     * Returns Action instances that were attached to the associated FlowNode, or to any of its
+     * children not represented in the graph. Filters by class to mimic Item.getActions(class).
+     */
+    public <T extends Action> Collection<T> getPipelineActions(Class<T> clazz) {
+        if (pipelineActions == null) {
+            return Collections.emptyList();
+        }
+        ArrayList<T> filtered = new ArrayList<>();
+        for (Action a : pipelineActions) {
+            if (clazz.isInstance(a)) {
+                filtered.add(clazz.cast(a));
+            }
+        }
+        return filtered;
+    }
+
+    /**
+     * Returns Action instances that were attached to the associated FlowNode, or to any of its
+     * children not represented in the graph.
+     */
+    public Collection<Action> getPipelineActions() {
+        return Collections.unmodifiableCollection(this.pipelineActions);
+    }
+
+    public void setPipelineActions(Collection<Action> pipelineActions) {
+        this.pipelineActions = pipelineActions;
+    }
+
+    public String getArgumentsAsString() {
+        return PipelineNodeUtil.getArgumentsAsString(node);
+    }
+
+    public boolean isSynthetic() {
+        return PipelineNodeUtil.isSyntheticStage(node);
+    }
+
+    public boolean isUnhandledException() {
+        return PipelineNodeUtil.isUnhandledException(node);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/NodeRunStatus.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/NodeRunStatus.java
@@ -13,102 +13,100 @@ import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 /** @author Vivek Pandey */
 public class NodeRunStatus {
 
-  public final BlueRun.BlueRunResult result;
-  public final BlueRun.BlueRunState state;
+    public final BlueRun.BlueRunResult result;
+    public final BlueRun.BlueRunState state;
 
-  public NodeRunStatus(@NonNull FlowNode endNode) {
-    Result result = null;
-    ErrorAction errorAction = endNode.getError();
-    WarningAction warningAction = endNode.getPersistentAction(WarningAction.class);
-    if (errorAction != null) {
-      if (errorAction.getError() instanceof FlowInterruptedException) {
-        result = ((FlowInterruptedException) errorAction.getError()).getResult();
-      }
-      if (result == null || result != Result.ABORTED) {
-        this.result = BlueRun.BlueRunResult.FAILURE;
-      } else {
-        this.result = BlueRun.BlueRunResult.ABORTED;
-      }
-      this.state =
-          endNode.isActive() ? BlueRun.BlueRunState.RUNNING : BlueRun.BlueRunState.FINISHED;
-    } else if (warningAction != null) {
-      this.result = new NodeRunStatus(GenericStatus.fromResult(warningAction.getResult())).result;
-      this.state =
-          endNode.isActive() ? BlueRun.BlueRunState.RUNNING : BlueRun.BlueRunState.FINISHED;
-    } else if (QueueItemAction.getNodeState(endNode) == QueueItemAction.QueueState.QUEUED) {
-      this.result = BlueRun.BlueRunResult.UNKNOWN;
-      this.state = BlueRun.BlueRunState.QUEUED;
-    } else if (QueueItemAction.getNodeState(endNode) == QueueItemAction.QueueState.CANCELLED) {
-      this.result = BlueRun.BlueRunResult.ABORTED;
-      this.state = BlueRun.BlueRunState.FINISHED;
-    } else if (endNode.isActive()) {
-      this.result = BlueRun.BlueRunResult.UNKNOWN;
-      this.state = BlueRun.BlueRunState.RUNNING;
-    } else if (NotExecutedNodeAction.isExecuted(endNode)) {
-      this.result = BlueRun.BlueRunResult.SUCCESS;
-      this.state = BlueRun.BlueRunState.FINISHED;
-    } else {
-      this.result = BlueRun.BlueRunResult.NOT_BUILT;
-      this.state = BlueRun.BlueRunState.QUEUED;
+    public NodeRunStatus(@NonNull FlowNode endNode) {
+        Result result = null;
+        ErrorAction errorAction = endNode.getError();
+        WarningAction warningAction = endNode.getPersistentAction(WarningAction.class);
+        if (errorAction != null) {
+            if (errorAction.getError() instanceof FlowInterruptedException) {
+                result = ((FlowInterruptedException) errorAction.getError()).getResult();
+            }
+            if (result == null || result != Result.ABORTED) {
+                this.result = BlueRun.BlueRunResult.FAILURE;
+            } else {
+                this.result = BlueRun.BlueRunResult.ABORTED;
+            }
+            this.state = endNode.isActive() ? BlueRun.BlueRunState.RUNNING : BlueRun.BlueRunState.FINISHED;
+        } else if (warningAction != null) {
+            this.result = new NodeRunStatus(GenericStatus.fromResult(warningAction.getResult())).result;
+            this.state = endNode.isActive() ? BlueRun.BlueRunState.RUNNING : BlueRun.BlueRunState.FINISHED;
+        } else if (QueueItemAction.getNodeState(endNode) == QueueItemAction.QueueState.QUEUED) {
+            this.result = BlueRun.BlueRunResult.UNKNOWN;
+            this.state = BlueRun.BlueRunState.QUEUED;
+        } else if (QueueItemAction.getNodeState(endNode) == QueueItemAction.QueueState.CANCELLED) {
+            this.result = BlueRun.BlueRunResult.ABORTED;
+            this.state = BlueRun.BlueRunState.FINISHED;
+        } else if (endNode.isActive()) {
+            this.result = BlueRun.BlueRunResult.UNKNOWN;
+            this.state = BlueRun.BlueRunState.RUNNING;
+        } else if (NotExecutedNodeAction.isExecuted(endNode)) {
+            this.result = BlueRun.BlueRunResult.SUCCESS;
+            this.state = BlueRun.BlueRunState.FINISHED;
+        } else {
+            this.result = BlueRun.BlueRunResult.NOT_BUILT;
+            this.state = BlueRun.BlueRunState.QUEUED;
+        }
     }
-  }
 
-  public NodeRunStatus(BlueRun.BlueRunResult result, BlueRun.BlueRunState state) {
-    this.result = result;
-    this.state = state;
-  }
-
-  public BlueRun.BlueRunResult getResult() {
-    return result;
-  }
-
-  public BlueRun.BlueRunState getState() {
-    return state;
-  }
-
-  public NodeRunStatus(GenericStatus status) {
-    if (status == null) {
-      this.result = BlueRun.BlueRunResult.NOT_BUILT;
-      this.state = BlueRun.BlueRunState.QUEUED;
-      return;
+    public NodeRunStatus(BlueRun.BlueRunResult result, BlueRun.BlueRunState state) {
+        this.result = result;
+        this.state = state;
     }
-    switch (status) {
-      case PAUSED_PENDING_INPUT:
-        this.result = BlueRun.BlueRunResult.UNKNOWN;
-        this.state = BlueRun.BlueRunState.PAUSED;
-        break;
-      case ABORTED:
-        this.result = BlueRun.BlueRunResult.ABORTED;
-        this.state = BlueRun.BlueRunState.FINISHED;
-        break;
-      case FAILURE:
-        this.result = BlueRun.BlueRunResult.FAILURE;
-        this.state = BlueRun.BlueRunState.FINISHED;
-        break;
-      case IN_PROGRESS:
-        this.result = BlueRun.BlueRunResult.UNKNOWN;
-        this.state = BlueRun.BlueRunState.RUNNING;
-        break;
-      case UNSTABLE:
-        this.result = BlueRun.BlueRunResult.UNSTABLE;
-        this.state = BlueRun.BlueRunState.FINISHED;
-        break;
-      case SUCCESS:
-        this.result = BlueRun.BlueRunResult.SUCCESS;
-        this.state = BlueRun.BlueRunState.FINISHED;
-        break;
-      case NOT_EXECUTED:
-        this.result = BlueRun.BlueRunResult.NOT_BUILT;
-        this.state = BlueRun.BlueRunState.NOT_BUILT;
-        break;
-      case QUEUED:
-        this.result = BlueRun.BlueRunResult.UNKNOWN;
-        this.state = BlueRun.BlueRunState.QUEUED;
-        break;
-      default:
-        // Shouldn't happen, above includes all statuses
-        this.result = BlueRun.BlueRunResult.NOT_BUILT;
-        this.state = BlueRun.BlueRunState.QUEUED;
+
+    public BlueRun.BlueRunResult getResult() {
+        return result;
     }
-  }
+
+    public BlueRun.BlueRunState getState() {
+        return state;
+    }
+
+    public NodeRunStatus(GenericStatus status) {
+        if (status == null) {
+            this.result = BlueRun.BlueRunResult.NOT_BUILT;
+            this.state = BlueRun.BlueRunState.QUEUED;
+            return;
+        }
+        switch (status) {
+            case PAUSED_PENDING_INPUT:
+                this.result = BlueRun.BlueRunResult.UNKNOWN;
+                this.state = BlueRun.BlueRunState.PAUSED;
+                break;
+            case ABORTED:
+                this.result = BlueRun.BlueRunResult.ABORTED;
+                this.state = BlueRun.BlueRunState.FINISHED;
+                break;
+            case FAILURE:
+                this.result = BlueRun.BlueRunResult.FAILURE;
+                this.state = BlueRun.BlueRunState.FINISHED;
+                break;
+            case IN_PROGRESS:
+                this.result = BlueRun.BlueRunResult.UNKNOWN;
+                this.state = BlueRun.BlueRunState.RUNNING;
+                break;
+            case UNSTABLE:
+                this.result = BlueRun.BlueRunResult.UNSTABLE;
+                this.state = BlueRun.BlueRunState.FINISHED;
+                break;
+            case SUCCESS:
+                this.result = BlueRun.BlueRunResult.SUCCESS;
+                this.state = BlueRun.BlueRunState.FINISHED;
+                break;
+            case NOT_EXECUTED:
+                this.result = BlueRun.BlueRunResult.NOT_BUILT;
+                this.state = BlueRun.BlueRunState.NOT_BUILT;
+                break;
+            case QUEUED:
+                this.result = BlueRun.BlueRunResult.UNKNOWN;
+                this.state = BlueRun.BlueRunState.QUEUED;
+                break;
+            default:
+                // Shouldn't happen, above includes all statuses
+                this.result = BlueRun.BlueRunResult.NOT_BUILT;
+                this.state = BlueRun.BlueRunState.QUEUED;
+        }
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraph.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraph.java
@@ -4,19 +4,19 @@ import java.util.List;
 
 public class PipelineGraph {
 
-  private List<PipelineStage> stages;
-  private boolean complete = false;
+    private List<PipelineStage> stages;
+    private boolean complete = false;
 
-  public PipelineGraph(List<PipelineStage> stages, boolean complete) {
-    this.stages = stages;
-    this.complete = complete;
-  }
+    public PipelineGraph(List<PipelineStage> stages, boolean complete) {
+        this.stages = stages;
+        this.complete = complete;
+    }
 
-  public boolean isComplete() {
-    return complete;
-  }
+    public boolean isComplete() {
+        return complete;
+    }
 
-  public List<PipelineStage> getStages() {
-    return stages;
-  }
+    public List<PipelineStage> getStages() {
+        return stages;
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
@@ -23,165 +23,154 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PipelineGraphApi {
-  private static final Logger logger = LoggerFactory.getLogger(PipelineStepApi.class);
-  private final transient WorkflowRun run;
+    private static final Logger logger = LoggerFactory.getLogger(PipelineStepApi.class);
+    private final transient WorkflowRun run;
 
-  public PipelineGraphApi(WorkflowRun run) {
-    this.run = run;
-  }
-
-  public Integer replay() throws ExecutionException, InterruptedException, TimeoutException {
-    run.checkPermission(Item.BUILD);
-
-    CauseAction causeAction = new CauseAction(new Cause.UserIdCause());
-
-    if (!run.getParent().isBuildable()) {
-      return null;
+    public PipelineGraphApi(WorkflowRun run) {
+        this.run = run;
     }
 
-    Queue.Item item = Queue.getInstance().schedule2(run.getParent(), 0, causeAction).getItem();
-    if (item == null) {
-      return null;
+    public Integer replay() throws ExecutionException, InterruptedException, TimeoutException {
+        run.checkPermission(Item.BUILD);
+
+        CauseAction causeAction = new CauseAction(new Cause.UserIdCause());
+
+        if (!run.getParent().isBuildable()) {
+            return null;
+        }
+
+        Queue.Item item =
+                Queue.getInstance().schedule2(run.getParent(), 0, causeAction).getItem();
+        if (item == null) {
+            return null;
+        }
+
+        return run.getParent().getNextBuildNumber();
     }
 
-    return run.getParent().getNextBuildNumber();
-  }
+    private List<PipelineStageInternal> getPipelineNodes() {
+        PipelineNodeGraphVisitor builder = new PipelineNodeGraphVisitor(run);
+        return builder.getPipelineNodes().stream()
+                .map(flowNodeWrapper -> {
+                    String state = flowNodeWrapper.getStatus().getResult().name();
+                    // TODO: Why do we do this? Seems like it will return uppercase for some states and
+                    // lowercase for others?
+                    if (flowNodeWrapper.getStatus().getState() != BlueRun.BlueRunState.FINISHED) {
+                        state = flowNodeWrapper.getStatus().getState().name().toLowerCase(Locale.ROOT);
+                    }
 
-  private List<PipelineStageInternal> getPipelineNodes() {
-    PipelineNodeGraphVisitor builder = new PipelineNodeGraphVisitor(run);
-    return builder.getPipelineNodes().stream()
-        .map(
-            flowNodeWrapper -> {
-              String state = flowNodeWrapper.getStatus().getResult().name();
-              // TODO: Why do we do this? Seems like it will return uppercase for some states and
-              // lowercase for others?
-              if (flowNodeWrapper.getStatus().getState() != BlueRun.BlueRunState.FINISHED) {
-                state = flowNodeWrapper.getStatus().getState().name().toLowerCase(Locale.ROOT);
-              }
-
-              return new PipelineStageInternal(
-                  flowNodeWrapper
-                      .getId(), // TODO no need to parse it BO returns a string even though the
-                  // datatype is number on the frontend
-                  flowNodeWrapper.getDisplayName(),
-                  flowNodeWrapper.getParents().stream()
-                      .map(FlowNodeWrapper::getId)
-                      .collect(Collectors.toList()),
-                  state,
-                  50, // TODO how ???
-                  flowNodeWrapper.getType().name(),
-                  flowNodeWrapper
-                      .getDisplayName(), // TODO blue ocean uses timing information: "Passed in 0s"
-                  flowNodeWrapper.isSynthetic(),
-                  flowNodeWrapper.getTiming());
-            })
-        .collect(Collectors.toList());
-  }
-
-  private Function<String, PipelineStage> mapper(
-      Map<String, PipelineStageInternal> stageMap, Map<String, List<String>> stageToChildrenMap) {
-
-    return id -> {
-      List<String> orDefault = stageToChildrenMap.getOrDefault(id, emptyList());
-      List<PipelineStage> children =
-          orDefault.stream().map(mapper(stageMap, stageToChildrenMap)).collect(Collectors.toList());
-      return stageMap.get(id).toPipelineStage(children);
-    };
-  }
-
-  /*
-   * Create a Tree from the GraphVisitor.
-   * Original source: https://github.com/jenkinsci/workflow-support-plugin/blob/master/src/main/java/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable.java#L126
-   */
-  public PipelineGraph createTree() {
-    List<PipelineStageInternal> stages = getPipelineNodes();
-    List<String> topLevelStageIds = new ArrayList<>();
-
-    // id => stage
-    Map<String, PipelineStageInternal> stageMap =
-        stages.stream()
-            .collect(
-                Collectors.toMap(
-                    PipelineStageInternal::getId, stage -> stage, (u, v) -> u, LinkedHashMap::new));
-
-    Map<String, List<String>> stageToChildrenMap = new HashMap<>();
-
-    FlowExecution execution = run.getExecution();
-    if (execution == null) {
-      // If we don't have an execution - e.g. if the Pipeline has a syntax error - then return an
-      // empty graph.
-      return new PipelineGraph(new ArrayList<>(), false);
+                    return new PipelineStageInternal(
+                            flowNodeWrapper.getId(), // TODO no need to parse it BO returns a string even though the
+                            // datatype is number on the frontend
+                            flowNodeWrapper.getDisplayName(),
+                            flowNodeWrapper.getParents().stream()
+                                    .map(FlowNodeWrapper::getId)
+                                    .collect(Collectors.toList()),
+                            state,
+                            50, // TODO how ???
+                            flowNodeWrapper.getType().name(),
+                            flowNodeWrapper.getDisplayName(), // TODO blue ocean uses timing information: "Passed in 0s"
+                            flowNodeWrapper.isSynthetic(),
+                            flowNodeWrapper.getTiming());
+                })
+                .collect(Collectors.toList());
     }
-    stages.forEach(
-        stage -> {
-          try {
-            FlowNode stageNode = execution.getNode(stage.getId());
-            if (stageNode == null) {
-              return;
+
+    private Function<String, PipelineStage> mapper(
+            Map<String, PipelineStageInternal> stageMap, Map<String, List<String>> stageToChildrenMap) {
+
+        return id -> {
+            List<String> orDefault = stageToChildrenMap.getOrDefault(id, emptyList());
+            List<PipelineStage> children =
+                    orDefault.stream().map(mapper(stageMap, stageToChildrenMap)).collect(Collectors.toList());
+            return stageMap.get(id).toPipelineStage(children);
+        };
+    }
+
+    /*
+     * Create a Tree from the GraphVisitor.
+     * Original source: https://github.com/jenkinsci/workflow-support-plugin/blob/master/src/main/java/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable.java#L126
+     */
+    public PipelineGraph createTree() {
+        List<PipelineStageInternal> stages = getPipelineNodes();
+        List<String> topLevelStageIds = new ArrayList<>();
+
+        // id => stage
+        Map<String, PipelineStageInternal> stageMap = stages.stream()
+                .collect(Collectors.toMap(
+                        PipelineStageInternal::getId, stage -> stage, (u, v) -> u, LinkedHashMap::new));
+
+        Map<String, List<String>> stageToChildrenMap = new HashMap<>();
+
+        FlowExecution execution = run.getExecution();
+        if (execution == null) {
+            // If we don't have an execution - e.g. if the Pipeline has a syntax error - then return an
+            // empty graph.
+            return new PipelineGraph(new ArrayList<>(), false);
+        }
+        stages.forEach(stage -> {
+            try {
+                FlowNode stageNode = execution.getNode(stage.getId());
+                if (stageNode == null) {
+                    return;
+                }
+                List<String> ancestors = getAncestors(stage, stageMap);
+                String treeParentId = null;
+                // Compare the list of GraphVistor ancestors to the IDs of the enclosing node in the
+                // execution.
+                // If a node encloses another node, it means it's a tree parent, so the first ancestor
+                // ID we find
+                // which matches an enclosing node then it's the stages tree parent.
+                List<String> enclosingIds = stageNode.getAllEnclosingIds();
+                for (String ancestorId : ancestors) {
+                    if (enclosingIds.contains(ancestorId)) {
+                        treeParentId = ancestorId;
+                        break;
+                    }
+                }
+                if (treeParentId != null) {
+                    List<String> childrenOfParent = stageToChildrenMap.getOrDefault(treeParentId, new ArrayList<>());
+                    childrenOfParent.add(stage.getId());
+                    stageToChildrenMap.put(treeParentId, childrenOfParent);
+                } else {
+                    // If we can't find a matching parent in the execution and GraphVistor then this is a
+                    // top level node.
+                    stageToChildrenMap.put(stage.getId(), new ArrayList<>());
+                    topLevelStageIds.add(stage.getId());
+                }
+            } catch (java.io.IOException ex) {
+                logger.error("Caught a "
+                        + ex.getClass().getSimpleName()
+                        + " when trying to find parent of stage '"
+                        + stage.getName()
+                        + "'");
             }
-            List<String> ancestors = getAncestors(stage, stageMap);
-            String treeParentId = null;
-            // Compare the list of GraphVistor ancestors to the IDs of the enclosing node in the
-            // execution.
-            // If a node encloses another node, it means it's a tree parent, so the first ancestor
-            // ID we find
-            // which matches an enclosing node then it's the stages tree parent.
-            List<String> enclosingIds = stageNode.getAllEnclosingIds();
-            for (String ancestorId : ancestors) {
-              if (enclosingIds.contains(ancestorId)) {
-                treeParentId = ancestorId;
-                break;
-              }
-            }
-            if (treeParentId != null) {
-              List<String> childrenOfParent =
-                  stageToChildrenMap.getOrDefault(treeParentId, new ArrayList<>());
-              childrenOfParent.add(stage.getId());
-              stageToChildrenMap.put(treeParentId, childrenOfParent);
-            } else {
-              // If we can't find a matching parent in the execution and GraphVistor then this is a
-              // top level node.
-              stageToChildrenMap.put(stage.getId(), new ArrayList<>());
-              topLevelStageIds.add(stage.getId());
-            }
-          } catch (java.io.IOException ex) {
-            logger.error(
-                "Caught a "
-                    + ex.getClass().getSimpleName()
-                    + " when trying to find parent of stage '"
-                    + stage.getName()
-                    + "'");
-          }
         });
 
-    List<PipelineStage> stageResults =
-        stageMap.values().stream()
-            .map(
-                pipelineStageInternal -> {
-                  List<PipelineStage> children =
-                      stageToChildrenMap.getOrDefault(pipelineStageInternal.getId(), emptyList())
-                          .stream()
-                          .map(mapper(stageMap, stageToChildrenMap))
-                          .collect(Collectors.toList());
+        List<PipelineStage> stageResults = stageMap.values().stream()
+                .map(pipelineStageInternal -> {
+                    List<PipelineStage> children =
+                            stageToChildrenMap.getOrDefault(pipelineStageInternal.getId(), emptyList()).stream()
+                                    .map(mapper(stageMap, stageToChildrenMap))
+                                    .collect(Collectors.toList());
 
-                  return pipelineStageInternal.toPipelineStage(children);
+                    return pipelineStageInternal.toPipelineStage(children);
                 })
-            .filter(stage -> topLevelStageIds.contains(stage.getId()))
-            .collect(Collectors.toList());
-    return new PipelineGraph(stageResults, execution.isComplete());
-  }
-
-  private List<String> getAncestors(
-      PipelineStageInternal stage, Map<String, PipelineStageInternal> stageMap) {
-    List<String> ancestors = new ArrayList<>();
-    if (!stage.getParents().isEmpty()) {
-      String parentId = stage.getParents().get(0); // Assume one parent.
-      ancestors.add(parentId);
-      if (stageMap.containsKey(parentId)) {
-        PipelineStageInternal parent = stageMap.get(parentId);
-        ancestors.addAll(getAncestors(parent, stageMap));
-      }
+                .filter(stage -> topLevelStageIds.contains(stage.getId()))
+                .collect(Collectors.toList());
+        return new PipelineGraph(stageResults, execution.isComplete());
     }
-    return ancestors;
-  }
+
+    private List<String> getAncestors(PipelineStageInternal stage, Map<String, PipelineStageInternal> stageMap) {
+        List<String> ancestors = new ArrayList<>();
+        if (!stage.getParents().isEmpty()) {
+            String parentId = stage.getParents().get(0); // Assume one parent.
+            ancestors.add(parentId);
+            if (stageMap.containsKey(parentId)) {
+                PipelineStageInternal parent = stageMap.get(parentId);
+                ancestors.addAll(getAncestors(parent, stageMap));
+            }
+        }
+        return ancestors;
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeGraphVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeGraphVisitor.java
@@ -55,836 +55,778 @@ import org.slf4j.LoggerFactory;
  *     UI.
  */
 public class PipelineNodeGraphVisitor extends StandardChunkVisitor {
-  private final WorkflowRun run;
+    private final WorkflowRun run;
 
-  private final ArrayDeque<FlowNodeWrapper> parallelBranches = new ArrayDeque<>();
+    private final ArrayDeque<FlowNodeWrapper> parallelBranches = new ArrayDeque<>();
 
-  public final ArrayDeque<FlowNodeWrapper> nodes = new ArrayDeque<>();
+    public final ArrayDeque<FlowNodeWrapper> nodes = new ArrayDeque<>();
 
-  private FlowNode firstExecuted = null;
+    private FlowNode firstExecuted = null;
 
-  private FlowNodeWrapper nextStage;
+    private FlowNodeWrapper nextStage;
 
-  private Stack<FlowNode> parallelEnds = new Stack<>();
+    private Stack<FlowNode> parallelEnds = new Stack<>();
 
-  public final Map<String, FlowNodeWrapper> nodeMap = new LinkedHashMap<>();
+    public final Map<String, FlowNodeWrapper> nodeMap = new LinkedHashMap<>();
 
-  public final Map<String, Stack<FlowNodeWrapper>> stackPerEnd = new HashMap<>();
+    public final Map<String, Stack<FlowNodeWrapper>> stackPerEnd = new HashMap<>();
 
-  private static final Logger logger = LoggerFactory.getLogger(PipelineNodeGraphVisitor.class);
+    private static final Logger logger = LoggerFactory.getLogger(PipelineNodeGraphVisitor.class);
 
-  private final boolean isNodeVisitorDumpEnabled = logger.isTraceEnabled();
+    private final boolean isNodeVisitorDumpEnabled = logger.isTraceEnabled();
 
-  private final Stack<FlowNode> nestedStages = new Stack<>();
-  private final Stack<FlowNode> nestedbranches = new Stack<>();
+    private final Stack<FlowNode> nestedStages = new Stack<>();
+    private final Stack<FlowNode> nestedbranches = new Stack<>();
 
-  private final ArrayDeque<FlowNode> pendingInputSteps = new ArrayDeque<>();
+    private final ArrayDeque<FlowNode> pendingInputSteps = new ArrayDeque<>();
 
-  private final Stack<FlowNode> pendingBranchEndNodes = new Stack<>();
-  private final Stack<FlowNode> parallelBranchEndNodes = new Stack<>();
-  private final Stack<FlowNode> parallelBranchStartNodes = new Stack<>();
+    private final Stack<FlowNode> pendingBranchEndNodes = new Stack<>();
+    private final Stack<FlowNode> parallelBranchEndNodes = new Stack<>();
+    private final Stack<FlowNode> parallelBranchStartNodes = new Stack<>();
 
-  private final InputAction inputAction;
+    private final InputAction inputAction;
 
-  private StepStartNode agentNode = null;
+    private StepStartNode agentNode = null;
 
-  // Collects instances of Action as we walk up the graph, to be drained when appropriate
-  private Set<Action> pipelineActions;
+    // Collects instances of Action as we walk up the graph, to be drained when appropriate
+    private Set<Action> pipelineActions;
 
-  // Temporary holding for actions waiting to be assigned to the wrapper for a branch
-  private Map<FlowNode /* is the branchStartNode */, Set<Action>> pendingActionsForBranches;
+    // Temporary holding for actions waiting to be assigned to the wrapper for a branch
+    private Map<FlowNode /* is the branchStartNode */, Set<Action>> pendingActionsForBranches;
 
-  private static final String PARALLEL_SYNTHETIC_STAGE_NAME = "Parallel";
+    private static final String PARALLEL_SYNTHETIC_STAGE_NAME = "Parallel";
 
-  private final boolean declarative;
+    private final boolean declarative;
 
-  public PipelineNodeGraphVisitor(WorkflowRun run) {
-    this.run = run;
-    this.inputAction = run.getAction(InputAction.class);
-    this.pipelineActions = new HashSet<>();
-    this.pendingActionsForBranches = new HashMap<>();
-    declarative = run.getAction(ExecutionModelAction.class) != null;
-    FlowExecution execution = run.getExecution();
-    if (execution != null) {
-      try {
-        ForkScanner.visitSimpleChunks(execution.getCurrentHeads(), this, new StageChunkFinder());
-      } catch (final Throwable t) {
-        // Log run ID, because the eventual exception handler (probably Stapler) isn't specific
-        // enough to do so
-        logger.error(
-            "Caught a "
-                + t.getClass().getSimpleName()
-                + " traversing the graph for run "
-                + run.getExternalizableId());
-        throw t;
-      }
-    } else {
-      logger.debug("Could not find execution for run " + run.getExternalizableId());
-    }
-  }
-
-  @Override
-  public void chunkStart(
-      @NonNull FlowNode startNode,
-      @CheckForNull FlowNode beforeBlock,
-      @NonNull ForkScanner scanner) {
-    super.chunkStart(startNode, beforeBlock, scanner);
-    if (isNodeVisitorDumpEnabled) {
-      dump(
-          String.format(
-              "chunkStart=> id: %s, name: %s, function: %s",
-              startNode.getId(), startNode.getDisplayName(), startNode.getDisplayFunctionName()));
-    }
-
-    if (NotExecutedNodeAction.isExecuted(startNode)) {
-      firstExecuted = startNode;
-    }
-  }
-
-  @Override
-  public void chunkEnd(
-      @NonNull FlowNode endNode, @CheckForNull FlowNode afterBlock, @NonNull ForkScanner scanner) {
-    super.chunkEnd(endNode, afterBlock, scanner);
-    if (isNodeVisitorDumpEnabled) {
-      dump(
-          String.format(
-              "chunkEnd=> id: %s, name: %s, function: %s, type:%s",
-              endNode.getId(),
-              endNode.getDisplayName(),
-              endNode.getDisplayFunctionName(),
-              endNode.getClass()));
-    }
-
-    if (isNodeVisitorDumpEnabled && endNode instanceof StepEndNode) {
-      dump("\tStartNode: " + ((StepEndNode) endNode).getStartNode());
-    }
-
-    if (endNode instanceof StepStartNode && PipelineNodeUtil.isAgentStart(endNode)) {
-      agentNode = (StepStartNode) endNode;
-    }
-
-    // capture orphan branches
-    captureOrphanParallelBranches();
-
-    // if block stage node push it to stack as it may have nested stages
-    if (parallelEnds.isEmpty()
-        && endNode instanceof StepEndNode
-        && PipelineNodeUtil.isStage(((StepEndNode) endNode).getStartNode())) {
-
-      // XXX: There seems to be bug in eventing, chunkEnd is sent twice for the same FlowNode
-      //     Lets peek and if the last one is same as this endNode then skip adding it
-      FlowNode node = null;
-      if (!nestedStages.empty()) {
-        node = nestedStages.peek();
-      }
-      if (node == null || !node.equals(endNode)) {
-        nestedStages.push(endNode);
-      }
-    }
-    firstExecuted = null;
-
-    // if we're using marker-based (and not block-scoped) stages, add the last node as part of its
-    // contents
-    if (!(endNode instanceof BlockEndNode)) {
-      atomNode(null, endNode, afterBlock, scanner);
-    }
-  }
-
-  // This gets triggered on encountering a new chunk (stage or branch)
-  @SuppressFBWarnings(
-      value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
-      justification =
-          "chunk.getLastNode() is marked non null but is null sometimes, when JENKINS-40200 is fixed we will remove this check ")
-  @Override
-  protected void handleChunkDone(@NonNull MemoryFlowChunk chunk) {
-    if (isNodeVisitorDumpEnabled) {
-      dump(
-          String.format(
-              "handleChunkDone=> id: %s, name: %s, function: %s",
-              chunk.getFirstNode().getId(),
-              chunk.getFirstNode().getDisplayName(),
-              chunk.getFirstNode().getDisplayFunctionName()));
-    }
-
-    boolean parallelNestedStages = false;
-
-    // it's nested stages inside parallel so let's collect them later
-    if (!parallelEnds.isEmpty()) {
-      parallelNestedStages = true;
-    }
-
-    TimingInfo times = null;
-
-    // TODO: remove chunk.getLastNode() != null check based on how JENKINS-40200 gets resolved
-    if (firstExecuted != null && chunk.getLastNode() != null) {
-      times =
-          StatusAndTiming.computeChunkTiming(
-              run,
-              chunk.getPauseTimeMillis(),
-              firstExecuted,
-              chunk.getLastNode(),
-              chunk.getNodeAfter());
-    }
-
-    if (times == null) {
-      times = new TimingInfo();
-    }
-
-    NodeRunStatus status;
-    boolean skippedStage = PipelineNodeUtil.isSkippedStage(chunk.getFirstNode());
-    if (skippedStage) {
-      status = new NodeRunStatus(BlueRun.BlueRunResult.NOT_BUILT, BlueRun.BlueRunState.SKIPPED);
-    } else if (firstExecuted == null) {
-      status = new NodeRunStatus(GenericStatus.NOT_EXECUTED);
-    } else if (chunk.getLastNode() != null) {
-      // StatusAndTiming.computeChunkStatus2 seems to return wrong status for parallel sequential
-      // stages
-      // so check check if active and in the case of nested sequential
-      if (parallelNestedStages && chunk.getFirstNode().isActive()) {
-        status = new NodeRunStatus(chunk.getFirstNode());
-      } else {
-        FlowNode nodeBefore = chunk.getNodeBefore(),
-            firstNode = chunk.getFirstNode(),
-            lastNode = chunk.getLastNode(),
-            nodeAfter = chunk.getNodeAfter();
-        status =
-            new NodeRunStatus(
-                StatusAndTiming.computeChunkStatus2(
-                    run, nodeBefore, firstNode, lastNode, nodeAfter));
-      }
-    } else {
-      status = new NodeRunStatus(firstExecuted);
-    }
-
-    if (!pendingInputSteps.isEmpty()) {
-      status = new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.PAUSED);
-    }
-    FlowNodeWrapper stage = new FlowNodeWrapper(chunk.getFirstNode(), status, times, run);
-
-    stage.setCauseOfFailure(PipelineNodeUtil.getCauseOfBlockage(stage.getNode(), agentNode));
-
-    accumulatePipelineActions(chunk.getFirstNode());
-    final Set<Action> pipelineActions = drainPipelineActions();
-    if (isNodeVisitorDumpEnabled && pipelineActions.size() > 0) {
-      dump("\tAdding " + pipelineActions.size() + " actions to stage id: " + stage.getId());
-    }
-    stage.setPipelineActions(pipelineActions);
-
-    if (!parallelNestedStages) {
-      nodes.push(stage);
-      nodeMap.put(stage.getId(), stage);
-    }
-    if (!skippedStage && !parallelBranches.isEmpty()) {
-      Iterator<FlowNodeWrapper> branches = parallelBranches.descendingIterator();
-      while (branches.hasNext()) {
-        FlowNodeWrapper p = branches.next();
-        if (isNodeVisitorDumpEnabled) {
-          dump(
-              String.format(
-                  "handleChunkDone=> found node [id: %s, name: %s, function: %s] is child of [id: %s, name: %s, function: %s] - parallelBranches",
-                  p.getId(),
-                  p.getDisplayName(),
-                  p.getNode().getDisplayFunctionName(),
-                  stage.getId(),
-                  stage.getDisplayName(),
-                  stage.getNode().getDisplayFunctionName()));
-        }
-        p.addParent(stage);
-        stage.addEdge(p);
-      }
-    } else {
-      if (parallelNestedStages) {
-        if (pendingBranchEndNodes.isEmpty()) {
-          logger.debug("skip parsing stage {} but parallelBranchEndNodes is empty", stage);
+    public PipelineNodeGraphVisitor(WorkflowRun run) {
+        this.run = run;
+        this.inputAction = run.getAction(InputAction.class);
+        this.pipelineActions = new HashSet<>();
+        this.pendingActionsForBranches = new HashMap<>();
+        declarative = run.getAction(ExecutionModelAction.class) != null;
+        FlowExecution execution = run.getExecution();
+        if (execution != null) {
+            try {
+                ForkScanner.visitSimpleChunks(execution.getCurrentHeads(), this, new StageChunkFinder());
+            } catch (final Throwable t) {
+                // Log run ID, because the eventual exception handler (probably Stapler) isn't specific
+                // enough to do so
+                logger.error("Caught a "
+                        + t.getClass().getSimpleName()
+                        + " traversing the graph for run "
+                        + run.getExternalizableId());
+                throw t;
+            }
         } else {
-          String endId = pendingBranchEndNodes.peek().getId();
-          Stack<FlowNodeWrapper> stack = stackPerEnd.computeIfAbsent(endId, k -> new Stack<>());
-          stack.add(stage);
+            logger.debug("Could not find execution for run " + run.getExternalizableId());
         }
-      }
-      if (nextStage != null && !parallelNestedStages) {
+    }
+
+    @Override
+    public void chunkStart(
+            @NonNull FlowNode startNode, @CheckForNull FlowNode beforeBlock, @NonNull ForkScanner scanner) {
+        super.chunkStart(startNode, beforeBlock, scanner);
         if (isNodeVisitorDumpEnabled) {
-          dump(
-              String.format(
-                  "handleChunkDone=> found node [id: %s, name: %s, function: %s] is child of [id: %s, name: %s, function: %s]",
-                  nextStage.getId(),
-                  nextStage.getDisplayName(),
-                  nextStage.getNode().getDisplayFunctionName(),
-                  stage.getId(),
-                  stage.getDisplayName(),
-                  stage.getNode().getDisplayFunctionName()));
+            dump(String.format(
+                    "chunkStart=> id: %s, name: %s, function: %s",
+                    startNode.getId(), startNode.getDisplayName(), startNode.getDisplayFunctionName()));
         }
-        nextStage.addParent(stage);
-        stage.addEdge(nextStage);
-      }
-      if (nextStage == null) {
+
+        if (NotExecutedNodeAction.isExecuted(startNode)) {
+            firstExecuted = startNode;
+        }
+    }
+
+    @Override
+    public void chunkEnd(@NonNull FlowNode endNode, @CheckForNull FlowNode afterBlock, @NonNull ForkScanner scanner) {
+        super.chunkEnd(endNode, afterBlock, scanner);
         if (isNodeVisitorDumpEnabled) {
-          dump(
-              String.format(
-                  "handleChunkDone=> WARNING: nextStage is null! Unable for assign parent stage for stage [id: %s, name: %s, function: %s]",
-                  stage.getId(), stage.getDisplayName(), stage.getNode().getDisplayFunctionName()));
+            dump(String.format(
+                    "chunkEnd=> id: %s, name: %s, function: %s, type:%s",
+                    endNode.getId(), endNode.getDisplayName(), endNode.getDisplayFunctionName(), endNode.getClass()));
         }
-      }
-      for (FlowNodeWrapper p : parallelBranches) {
-        nodes.remove(p);
-        nodeMap.remove(p.getId(), p);
-      }
-    }
-    parallelBranches.clear();
-    if (!parallelNestedStages) {
-      if (isNodeVisitorDumpEnabled) {
-        dump(
-            String.format(
-                "handleChunkDone=> setting nextStage to: [id: %s, name: %s, function: %s]",
-                stage.getId(), stage.getDisplayName(), stage.getNode().getDisplayFunctionName()));
-      }
-      this.nextStage = stage;
-    }
-  }
 
-  @Override
-  protected void resetChunk(@NonNull MemoryFlowChunk chunk) {
-    super.resetChunk(chunk);
-    firstExecuted = null;
-    pendingInputSteps.clear();
-  }
+        if (isNodeVisitorDumpEnabled && endNode instanceof StepEndNode) {
+            dump("\tStartNode: " + ((StepEndNode) endNode).getStartNode());
+        }
 
-  @Override
-  public void parallelStart(
-      @NonNull FlowNode parallelStartNode,
-      @NonNull FlowNode branchNode,
-      @NonNull ForkScanner scanner) {
-    if (isNodeVisitorDumpEnabled) {
-      dump(
-          String.format(
-              "parallelStart=> id: %s, name: %s, function: %s",
-              parallelStartNode.getId(),
-              parallelStartNode.getDisplayName(),
-              parallelStartNode.getDisplayFunctionName()));
-      dump(
-          String.format(
-              "\tbranch=> id: %s, name: %s, function: %s",
-              branchNode.getId(),
-              branchNode.getDisplayName(),
-              branchNode.getDisplayFunctionName()));
+        if (endNode instanceof StepStartNode && PipelineNodeUtil.isAgentStart(endNode)) {
+            agentNode = (StepStartNode) endNode;
+        }
+
+        // capture orphan branches
+        captureOrphanParallelBranches();
+
+        // if block stage node push it to stack as it may have nested stages
+        if (parallelEnds.isEmpty()
+                && endNode instanceof StepEndNode
+                && PipelineNodeUtil.isStage(((StepEndNode) endNode).getStartNode())) {
+
+            // XXX: There seems to be bug in eventing, chunkEnd is sent twice for the same FlowNode
+            //     Lets peek and if the last one is same as this endNode then skip adding it
+            FlowNode node = null;
+            if (!nestedStages.empty()) {
+                node = nestedStages.peek();
+            }
+            if (node == null || !node.equals(endNode)) {
+                nestedStages.push(endNode);
+            }
+        }
+        firstExecuted = null;
+
+        // if we're using marker-based (and not block-scoped) stages, add the last node as part of its
+        // contents
+        if (!(endNode instanceof BlockEndNode)) {
+            atomNode(null, endNode, afterBlock, scanner);
+        }
     }
 
-    if (nestedbranches.size() != parallelBranchEndNodes.size()) {
-      logger.debug(
-          String.format(
-              "nestedBranches size: %s not equal to parallelBranchEndNodes: %s",
-              nestedbranches.size(), parallelBranchEndNodes.size()));
-      if (!parallelEnds.isEmpty()) {
-        parallelEnds.pop();
-      }
-      return;
-    }
+    // This gets triggered on encountering a new chunk (stage or branch)
+    @SuppressFBWarnings(
+            value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+            justification =
+                    "chunk.getLastNode() is marked non null but is null sometimes, when JENKINS-40200 is fixed we will remove this check ")
+    @Override
+    protected void handleChunkDone(@NonNull MemoryFlowChunk chunk) {
+        if (isNodeVisitorDumpEnabled) {
+            dump(String.format(
+                    "handleChunkDone=> id: %s, name: %s, function: %s",
+                    chunk.getFirstNode().getId(),
+                    chunk.getFirstNode().getDisplayName(),
+                    chunk.getFirstNode().getDisplayFunctionName()));
+        }
 
-    if (!pendingBranchEndNodes.isEmpty()) {
-      logger.debug("Found parallelBranchEndNodes, but the corresponding branchStartNode yet");
-      if (!parallelEnds.isEmpty()) {
-        parallelEnds.pop();
-      }
-      return;
-    }
+        boolean parallelNestedStages = false;
 
-    while (!nestedbranches.empty() && !parallelBranchEndNodes.empty()) {
-      FlowNode branchStartNode = nestedbranches.pop();
-      FlowNode endNode = parallelBranchEndNodes.pop();
+        // it's nested stages inside parallel so let's collect them later
+        if (!parallelEnds.isEmpty()) {
+            parallelNestedStages = true;
+        }
 
-      if (isNodeVisitorDumpEnabled) {
-        dump(String.format("\tBranch with start node id: %s", branchStartNode.getId()));
-      }
+        TimingInfo times = null;
 
-      TimingInfo times;
-      NodeRunStatus status;
+        // TODO: remove chunk.getLastNode() != null check based on how JENKINS-40200 gets resolved
+        if (firstExecuted != null && chunk.getLastNode() != null) {
+            times = StatusAndTiming.computeChunkTiming(
+                    run, chunk.getPauseTimeMillis(), firstExecuted, chunk.getLastNode(), chunk.getNodeAfter());
+        }
 
-      if (endNode != null) {
-        // Branch has completed
-        times =
-            StatusAndTiming.computeChunkTiming(
-                run, chunk.getPauseTimeMillis(), branchStartNode, endNode, chunk.getNodeAfter());
-        if (endNode instanceof StepAtomNode) {
-          if (PipelineNodeUtil.isPausedForInputStep((StepAtomNode) endNode, inputAction)) {
+        if (times == null) {
+            times = new TimingInfo();
+        }
+
+        NodeRunStatus status;
+        boolean skippedStage = PipelineNodeUtil.isSkippedStage(chunk.getFirstNode());
+        if (skippedStage) {
+            status = new NodeRunStatus(BlueRun.BlueRunResult.NOT_BUILT, BlueRun.BlueRunState.SKIPPED);
+        } else if (firstExecuted == null) {
+            status = new NodeRunStatus(GenericStatus.NOT_EXECUTED);
+        } else if (chunk.getLastNode() != null) {
+            // StatusAndTiming.computeChunkStatus2 seems to return wrong status for parallel sequential
+            // stages
+            // so check check if active and in the case of nested sequential
+            if (parallelNestedStages && chunk.getFirstNode().isActive()) {
+                status = new NodeRunStatus(chunk.getFirstNode());
+            } else {
+                FlowNode nodeBefore = chunk.getNodeBefore(),
+                        firstNode = chunk.getFirstNode(),
+                        lastNode = chunk.getLastNode(),
+                        nodeAfter = chunk.getNodeAfter();
+                status = new NodeRunStatus(
+                        StatusAndTiming.computeChunkStatus2(run, nodeBefore, firstNode, lastNode, nodeAfter));
+            }
+        } else {
+            status = new NodeRunStatus(firstExecuted);
+        }
+
+        if (!pendingInputSteps.isEmpty()) {
             status = new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.PAUSED);
-          } else {
-            status = new NodeRunStatus(endNode);
-          }
-        } else {
-          FlowNode parallelEnd = null;
-          if (!parallelEnds.isEmpty()) {
-            parallelEnd = parallelEnds.peek();
-          }
-          GenericStatus genericStatus =
-              StatusAndTiming.computeChunkStatus2(
-                  run, parallelStartNode, branchStartNode, endNode, parallelEnd);
-          status = new NodeRunStatus(genericStatus);
         }
-      } else {
-        // Branch still running / paused
-        long startTime = System.currentTimeMillis();
-        if (branchStartNode.getAction(TimingAction.class) != null) {
-          startTime = TimingAction.getStartTime(branchStartNode);
+        FlowNodeWrapper stage = new FlowNodeWrapper(chunk.getFirstNode(), status, times, run);
+
+        stage.setCauseOfFailure(PipelineNodeUtil.getCauseOfBlockage(stage.getNode(), agentNode));
+
+        accumulatePipelineActions(chunk.getFirstNode());
+        final Set<Action> pipelineActions = drainPipelineActions();
+        if (isNodeVisitorDumpEnabled && pipelineActions.size() > 0) {
+            dump("\tAdding " + pipelineActions.size() + " actions to stage id: " + stage.getId());
         }
-        times =
-            new TimingInfo(
-                System.currentTimeMillis() - startTime, chunk.getPauseTimeMillis(), startTime);
-        status = new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.RUNNING);
-      }
-      assert times != null; // keep FB happy
+        stage.setPipelineActions(pipelineActions);
 
-      FlowNodeWrapper branch = new FlowNodeWrapper(branchStartNode, status, times, run);
-
-      // Collect any pending actions (required for most-recently-handled branch)
-      ArrayList<Action> branchActions = new ArrayList<>(drainPipelineActions());
-
-      // Add actions for this branch, which are collected when changing branches
-      if (pendingActionsForBranches.containsKey(branchStartNode)) {
-        branchActions.addAll(pendingActionsForBranches.get(branchStartNode));
-        pendingActionsForBranches.remove(branchStartNode);
-      }
-
-      if (isNodeVisitorDumpEnabled && branchActions.size() > 0) {
-        dump("\t\tAdding " + branchActions.size() + " actions to branch id: " + branch.getId());
-      }
-
-      // Check the stack for this branch, for declarative pipelines it should be non-empty even if
-      // only 1 stage
-      Stack<FlowNodeWrapper> stack = stackPerEnd.get(endNode.getId());
-      if (stack != null && !stack.isEmpty()) {
-
-        if (isNodeVisitorDumpEnabled) {
-          dump(String.format("\t\t\"Complex\" stages detected (%d)", stack.size()));
+        if (!parallelNestedStages) {
+            nodes.push(stage);
+            nodeMap.put(stage.getId(), stage);
         }
-
-        if (stack.size() == 1) {
-          FlowNodeWrapper firstNodeWrapper = stack.pop();
-          // We've got a single non-nested stage for this branch. We're going to discard it from our
-          // graph,
-          // since we use the node for the branch itself, which has been created with the same
-          // name...
-
-          if (isNodeVisitorDumpEnabled) {
-            dump("\t\tSingle-stage branch");
-          }
-
-          // ...but first we need to poach any actions from the stage node we'll be discarding
-          branchActions.addAll(firstNodeWrapper.getPipelineActions());
-
-          if (nextStage != null) {
-            branch.addEdge(nextStage);
-          }
-        } else {
-          if (isDeclarative()) {
-            // Declarative parallel pipeline scenario
-            // We've got nested stages for sequential stage branches and/or branch labelling
-            // purposes
-            FlowNodeWrapper firstNodeWrapper = stack.pop();
-
-            // Usually ignore firstNodeWrapper, but if the first stage has a different name...
-            if (!StringUtils.equals(firstNodeWrapper.getDisplayName(), branch.getDisplayName())) {
-              // we record this node so the UI can show the label for the branch...
-              if (isNodeVisitorDumpEnabled) {
-                dump("\t\tNested labelling stage detected");
-              }
-              if (isNodeVisitorDumpEnabled) {
-                dump(
-                    String.format(
-                        "parallelStart=> found node [id: %s, name: %s, function: %s] is child of [id: %s, name: %s, function: %s] - declarative",
-                        firstNodeWrapper.getId(),
-                        firstNodeWrapper.getDisplayName(),
-                        firstNodeWrapper.getNode().getDisplayFunctionName(),
-                        branch.getId(),
-                        branch.getDisplayName(),
-                        branch.getNode().getDisplayFunctionName()));
-              }
-              branch.addEdge(firstNodeWrapper);
-              firstNodeWrapper.addParent(branch);
-              nodes.add(firstNodeWrapper);
-              // Note that there's no edge from this labelling node to the rest of the branch stages
+        if (!skippedStage && !parallelBranches.isEmpty()) {
+            Iterator<FlowNodeWrapper> branches = parallelBranches.descendingIterator();
+            while (branches.hasNext()) {
+                FlowNodeWrapper p = branches.next();
+                if (isNodeVisitorDumpEnabled) {
+                    dump(String.format(
+                            "handleChunkDone=> found node [id: %s, name: %s, function: %s] is child of [id: %s, name: %s, function: %s] - parallelBranches",
+                            p.getId(),
+                            p.getDisplayName(),
+                            p.getNode().getDisplayFunctionName(),
+                            stage.getId(),
+                            stage.getDisplayName(),
+                            stage.getNode().getDisplayFunctionName()));
+                }
+                p.addParent(stage);
+                stage.addEdge(p);
             }
-          }
-          // Declarative and scripted parallel pipeline scenario
-          FlowNodeWrapper previousNode = branch;
-          while (!stack.isEmpty()) {
-            // Grab next, link to prev, add to result
-            FlowNodeWrapper currentStage = stack.pop();
-            if (isNodeVisitorDumpEnabled) {
-              dump(
-                  String.format(
-                      "parallelStart=> found node [id: %s, name: %s, function: %s] is child of [id: %s, name: %s, function: %s]",
-                      currentStage.getId(),
-                      currentStage.getDisplayName(),
-                      currentStage.getNode().getDisplayFunctionName(),
-                      previousNode.getId(),
-                      previousNode.getDisplayName(),
-                      previousNode.getNode().getDisplayFunctionName()));
+        } else {
+            if (parallelNestedStages) {
+                if (pendingBranchEndNodes.isEmpty()) {
+                    logger.debug("skip parsing stage {} but parallelBranchEndNodes is empty", stage);
+                } else {
+                    String endId = pendingBranchEndNodes.peek().getId();
+                    Stack<FlowNodeWrapper> stack = stackPerEnd.computeIfAbsent(endId, k -> new Stack<>());
+                    stack.add(stage);
+                }
             }
-            previousNode.addEdge(currentStage);
-            currentStage.addParent(previousNode);
-            nodes.add(currentStage);
-            previousNode = currentStage;
-          }
-
-          if (nextStage != null) {
-            previousNode.addEdge(nextStage);
-          }
+            if (nextStage != null && !parallelNestedStages) {
+                if (isNodeVisitorDumpEnabled) {
+                    dump(String.format(
+                            "handleChunkDone=> found node [id: %s, name: %s, function: %s] is child of [id: %s, name: %s, function: %s]",
+                            nextStage.getId(),
+                            nextStage.getDisplayName(),
+                            nextStage.getNode().getDisplayFunctionName(),
+                            stage.getId(),
+                            stage.getDisplayName(),
+                            stage.getNode().getDisplayFunctionName()));
+                }
+                nextStage.addParent(stage);
+                stage.addEdge(nextStage);
+            }
+            if (nextStage == null) {
+                if (isNodeVisitorDumpEnabled) {
+                    dump(String.format(
+                            "handleChunkDone=> WARNING: nextStage is null! Unable for assign parent stage for stage [id: %s, name: %s, function: %s]",
+                            stage.getId(),
+                            stage.getDisplayName(),
+                            stage.getNode().getDisplayFunctionName()));
+                }
+            }
+            for (FlowNodeWrapper p : parallelBranches) {
+                nodes.remove(p);
+                nodeMap.remove(p.getId(), p);
+            }
         }
-      } else {
-        // Classic pipeline branch, single stage
-
-        if (isNodeVisitorDumpEnabled) {
-          dump("\t\tSimple branch (classic pipeline)");
-        }
-
-        if (nextStage != null) {
-          branch.addEdge(nextStage);
-        }
-      }
-
-      branch.setPipelineActions(branchActions);
-      parallelBranches.push(branch);
-    }
-
-    FlowNodeWrapper[] sortedBranches = parallelBranches.toArray(new FlowNodeWrapper[0]);
-    Arrays.sort(sortedBranches, Comparator.comparing(FlowNodeWrapper::getDisplayName));
-
-    parallelBranches.clear();
-    for (FlowNodeWrapper sortedBranch : sortedBranches) {
-      parallelBranches.push(sortedBranch);
-    }
-    for (FlowNodeWrapper p : parallelBranches) {
-      nodes.push(p);
-      nodeMap.put(p.getId(), p);
-    }
-
-    // Removes parallelEnd node for next parallel block
-    if (!parallelEnds.isEmpty()) {
-      parallelEnds.pop();
-    }
-  }
-
-  @Override
-  public void parallelEnd(
-      @NonNull FlowNode parallelStartNode,
-      @NonNull FlowNode parallelEndNode,
-      @NonNull ForkScanner scanner) {
-    if (isNodeVisitorDumpEnabled) {
-      dump(
-          String.format(
-              "parallelEnd=> id: %s, name: %s, function: %s",
-              parallelEndNode.getId(),
-              parallelEndNode.getDisplayName(),
-              parallelEndNode.getDisplayFunctionName()));
-      if (parallelEndNode instanceof StepEndNode) {
-        dump(
-            String.format(
-                "parallelEnd=> id: %s, StartNode: %s, name: %s, function: %s",
-                parallelEndNode.getId(),
-                ((StepEndNode) parallelEndNode).getStartNode().getId(),
-                ((StepEndNode) parallelEndNode).getStartNode().getDisplayName(),
-                ((StepEndNode) parallelEndNode).getStartNode().getDisplayFunctionName()));
-      }
-    }
-    captureOrphanParallelBranches();
-    this.parallelEnds.add(parallelEndNode);
-  }
-
-  @Override
-  public void parallelBranchStart(
-      @NonNull FlowNode parallelStartNode,
-      @NonNull FlowNode branchStartNode,
-      @NonNull ForkScanner scanner) {
-    if (isNodeVisitorDumpEnabled) {
-      dump(
-          String.format(
-              "parallelBranchStart=> id: %s, name: %s, function: %s",
-              branchStartNode.getId(),
-              branchStartNode.getDisplayName(),
-              branchStartNode.getDisplayFunctionName()));
-    }
-
-    // Save actions for this branch, so we can add them to the FlowNodeWrapper later
-    pendingActionsForBranches.put(branchStartNode, drainPipelineActions());
-    nestedbranches.push(branchStartNode);
-    if (!pendingBranchEndNodes.isEmpty()) {
-      FlowNode endNode = pendingBranchEndNodes.pop();
-      parallelBranchEndNodes.add(endNode);
-    }
-  }
-
-  @Override
-  public void parallelBranchEnd(
-      @NonNull FlowNode parallelStartNode,
-      @NonNull FlowNode branchEndNode,
-      @NonNull ForkScanner scanner) {
-    if (isNodeVisitorDumpEnabled) {
-      dump(
-          String.format(
-              "parallelBranchEnd=> id: %s, name: %s, function: %s, type: %s",
-              branchEndNode.getId(),
-              branchEndNode.getDisplayName(),
-              branchEndNode.getDisplayFunctionName(),
-              branchEndNode.getClass()));
-      if (branchEndNode instanceof StepEndNode) {
-        dump(
-            String.format(
-                "parallelBranchEnd=> id: %s, StartNode: %s, name: %s, function: %s",
-                branchEndNode.getId(),
-                ((StepEndNode) branchEndNode).getStartNode().getId(),
-                ((StepEndNode) branchEndNode).getStartNode().getDisplayName(),
-                ((StepEndNode) branchEndNode).getStartNode().getDisplayFunctionName()));
-      }
-    }
-    pendingBranchEndNodes.add(branchEndNode);
-    parallelBranchStartNodes.add(parallelStartNode);
-  }
-
-  @Override
-  public void atomNode(
-      @CheckForNull FlowNode before,
-      @NonNull FlowNode atomNode,
-      @CheckForNull FlowNode after,
-      @NonNull ForkScanner scan) {
-    if (isNodeVisitorDumpEnabled) {
-      dump(
-          String.format(
-              "atomNode=> id: %s, name: %s, function: %s, type: %s",
-              atomNode.getId(),
-              atomNode.getDisplayName(),
-              atomNode.getDisplayFunctionName(),
-              atomNode.getClass()));
-    }
-
-    accumulatePipelineActions(atomNode);
-
-    if (atomNode instanceof FlowStartNode) {
-      captureOrphanParallelBranches();
-      return;
-    }
-
-    if (NotExecutedNodeAction.isExecuted(atomNode)) {
-      firstExecuted = atomNode;
-    }
-    long pause = PauseAction.getPauseDuration(atomNode);
-    chunk.setPauseTimeMillis(chunk.getPauseTimeMillis() + pause);
-
-    if (atomNode instanceof StepAtomNode
-        && PipelineNodeUtil.isPausedForInputStep((StepAtomNode) atomNode, inputAction)) {
-      pendingInputSteps.add(atomNode);
-    }
-  }
-
-  private void dump(String str) {
-    logger.trace(System.identityHashCode(this) + ": " + str);
-  }
-
-  /**
-   * Find any Actions on this node, and add them to the pipelineActions collection until we can
-   * attach them to a FlowNodeWrapper.
-   */
-  protected void accumulatePipelineActions(FlowNode node) {
-    final List<Action> actions = node.getActions(Action.class);
-    pipelineActions.addAll(actions);
-    if (isNodeVisitorDumpEnabled) {
-      dump(
-          String.format(
-              "\t\taccumulating actions - added %d, total is %d",
-              actions.size(), pipelineActions.size()));
-    }
-  }
-
-  /** Empty the pipelineActions buffer, returning its contents. */
-  protected Set<Action> drainPipelineActions() {
-    if (isNodeVisitorDumpEnabled) {
-      dump(String.format("\t\tdraining accumulated actions - total is %d", pipelineActions.size()));
-    }
-
-    if (pipelineActions.size() == 0) {
-      return Collections.emptySet();
-    }
-
-    Set<Action> drainedActions = pipelineActions;
-    pipelineActions = new HashSet<>();
-    return drainedActions;
-  }
-
-  public List<FlowNodeWrapper> getPipelineNodes() {
-    return new ArrayList<>(nodes);
-  }
-
-  private static Optional<FlowNodeWrapper> findNodeWrapperByIdIn(
-      String id, Collection<FlowNodeWrapper> nodes) {
-    for (FlowNodeWrapper node : nodes) {
-      if (node.getId().equals(id)) {
-        return Optional.of(node);
-      }
-    }
-    return Optional.empty();
-  }
-
-  /**
-   * Instead of looking up by id, sometimes the IDs are wrong during build, so we look based on the
-   * parentage and display name.
-   */
-  private static Optional<FlowNodeWrapper> findNodeWrapperByParentageIn(
-      FlowNodeWrapper example, List<FlowNodeWrapper> nodes) {
-    final String exampleDisplayName = example.getDisplayName();
-    final FlowNodeWrapper firstParent = example.getFirstParent();
-    String exampleParentName = firstParent == null ? "" : firstParent.getDisplayName();
-
-    for (FlowNodeWrapper node : nodes) {
-      FlowNodeWrapper nodeParent = node.getFirstParent();
-      String nodeParentName = nodeParent == null ? "" : nodeParent.getDisplayName();
-      if (node.getDisplayName().equals(exampleDisplayName)
-          && nodeParentName.equals(exampleParentName)) {
-        return Optional.of(node);
-      }
-    }
-    return Optional.empty();
-  }
-
-  private void captureOrphanParallelBranches() {
-    if (!parallelBranches.isEmpty()
-        && (firstExecuted == null || !PipelineNodeUtil.isStage(firstExecuted))) {
-      FlowNodeWrapper synStage = createParallelSyntheticNode();
-      if (synStage != null) {
-        nodes.push(synStage);
-        nodeMap.put(synStage.getId(), synStage);
         parallelBranches.clear();
-        if (isNodeVisitorDumpEnabled) {
-          dump(
-              String.format(
-                  "captureOrphanParallelBranches=> setting nextStage to: [id: %s, name: %s, function: %s]",
-                  synStage.getId(),
-                  synStage.getDisplayName(),
-                  synStage.getNode().getDisplayFunctionName()));
+        if (!parallelNestedStages) {
+            if (isNodeVisitorDumpEnabled) {
+                dump(String.format(
+                        "handleChunkDone=> setting nextStage to: [id: %s, name: %s, function: %s]",
+                        stage.getId(), stage.getDisplayName(), stage.getNode().getDisplayFunctionName()));
+            }
+            this.nextStage = stage;
         }
-        this.nextStage = synStage;
-      }
-    }
-  }
-
-  /**
-   * Create synthetic stage that wraps a parallel block at top level, that is not enclosed inside a
-   * stage.
-   */
-  private @Nullable FlowNodeWrapper createParallelSyntheticNode() {
-
-    if (parallelBranches.isEmpty()) {
-      return null;
     }
 
-    FlowNodeWrapper firstBranch = parallelBranches.getLast();
-    FlowNodeWrapper parallel = firstBranch.getFirstParent();
-
-    if (isNodeVisitorDumpEnabled) {
-      dump(
-          String.format(
-              "createParallelSyntheticNode=> firstBranch: %s, parallel:%s",
-              firstBranch.getId(), (parallel == null ? "(none)" : parallel.getId())));
+    @Override
+    protected void resetChunk(@NonNull MemoryFlowChunk chunk) {
+        super.resetChunk(chunk);
+        firstExecuted = null;
+        pendingInputSteps.clear();
     }
 
-    String syntheticNodeId =
-        firstBranch.getNode().getParents().stream()
-            .map((node) -> node.getId())
-            .findFirst()
-            .orElseGet(
-                () -> createSyntheticStageId(firstBranch.getId(), PARALLEL_SYNTHETIC_STAGE_NAME));
-    List<FlowNode> parents;
-    if (parallel != null) {
-      parents = parallel.getNode().getParents();
-    } else {
-      parents = new ArrayList<>();
-    }
-    FlowNode syntheticNode =
-        new FlowNode(firstBranch.getNode().getExecution(), syntheticNodeId, parents) {
-          @Override
-          public void save() throws IOException {
-            // no-op to avoid JENKINS-45892 violations from serializing the synthetic FlowNode.
-          }
+    @Override
+    public void parallelStart(
+            @NonNull FlowNode parallelStartNode, @NonNull FlowNode branchNode, @NonNull ForkScanner scanner) {
+        if (isNodeVisitorDumpEnabled) {
+            dump(String.format(
+                    "parallelStart=> id: %s, name: %s, function: %s",
+                    parallelStartNode.getId(),
+                    parallelStartNode.getDisplayName(),
+                    parallelStartNode.getDisplayFunctionName()));
+            dump(String.format(
+                    "\tbranch=> id: %s, name: %s, function: %s",
+                    branchNode.getId(), branchNode.getDisplayName(), branchNode.getDisplayFunctionName()));
+        }
 
-          @Override
-          protected String getTypeDisplayName() {
-            return PARALLEL_SYNTHETIC_STAGE_NAME;
-          }
+        if (nestedbranches.size() != parallelBranchEndNodes.size()) {
+            logger.debug(String.format(
+                    "nestedBranches size: %s not equal to parallelBranchEndNodes: %s",
+                    nestedbranches.size(), parallelBranchEndNodes.size()));
+            if (!parallelEnds.isEmpty()) {
+                parallelEnds.pop();
+            }
+            return;
+        }
+
+        if (!pendingBranchEndNodes.isEmpty()) {
+            logger.debug("Found parallelBranchEndNodes, but the corresponding branchStartNode yet");
+            if (!parallelEnds.isEmpty()) {
+                parallelEnds.pop();
+            }
+            return;
+        }
+
+        while (!nestedbranches.empty() && !parallelBranchEndNodes.empty()) {
+            FlowNode branchStartNode = nestedbranches.pop();
+            FlowNode endNode = parallelBranchEndNodes.pop();
+
+            if (isNodeVisitorDumpEnabled) {
+                dump(String.format("\tBranch with start node id: %s", branchStartNode.getId()));
+            }
+
+            TimingInfo times;
+            NodeRunStatus status;
+
+            if (endNode != null) {
+                // Branch has completed
+                times = StatusAndTiming.computeChunkTiming(
+                        run, chunk.getPauseTimeMillis(), branchStartNode, endNode, chunk.getNodeAfter());
+                if (endNode instanceof StepAtomNode) {
+                    if (PipelineNodeUtil.isPausedForInputStep((StepAtomNode) endNode, inputAction)) {
+                        status = new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.PAUSED);
+                    } else {
+                        status = new NodeRunStatus(endNode);
+                    }
+                } else {
+                    FlowNode parallelEnd = null;
+                    if (!parallelEnds.isEmpty()) {
+                        parallelEnd = parallelEnds.peek();
+                    }
+                    GenericStatus genericStatus = StatusAndTiming.computeChunkStatus2(
+                            run, parallelStartNode, branchStartNode, endNode, parallelEnd);
+                    status = new NodeRunStatus(genericStatus);
+                }
+            } else {
+                // Branch still running / paused
+                long startTime = System.currentTimeMillis();
+                if (branchStartNode.getAction(TimingAction.class) != null) {
+                    startTime = TimingAction.getStartTime(branchStartNode);
+                }
+                times = new TimingInfo(System.currentTimeMillis() - startTime, chunk.getPauseTimeMillis(), startTime);
+                status = new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.RUNNING);
+            }
+            assert times != null; // keep FB happy
+
+            FlowNodeWrapper branch = new FlowNodeWrapper(branchStartNode, status, times, run);
+
+            // Collect any pending actions (required for most-recently-handled branch)
+            ArrayList<Action> branchActions = new ArrayList<>(drainPipelineActions());
+
+            // Add actions for this branch, which are collected when changing branches
+            if (pendingActionsForBranches.containsKey(branchStartNode)) {
+                branchActions.addAll(pendingActionsForBranches.get(branchStartNode));
+                pendingActionsForBranches.remove(branchStartNode);
+            }
+
+            if (isNodeVisitorDumpEnabled && branchActions.size() > 0) {
+                dump("\t\tAdding " + branchActions.size() + " actions to branch id: " + branch.getId());
+            }
+
+            // Check the stack for this branch, for declarative pipelines it should be non-empty even if
+            // only 1 stage
+            Stack<FlowNodeWrapper> stack = stackPerEnd.get(endNode.getId());
+            if (stack != null && !stack.isEmpty()) {
+
+                if (isNodeVisitorDumpEnabled) {
+                    dump(String.format("\t\t\"Complex\" stages detected (%d)", stack.size()));
+                }
+
+                if (stack.size() == 1) {
+                    FlowNodeWrapper firstNodeWrapper = stack.pop();
+                    // We've got a single non-nested stage for this branch. We're going to discard it from our
+                    // graph,
+                    // since we use the node for the branch itself, which has been created with the same
+                    // name...
+
+                    if (isNodeVisitorDumpEnabled) {
+                        dump("\t\tSingle-stage branch");
+                    }
+
+                    // ...but first we need to poach any actions from the stage node we'll be discarding
+                    branchActions.addAll(firstNodeWrapper.getPipelineActions());
+
+                    if (nextStage != null) {
+                        branch.addEdge(nextStage);
+                    }
+                } else {
+                    if (isDeclarative()) {
+                        // Declarative parallel pipeline scenario
+                        // We've got nested stages for sequential stage branches and/or branch labelling
+                        // purposes
+                        FlowNodeWrapper firstNodeWrapper = stack.pop();
+
+                        // Usually ignore firstNodeWrapper, but if the first stage has a different name...
+                        if (!StringUtils.equals(firstNodeWrapper.getDisplayName(), branch.getDisplayName())) {
+                            // we record this node so the UI can show the label for the branch...
+                            if (isNodeVisitorDumpEnabled) {
+                                dump("\t\tNested labelling stage detected");
+                            }
+                            if (isNodeVisitorDumpEnabled) {
+                                dump(String.format(
+                                        "parallelStart=> found node [id: %s, name: %s, function: %s] is child of [id: %s, name: %s, function: %s] - declarative",
+                                        firstNodeWrapper.getId(),
+                                        firstNodeWrapper.getDisplayName(),
+                                        firstNodeWrapper.getNode().getDisplayFunctionName(),
+                                        branch.getId(),
+                                        branch.getDisplayName(),
+                                        branch.getNode().getDisplayFunctionName()));
+                            }
+                            branch.addEdge(firstNodeWrapper);
+                            firstNodeWrapper.addParent(branch);
+                            nodes.add(firstNodeWrapper);
+                            // Note that there's no edge from this labelling node to the rest of the branch stages
+                        }
+                    }
+                    // Declarative and scripted parallel pipeline scenario
+                    FlowNodeWrapper previousNode = branch;
+                    while (!stack.isEmpty()) {
+                        // Grab next, link to prev, add to result
+                        FlowNodeWrapper currentStage = stack.pop();
+                        if (isNodeVisitorDumpEnabled) {
+                            dump(String.format(
+                                    "parallelStart=> found node [id: %s, name: %s, function: %s] is child of [id: %s, name: %s, function: %s]",
+                                    currentStage.getId(),
+                                    currentStage.getDisplayName(),
+                                    currentStage.getNode().getDisplayFunctionName(),
+                                    previousNode.getId(),
+                                    previousNode.getDisplayName(),
+                                    previousNode.getNode().getDisplayFunctionName()));
+                        }
+                        previousNode.addEdge(currentStage);
+                        currentStage.addParent(previousNode);
+                        nodes.add(currentStage);
+                        previousNode = currentStage;
+                    }
+
+                    if (nextStage != null) {
+                        previousNode.addEdge(nextStage);
+                    }
+                }
+            } else {
+                // Classic pipeline branch, single stage
+
+                if (isNodeVisitorDumpEnabled) {
+                    dump("\t\tSimple branch (classic pipeline)");
+                }
+
+                if (nextStage != null) {
+                    branch.addEdge(nextStage);
+                }
+            }
+
+            branch.setPipelineActions(branchActions);
+            parallelBranches.push(branch);
+        }
+
+        FlowNodeWrapper[] sortedBranches = parallelBranches.toArray(new FlowNodeWrapper[0]);
+        Arrays.sort(sortedBranches, Comparator.comparing(FlowNodeWrapper::getDisplayName));
+
+        parallelBranches.clear();
+        for (FlowNodeWrapper sortedBranch : sortedBranches) {
+            parallelBranches.push(sortedBranch);
+        }
+        for (FlowNodeWrapper p : parallelBranches) {
+            nodes.push(p);
+            nodeMap.put(p.getId(), p);
+        }
+
+        // Removes parallelEnd node for next parallel block
+        if (!parallelEnds.isEmpty()) {
+            parallelEnds.pop();
+        }
+    }
+
+    @Override
+    public void parallelEnd(
+            @NonNull FlowNode parallelStartNode, @NonNull FlowNode parallelEndNode, @NonNull ForkScanner scanner) {
+        if (isNodeVisitorDumpEnabled) {
+            dump(String.format(
+                    "parallelEnd=> id: %s, name: %s, function: %s",
+                    parallelEndNode.getId(),
+                    parallelEndNode.getDisplayName(),
+                    parallelEndNode.getDisplayFunctionName()));
+            if (parallelEndNode instanceof StepEndNode) {
+                dump(String.format(
+                        "parallelEnd=> id: %s, StartNode: %s, name: %s, function: %s",
+                        parallelEndNode.getId(),
+                        ((StepEndNode) parallelEndNode).getStartNode().getId(),
+                        ((StepEndNode) parallelEndNode).getStartNode().getDisplayName(),
+                        ((StepEndNode) parallelEndNode).getStartNode().getDisplayFunctionName()));
+            }
+        }
+        captureOrphanParallelBranches();
+        this.parallelEnds.add(parallelEndNode);
+    }
+
+    @Override
+    public void parallelBranchStart(
+            @NonNull FlowNode parallelStartNode, @NonNull FlowNode branchStartNode, @NonNull ForkScanner scanner) {
+        if (isNodeVisitorDumpEnabled) {
+            dump(String.format(
+                    "parallelBranchStart=> id: %s, name: %s, function: %s",
+                    branchStartNode.getId(),
+                    branchStartNode.getDisplayName(),
+                    branchStartNode.getDisplayFunctionName()));
+        }
+
+        // Save actions for this branch, so we can add them to the FlowNodeWrapper later
+        pendingActionsForBranches.put(branchStartNode, drainPipelineActions());
+        nestedbranches.push(branchStartNode);
+        if (!pendingBranchEndNodes.isEmpty()) {
+            FlowNode endNode = pendingBranchEndNodes.pop();
+            parallelBranchEndNodes.add(endNode);
+        }
+    }
+
+    @Override
+    public void parallelBranchEnd(
+            @NonNull FlowNode parallelStartNode, @NonNull FlowNode branchEndNode, @NonNull ForkScanner scanner) {
+        if (isNodeVisitorDumpEnabled) {
+            dump(String.format(
+                    "parallelBranchEnd=> id: %s, name: %s, function: %s, type: %s",
+                    branchEndNode.getId(),
+                    branchEndNode.getDisplayName(),
+                    branchEndNode.getDisplayFunctionName(),
+                    branchEndNode.getClass()));
+            if (branchEndNode instanceof StepEndNode) {
+                dump(String.format(
+                        "parallelBranchEnd=> id: %s, StartNode: %s, name: %s, function: %s",
+                        branchEndNode.getId(),
+                        ((StepEndNode) branchEndNode).getStartNode().getId(),
+                        ((StepEndNode) branchEndNode).getStartNode().getDisplayName(),
+                        ((StepEndNode) branchEndNode).getStartNode().getDisplayFunctionName()));
+            }
+        }
+        pendingBranchEndNodes.add(branchEndNode);
+        parallelBranchStartNodes.add(parallelStartNode);
+    }
+
+    @Override
+    public void atomNode(
+            @CheckForNull FlowNode before,
+            @NonNull FlowNode atomNode,
+            @CheckForNull FlowNode after,
+            @NonNull ForkScanner scan) {
+        if (isNodeVisitorDumpEnabled) {
+            dump(String.format(
+                    "atomNode=> id: %s, name: %s, function: %s, type: %s",
+                    atomNode.getId(),
+                    atomNode.getDisplayName(),
+                    atomNode.getDisplayFunctionName(),
+                    atomNode.getClass()));
+        }
+
+        accumulatePipelineActions(atomNode);
+
+        if (atomNode instanceof FlowStartNode) {
+            captureOrphanParallelBranches();
+            return;
+        }
+
+        if (NotExecutedNodeAction.isExecuted(atomNode)) {
+            firstExecuted = atomNode;
+        }
+        long pause = PauseAction.getPauseDuration(atomNode);
+        chunk.setPauseTimeMillis(chunk.getPauseTimeMillis() + pause);
+
+        if (atomNode instanceof StepAtomNode
+                && PipelineNodeUtil.isPausedForInputStep((StepAtomNode) atomNode, inputAction)) {
+            pendingInputSteps.add(atomNode);
+        }
+    }
+
+    private void dump(String str) {
+        logger.trace(System.identityHashCode(this) + ": " + str);
+    }
+
+    /**
+     * Find any Actions on this node, and add them to the pipelineActions collection until we can
+     * attach them to a FlowNodeWrapper.
+     */
+    protected void accumulatePipelineActions(FlowNode node) {
+        final List<Action> actions = node.getActions(Action.class);
+        pipelineActions.addAll(actions);
+        if (isNodeVisitorDumpEnabled) {
+            dump(String.format(
+                    "\t\taccumulating actions - added %d, total is %d", actions.size(), pipelineActions.size()));
+        }
+    }
+
+    /** Empty the pipelineActions buffer, returning its contents. */
+    protected Set<Action> drainPipelineActions() {
+        if (isNodeVisitorDumpEnabled) {
+            dump(String.format("\t\tdraining accumulated actions - total is %d", pipelineActions.size()));
+        }
+
+        if (pipelineActions.size() == 0) {
+            return Collections.emptySet();
+        }
+
+        Set<Action> drainedActions = pipelineActions;
+        pipelineActions = new HashSet<>();
+        return drainedActions;
+    }
+
+    public List<FlowNodeWrapper> getPipelineNodes() {
+        return new ArrayList<>(nodes);
+    }
+
+    private static Optional<FlowNodeWrapper> findNodeWrapperByIdIn(String id, Collection<FlowNodeWrapper> nodes) {
+        for (FlowNodeWrapper node : nodes) {
+            if (node.getId().equals(id)) {
+                return Optional.of(node);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Instead of looking up by id, sometimes the IDs are wrong during build, so we look based on the
+     * parentage and display name.
+     */
+    private static Optional<FlowNodeWrapper> findNodeWrapperByParentageIn(
+            FlowNodeWrapper example, List<FlowNodeWrapper> nodes) {
+        final String exampleDisplayName = example.getDisplayName();
+        final FlowNodeWrapper firstParent = example.getFirstParent();
+        String exampleParentName = firstParent == null ? "" : firstParent.getDisplayName();
+
+        for (FlowNodeWrapper node : nodes) {
+            FlowNodeWrapper nodeParent = node.getFirstParent();
+            String nodeParentName = nodeParent == null ? "" : nodeParent.getDisplayName();
+            if (node.getDisplayName().equals(exampleDisplayName) && nodeParentName.equals(exampleParentName)) {
+                return Optional.of(node);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private void captureOrphanParallelBranches() {
+        if (!parallelBranches.isEmpty() && (firstExecuted == null || !PipelineNodeUtil.isStage(firstExecuted))) {
+            FlowNodeWrapper synStage = createParallelSyntheticNode();
+            if (synStage != null) {
+                nodes.push(synStage);
+                nodeMap.put(synStage.getId(), synStage);
+                parallelBranches.clear();
+                if (isNodeVisitorDumpEnabled) {
+                    dump(String.format(
+                            "captureOrphanParallelBranches=> setting nextStage to: [id: %s, name: %s, function: %s]",
+                            synStage.getId(),
+                            synStage.getDisplayName(),
+                            synStage.getNode().getDisplayFunctionName()));
+                }
+                this.nextStage = synStage;
+            }
+        }
+    }
+
+    /**
+     * Create synthetic stage that wraps a parallel block at top level, that is not enclosed inside a
+     * stage.
+     */
+    private @Nullable FlowNodeWrapper createParallelSyntheticNode() {
+
+        if (parallelBranches.isEmpty()) {
+            return null;
+        }
+
+        FlowNodeWrapper firstBranch = parallelBranches.getLast();
+        FlowNodeWrapper parallel = firstBranch.getFirstParent();
+
+        if (isNodeVisitorDumpEnabled) {
+            dump(String.format(
+                    "createParallelSyntheticNode=> firstBranch: %s, parallel:%s",
+                    firstBranch.getId(), (parallel == null ? "(none)" : parallel.getId())));
+        }
+
+        String syntheticNodeId = firstBranch.getNode().getParents().stream()
+                .map((node) -> node.getId())
+                .findFirst()
+                .orElseGet(() -> createSyntheticStageId(firstBranch.getId(), PARALLEL_SYNTHETIC_STAGE_NAME));
+        List<FlowNode> parents;
+        if (parallel != null) {
+            parents = parallel.getNode().getParents();
+        } else {
+            parents = new ArrayList<>();
+        }
+        FlowNode syntheticNode = new FlowNode(firstBranch.getNode().getExecution(), syntheticNodeId, parents) {
+            @Override
+            public void save() throws IOException {
+                // no-op to avoid JENKINS-45892 violations from serializing the synthetic FlowNode.
+            }
+
+            @Override
+            protected String getTypeDisplayName() {
+                return PARALLEL_SYNTHETIC_STAGE_NAME;
+            }
         };
 
-    syntheticNode.addAction(new LabelAction(PARALLEL_SYNTHETIC_STAGE_NAME));
+        syntheticNode.addAction(new LabelAction(PARALLEL_SYNTHETIC_STAGE_NAME));
 
-    long duration = 0;
-    long pauseDuration = 0;
-    long startTime = System.currentTimeMillis();
-    boolean isCompleted = true;
-    boolean isPaused = false;
-    boolean isFailure = false;
-    boolean isUnknown = false;
-    for (FlowNodeWrapper pb : parallelBranches) {
-      if (!isPaused && pb.getStatus().getState() == BlueRun.BlueRunState.PAUSED) {
-        isPaused = true;
-      }
-      if (isCompleted && pb.getStatus().getState() != BlueRun.BlueRunState.FINISHED) {
-        isCompleted = false;
-      }
+        long duration = 0;
+        long pauseDuration = 0;
+        long startTime = System.currentTimeMillis();
+        boolean isCompleted = true;
+        boolean isPaused = false;
+        boolean isFailure = false;
+        boolean isUnknown = false;
+        for (FlowNodeWrapper pb : parallelBranches) {
+            if (!isPaused && pb.getStatus().getState() == BlueRun.BlueRunState.PAUSED) {
+                isPaused = true;
+            }
+            if (isCompleted && pb.getStatus().getState() != BlueRun.BlueRunState.FINISHED) {
+                isCompleted = false;
+            }
 
-      if (!isFailure && pb.getStatus().getResult() == BlueRun.BlueRunResult.FAILURE) {
-        isFailure = true;
-      }
-      if (!isUnknown && pb.getStatus().getResult() == BlueRun.BlueRunResult.UNKNOWN) {
-        isUnknown = true;
-      }
-      duration += pb.getTiming().getTotalDurationMillis();
-      pauseDuration += pb.getTiming().getPauseDurationMillis();
+            if (!isFailure && pb.getStatus().getResult() == BlueRun.BlueRunResult.FAILURE) {
+                isFailure = true;
+            }
+            if (!isUnknown && pb.getStatus().getResult() == BlueRun.BlueRunResult.UNKNOWN) {
+                isUnknown = true;
+            }
+            duration += pb.getTiming().getTotalDurationMillis();
+            pauseDuration += pb.getTiming().getPauseDurationMillis();
+        }
+
+        BlueRun.BlueRunState state = isCompleted
+                ? BlueRun.BlueRunState.FINISHED
+                : (isPaused ? BlueRun.BlueRunState.PAUSED : BlueRun.BlueRunState.RUNNING);
+        BlueRun.BlueRunResult result = isFailure
+                ? BlueRun.BlueRunResult.FAILURE
+                : (isUnknown ? BlueRun.BlueRunResult.UNKNOWN : BlueRun.BlueRunResult.SUCCESS);
+
+        TimingInfo timingInfo = new TimingInfo(duration, pauseDuration, startTime);
+
+        FlowNodeWrapper synStage =
+                new FlowNodeWrapper(syntheticNode, new NodeRunStatus(result, state), timingInfo, run);
+
+        Iterator<FlowNodeWrapper> sortedBranches = parallelBranches.descendingIterator();
+        while (sortedBranches.hasNext()) {
+            FlowNodeWrapper p = sortedBranches.next();
+            if (isNodeVisitorDumpEnabled) {
+                dump(String.format(
+                        "createParallelSyntheticNode=> found node [id: %s, name: %s, function: %s] is child of [id: %s, name: %s, function: %s]",
+                        p.getId(),
+                        p.getDisplayName(),
+                        p.getNode().getDisplayFunctionName(),
+                        synStage.getId(),
+                        synStage.getDisplayName(),
+                        synStage.getNode().getDisplayFunctionName()));
+            }
+            p.addParent(synStage);
+            synStage.addEdge(p);
+        }
+        return synStage;
     }
 
-    BlueRun.BlueRunState state =
-        isCompleted
-            ? BlueRun.BlueRunState.FINISHED
-            : (isPaused ? BlueRun.BlueRunState.PAUSED : BlueRun.BlueRunState.RUNNING);
-    BlueRun.BlueRunResult result =
-        isFailure
-            ? BlueRun.BlueRunResult.FAILURE
-            : (isUnknown ? BlueRun.BlueRunResult.UNKNOWN : BlueRun.BlueRunResult.SUCCESS);
-
-    TimingInfo timingInfo = new TimingInfo(duration, pauseDuration, startTime);
-
-    FlowNodeWrapper synStage =
-        new FlowNodeWrapper(syntheticNode, new NodeRunStatus(result, state), timingInfo, run);
-
-    Iterator<FlowNodeWrapper> sortedBranches = parallelBranches.descendingIterator();
-    while (sortedBranches.hasNext()) {
-      FlowNodeWrapper p = sortedBranches.next();
-      if (isNodeVisitorDumpEnabled) {
-        dump(
-            String.format(
-                "createParallelSyntheticNode=> found node [id: %s, name: %s, function: %s] is child of [id: %s, name: %s, function: %s]",
-                p.getId(),
-                p.getDisplayName(),
-                p.getNode().getDisplayFunctionName(),
-                synStage.getId(),
-                synStage.getDisplayName(),
-                synStage.getNode().getDisplayFunctionName()));
-      }
-      p.addParent(synStage);
-      synStage.addEdge(p);
+    public boolean isDeclarative() {
+        return declarative;
     }
-    return synStage;
-  }
 
-  public boolean isDeclarative() {
-    return declarative;
-  }
-
-  /**
-   * Create id of synthetic stage in a deterministic base.
-   *
-   * <p>For example, an orphan parallel block with id 12 (appears top level not wrapped inside a
-   * stage) gets wrapped in a synthetic stage with id: 12-parallel-synthetic. Later client calls
-   * nodes API using this id: /nodes/12-parallel-synthetic/ would correctly pick the synthetic stage
-   * wrapping parallel block 12 by doing a lookup nodeMap.get("12-parallel-synthetic")
-   */
-  private @NonNull String createSyntheticStageId(
-      @NonNull String firstNodeId, @NonNull String syntheticStageName) {
-    return String.format("%s-%s-synthetic", firstNodeId, syntheticStageName.toLowerCase());
-  }
+    /**
+     * Create id of synthetic stage in a deterministic base.
+     *
+     * <p>For example, an orphan parallel block with id 12 (appears top level not wrapped inside a
+     * stage) gets wrapped in a synthetic stage with id: 12-parallel-synthetic. Later client calls
+     * nodes API using this id: /nodes/12-parallel-synthetic/ would correctly pick the synthetic stage
+     * wrapping parallel block 12 by doing a lookup nodeMap.get("12-parallel-synthetic")
+     */
+    private @NonNull String createSyntheticStageId(@NonNull String firstNodeId, @NonNull String syntheticStageName) {
+        return String.format("%s-%s-synthetic", firstNodeId, syntheticStageName.toLowerCase());
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
@@ -36,263 +36,256 @@ import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 /** @author Vivek Pandey */
 public class PipelineNodeUtil {
 
-  private static final String DECLARATIVE_DISPLAY_NAME_PREFIX = "Declarative: ";
+    private static final String DECLARATIVE_DISPLAY_NAME_PREFIX = "Declarative: ";
 
-  public static String getDisplayName(@NonNull FlowNode node) {
-    ThreadNameAction threadNameAction = node.getAction(ThreadNameAction.class);
-    String name =
-        threadNameAction != null ? threadNameAction.getThreadName() : node.getDisplayName();
-    return isSyntheticStage(node) && name.startsWith(DECLARATIVE_DISPLAY_NAME_PREFIX)
-        ? name.substring(DECLARATIVE_DISPLAY_NAME_PREFIX.length())
-        : name;
-  }
-
-  public static boolean isStage(FlowNode node) {
-    return node != null
-        && ((node.getAction(StageAction.class) != null)
-            || (node.getAction(LabelAction.class) != null
-                && node.getAction(ThreadNameAction.class) == null));
-  }
-
-  public static boolean isSyntheticStage(@Nullable FlowNode node) {
-    return node != null && getSyntheticStage(node) != null;
-  }
-
-  @CheckForNull
-  public static TagsAction getSyntheticStage(@Nullable FlowNode node) {
-    if (node != null) {
-      for (Action action : node.getActions()) {
-        if (action instanceof TagsAction
-            && ((TagsAction) action).getTagValue(SyntheticStage.TAG_NAME) != null) {
-          return (TagsAction) action;
-        }
-      }
-    }
-    return null;
-  }
-
-  public static boolean isPostSyntheticStage(@Nullable FlowNode node) {
-    if (node == null) {
-      return false;
-    }
-    TagsAction tagsAction = getSyntheticStage(node);
-    if (tagsAction == null) {
-      return false;
-    }
-    String value = tagsAction.getTagValue(SyntheticStage.TAG_NAME);
-    return value != null && value.equals(SyntheticStage.getPost());
-  }
-
-  public static boolean isSkippedStage(@Nullable FlowNode node) {
-    if (node == null) {
-      return false;
+    public static String getDisplayName(@NonNull FlowNode node) {
+        ThreadNameAction threadNameAction = node.getAction(ThreadNameAction.class);
+        String name = threadNameAction != null ? threadNameAction.getThreadName() : node.getDisplayName();
+        return isSyntheticStage(node) && name.startsWith(DECLARATIVE_DISPLAY_NAME_PREFIX)
+                ? name.substring(DECLARATIVE_DISPLAY_NAME_PREFIX.length())
+                : name;
     }
 
-    for (Action action : node.getActions()) {
-      if (action instanceof TagsAction
-          && ((TagsAction) action).getTagValue(StageStatus.TAG_NAME) != null) {
-        TagsAction tagsAction = (TagsAction) action;
-        String value = tagsAction.getTagValue(StageStatus.TAG_NAME);
-        return value != null
-            && (value.equals(StageStatus.getSkippedForConditional())
-                || value.equals(StageStatus.getSkippedForFailure())
-                || value.equals(StageStatus.getSkippedForUnstable()));
-      }
+    public static boolean isStage(FlowNode node) {
+        return node != null
+                && ((node.getAction(StageAction.class) != null)
+                        || (node.getAction(LabelAction.class) != null
+                                && node.getAction(ThreadNameAction.class) == null));
     }
 
-    return false;
-  }
-
-  public static boolean isPreSyntheticStage(@Nullable FlowNode node) {
-    if (node == null) {
-      return false;
+    public static boolean isSyntheticStage(@Nullable FlowNode node) {
+        return node != null && getSyntheticStage(node) != null;
     }
-    TagsAction tagsAction = getSyntheticStage(node);
-    if (tagsAction == null) {
-      return false;
-    }
-    String value = tagsAction.getTagValue(SyntheticStage.TAG_NAME);
-    return value != null && value.equals(SyntheticStage.getPre());
-  }
 
-  public static boolean isParallelBranch(@Nullable FlowNode node) {
-    return node != null
-        && node.getAction(LabelAction.class) != null
-        && node.getAction(ThreadNameAction.class) != null;
-  }
-
-  public static boolean isUnhandledException(@Nullable FlowNode node) {
-    return node != null && node.getAction(ErrorAction.class) != null;
-  }
-
-  public static String getArgumentsAsString(@Nullable FlowNode node) {
-    if (node != null) {
-      return ArgumentsAction.getStepArgumentsAsString(node);
-    }
-    return "";
-  }
-
-  /**
-   * Gives cause of block for declarative style plugin where agent (node block) is declared inside a
-   * stage.
-   *
-   * <pre>
-   *    pipeline {
-   *      agent none
-   *      stages {
-   *          stage ('first') {
-   *              agent {
-   *                  label 'first'
-   *              }
-   *              steps{
-   *                  sh 'echo "from first"'
-   *              }
-   *          }
-   *      }
-   *    }
-   *  </pre>
-   *
-   * @param stage stage's {@link FlowNode}
-   * @param nodeBlock agent or node block's {@link FlowNode}
-   * @return cause of block if present, nul otherwise
-   */
-  public static @CheckForNull String getCauseOfBlockage(
-      @NonNull FlowNode stage, @Nullable FlowNode nodeBlock) {
-    if (nodeBlock != null) {
-      // Check and see if this node block is inside this stage
-      for (FlowNode p : nodeBlock.getParents()) {
-        if (p.equals(stage)) {
-          Queue.Item item = QueueItemAction.getQueueItem(nodeBlock);
-          if (item != null) {
-            CauseOfBlockage causeOfBlockage = item.getCauseOfBlockage();
-            String cause = null;
-            if (causeOfBlockage != null) {
-              cause = causeOfBlockage.getShortDescription();
-              if (cause == null) {
-                causeOfBlockage = item.task.getCauseOfBlockage();
-                if (causeOfBlockage != null) {
-                  return causeOfBlockage.getShortDescription();
+    @CheckForNull
+    public static TagsAction getSyntheticStage(@Nullable FlowNode node) {
+        if (node != null) {
+            for (Action action : node.getActions()) {
+                if (action instanceof TagsAction
+                        && ((TagsAction) action).getTagValue(SyntheticStage.TAG_NAME) != null) {
+                    return (TagsAction) action;
                 }
-              }
             }
-            return cause;
-          }
         }
-      }
+        return null;
     }
-    return null;
-  }
 
-  public static final Predicate<FlowNode> isLoggable =
-      input -> {
+    public static boolean isPostSyntheticStage(@Nullable FlowNode node) {
+        if (node == null) {
+            return false;
+        }
+        TagsAction tagsAction = getSyntheticStage(node);
+        if (tagsAction == null) {
+            return false;
+        }
+        String value = tagsAction.getTagValue(SyntheticStage.TAG_NAME);
+        return value != null && value.equals(SyntheticStage.getPost());
+    }
+
+    public static boolean isSkippedStage(@Nullable FlowNode node) {
+        if (node == null) {
+            return false;
+        }
+
+        for (Action action : node.getActions()) {
+            if (action instanceof TagsAction && ((TagsAction) action).getTagValue(StageStatus.TAG_NAME) != null) {
+                TagsAction tagsAction = (TagsAction) action;
+                String value = tagsAction.getTagValue(StageStatus.TAG_NAME);
+                return value != null
+                        && (value.equals(StageStatus.getSkippedForConditional())
+                                || value.equals(StageStatus.getSkippedForFailure())
+                                || value.equals(StageStatus.getSkippedForUnstable()));
+            }
+        }
+
+        return false;
+    }
+
+    public static boolean isPreSyntheticStage(@Nullable FlowNode node) {
+        if (node == null) {
+            return false;
+        }
+        TagsAction tagsAction = getSyntheticStage(node);
+        if (tagsAction == null) {
+            return false;
+        }
+        String value = tagsAction.getTagValue(SyntheticStage.TAG_NAME);
+        return value != null && value.equals(SyntheticStage.getPre());
+    }
+
+    public static boolean isParallelBranch(@Nullable FlowNode node) {
+        return node != null
+                && node.getAction(LabelAction.class) != null
+                && node.getAction(ThreadNameAction.class) != null;
+    }
+
+    public static boolean isUnhandledException(@Nullable FlowNode node) {
+        return node != null && node.getAction(ErrorAction.class) != null;
+    }
+
+    public static String getArgumentsAsString(@Nullable FlowNode node) {
+        if (node != null) {
+            return ArgumentsAction.getStepArgumentsAsString(node);
+        }
+        return "";
+    }
+
+    /**
+     * Gives cause of block for declarative style plugin where agent (node block) is declared inside a
+     * stage.
+     *
+     * <pre>
+     *    pipeline {
+     *      agent none
+     *      stages {
+     *          stage ('first') {
+     *              agent {
+     *                  label 'first'
+     *              }
+     *              steps{
+     *                  sh 'echo "from first"'
+     *              }
+     *          }
+     *      }
+     *    }
+     *  </pre>
+     *
+     * @param stage stage's {@link FlowNode}
+     * @param nodeBlock agent or node block's {@link FlowNode}
+     * @return cause of block if present, nul otherwise
+     */
+    public static @CheckForNull String getCauseOfBlockage(@NonNull FlowNode stage, @Nullable FlowNode nodeBlock) {
+        if (nodeBlock != null) {
+            // Check and see if this node block is inside this stage
+            for (FlowNode p : nodeBlock.getParents()) {
+                if (p.equals(stage)) {
+                    Queue.Item item = QueueItemAction.getQueueItem(nodeBlock);
+                    if (item != null) {
+                        CauseOfBlockage causeOfBlockage = item.getCauseOfBlockage();
+                        String cause = null;
+                        if (causeOfBlockage != null) {
+                            cause = causeOfBlockage.getShortDescription();
+                            if (cause == null) {
+                                causeOfBlockage = item.task.getCauseOfBlockage();
+                                if (causeOfBlockage != null) {
+                                    return causeOfBlockage.getShortDescription();
+                                }
+                            }
+                        }
+                        return cause;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    public static final Predicate<FlowNode> isLoggable = input -> {
         if (input == null) return false;
         return input.getAction(LogAction.class) != null;
-      };
+    };
 
-  public static boolean isPausedForInputStep(
-      @NonNull StepAtomNode step, @Nullable InputAction inputAction) {
-    if (inputAction == null) {
-      return false;
-    }
-    PauseAction pauseAction = step.getAction(PauseAction.class);
-    return (pauseAction != null
-        && pauseAction.isPaused()
-        && pauseAction.getCause().equals("Input"));
-  }
-
-  /**
-   * Determine if the given {@link FlowNode} is the initial {@link StepStartNode} for an {@link
-   * ExecutorStep}.
-   *
-   * @param node a possibly null {@link FlowNode}
-   * @return true if {@code node} is the non-body start of the agent execution.
-   */
-  public static boolean isAgentStart(@Nullable FlowNode node) {
-    if (node != null) {
-      if (node instanceof StepStartNode) {
-        StepStartNode stepStartNode = (StepStartNode) node;
-        if (stepStartNode.getDescriptor() != null) {
-          StepDescriptor sd = stepStartNode.getDescriptor();
-          return sd != null
-              && ExecutorStep.DescriptorImpl.class.equals(sd.getClass())
-              && !stepStartNode.isBody();
+    public static boolean isPausedForInputStep(@NonNull StepAtomNode step, @Nullable InputAction inputAction) {
+        if (inputAction == null) {
+            return false;
         }
-      }
+        PauseAction pauseAction = step.getAction(PauseAction.class);
+        return (pauseAction != null
+                && pauseAction.isPaused()
+                && pauseAction.getCause().equals("Input"));
     }
 
-    return false;
-  }
-
-  /* Get the AnnotatedLargeText for a given node.
-   * @param node a possibly null {@link FlowNode}
-   * @return The AnnotatedLargeText object representing the log text for this node, or null.
-   */
-  public static AnnotatedLargeText<? extends FlowNode> getLogText(@Nullable FlowNode node) {
-    if (node != null) {
-      LogAction logAction = node.getAction(LogAction.class);
-      if (logAction != null) {
-        return logAction.getLogText();
-      }
-    }
-    return null;
-  }
-
-  /* Get the generated log text for a given node.
-   * @param log The AnnotatedLargeText object for a given node.
-   * @return The AnnotatedLargeText object representing the log text for this node, or null.
-   */
-  public static String convertLogToString(AnnotatedLargeText<? extends FlowNode> log)
-      throws IOException {
-    return convertLogToString(log, 0L);
-  }
-
-  /* Get the generated log text for a given node.
-   * @param log The AnnotatedLargeText object for a given node.
-   * @param startByte The byte to start parsing from.
-   * @return The AnnotatedLargeText object representing the log text for this node, or null.
-   */
-  @SuppressWarnings("RV_RETURN_VALUE_IGNORED")
-  public static String convertLogToString(
-      AnnotatedLargeText<? extends FlowNode> log, Long startByte) throws IOException {
-    Writer stringWriter = new StringBuilderWriter();
-    // NOTE: This returns the total length of the console log, not the received bytes.
-    log.writeHtmlTo(startByte, stringWriter);
-    return stringWriter.toString();
-  }
-
-  /* The exception text from aa FlowNode.
-   * @param node a possibly null {@link FlowNode}
-   * @return A string representing the exception thrown from this node, or null.
-   */
-  public static String getExceptionText(@Nullable FlowNode node) {
-    if (node != null) {
-      String log = null;
-      ErrorAction error = node.getAction(ErrorAction.class);
-      if (error != null) {
-        Throwable exception = error.getError();
-        if (PipelineNodeUtil.isJenkinsFailureException(exception)) {
-          // If this is a Jenkins exception to mark a build failure then only return the mesage -
-          // the stack trace is unimportant as the message will be attached to the step.
-          log = exception.getMessage();
-        } else {
-          // If this is not a Jenkins failure exception, then we should print everything.
-          log = "Found unhandled " + exception.getClass().getName() + " exception:\n";
-          log += exception.getMessage() + "\n\t";
-          log +=
-              Arrays.stream(exception.getStackTrace())
-                  .map(s -> s.toString())
-                  .collect(Collectors.joining("\n\t"));
+    /**
+     * Determine if the given {@link FlowNode} is the initial {@link StepStartNode} for an {@link
+     * ExecutorStep}.
+     *
+     * @param node a possibly null {@link FlowNode}
+     * @return true if {@code node} is the non-body start of the agent execution.
+     */
+    public static boolean isAgentStart(@Nullable FlowNode node) {
+        if (node != null) {
+            if (node instanceof StepStartNode) {
+                StepStartNode stepStartNode = (StepStartNode) node;
+                if (stepStartNode.getDescriptor() != null) {
+                    StepDescriptor sd = stepStartNode.getDescriptor();
+                    return sd != null
+                            && ExecutorStep.DescriptorImpl.class.equals(sd.getClass())
+                            && !stepStartNode.isBody();
+                }
+            }
         }
-      }
-      return log;
-    }
-    return null;
-  }
 
-  public static boolean isJenkinsFailureException(Throwable exception) {
-    if (exception instanceof AbortException) {
-      return true;
+        return false;
     }
-    return false;
-  }
+
+    /* Get the AnnotatedLargeText for a given node.
+     * @param node a possibly null {@link FlowNode}
+     * @return The AnnotatedLargeText object representing the log text for this node, or null.
+     */
+    public static AnnotatedLargeText<? extends FlowNode> getLogText(@Nullable FlowNode node) {
+        if (node != null) {
+            LogAction logAction = node.getAction(LogAction.class);
+            if (logAction != null) {
+                return logAction.getLogText();
+            }
+        }
+        return null;
+    }
+
+    /* Get the generated log text for a given node.
+     * @param log The AnnotatedLargeText object for a given node.
+     * @return The AnnotatedLargeText object representing the log text for this node, or null.
+     */
+    public static String convertLogToString(AnnotatedLargeText<? extends FlowNode> log) throws IOException {
+        return convertLogToString(log, 0L);
+    }
+
+    /* Get the generated log text for a given node.
+     * @param log The AnnotatedLargeText object for a given node.
+     * @param startByte The byte to start parsing from.
+     * @return The AnnotatedLargeText object representing the log text for this node, or null.
+     */
+    @SuppressWarnings("RV_RETURN_VALUE_IGNORED")
+    public static String convertLogToString(AnnotatedLargeText<? extends FlowNode> log, Long startByte)
+            throws IOException {
+        Writer stringWriter = new StringBuilderWriter();
+        // NOTE: This returns the total length of the console log, not the received bytes.
+        log.writeHtmlTo(startByte, stringWriter);
+        return stringWriter.toString();
+    }
+
+    /* The exception text from aa FlowNode.
+     * @param node a possibly null {@link FlowNode}
+     * @return A string representing the exception thrown from this node, or null.
+     */
+    public static String getExceptionText(@Nullable FlowNode node) {
+        if (node != null) {
+            String log = null;
+            ErrorAction error = node.getAction(ErrorAction.class);
+            if (error != null) {
+                Throwable exception = error.getError();
+                if (PipelineNodeUtil.isJenkinsFailureException(exception)) {
+                    // If this is a Jenkins exception to mark a build failure then only return the mesage -
+                    // the stack trace is unimportant as the message will be attached to the step.
+                    log = exception.getMessage();
+                } else {
+                    // If this is not a Jenkins failure exception, then we should print everything.
+                    log = "Found unhandled " + exception.getClass().getName() + " exception:\n";
+                    log += exception.getMessage() + "\n\t";
+                    log += Arrays.stream(exception.getStackTrace())
+                            .map(s -> s.toString())
+                            .collect(Collectors.joining("\n\t"));
+                }
+            }
+            return log;
+        }
+        return null;
+    }
+
+    public static boolean isJenkinsFailureException(Throwable exception) {
+        if (exception instanceof AbortException) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStage.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStage.java
@@ -6,110 +6,108 @@ import java.util.List;
 
 public class PipelineStage {
 
-  private String name;
-  private List<PipelineStage> children;
-  private String state; // TODO enum
-  private int completePercent; // TODO int is fine?
-  private String type; // TODO enum
-  private String title;
-  private String id; // TODO what's this for?
-  private String seqContainerName;
-  private final PipelineStage nextSibling;
-  private boolean sequential;
-  private boolean synthetic;
-  private String pauseDurationMillis;
-  private String startTimeMillis;
-  private String totalDurationMillis;
+    private String name;
+    private List<PipelineStage> children;
+    private String state; // TODO enum
+    private int completePercent; // TODO int is fine?
+    private String type; // TODO enum
+    private String title;
+    private String id; // TODO what's this for?
+    private String seqContainerName;
+    private final PipelineStage nextSibling;
+    private boolean sequential;
+    private boolean synthetic;
+    private String pauseDurationMillis;
+    private String startTimeMillis;
+    private String totalDurationMillis;
 
-  public PipelineStage(
-      String id,
-      String name,
-      List<PipelineStage> children,
-      String state,
-      int completePercent,
-      String type,
-      String title,
-      String seqContainerName,
-      PipelineStage nextSibling,
-      boolean sequential,
-      boolean synthetic,
-      Long pauseDurationMillis,
-      Long startTimeMillis,
-      Long totalDurationMillis) {
-    this.id = id;
-    this.name = name;
-    this.children = children;
-    this.state = state;
-    this.completePercent = completePercent;
-    this.type = type;
-    this.title = title;
-    this.seqContainerName = seqContainerName;
-    this.nextSibling = nextSibling;
-    this.sequential = sequential;
-    this.synthetic = synthetic;
-    this.pauseDurationMillis = "Queued " + Util.getTimeSpanString(pauseDurationMillis);
-    this.startTimeMillis =
-        "Started "
-            + Util.getTimeSpanString(Math.abs(startTimeMillis - new Date().getTime()))
-            + " ago";
-    this.totalDurationMillis = "Took " + Util.getTimeSpanString(totalDurationMillis);
-  }
+    public PipelineStage(
+            String id,
+            String name,
+            List<PipelineStage> children,
+            String state,
+            int completePercent,
+            String type,
+            String title,
+            String seqContainerName,
+            PipelineStage nextSibling,
+            boolean sequential,
+            boolean synthetic,
+            Long pauseDurationMillis,
+            Long startTimeMillis,
+            Long totalDurationMillis) {
+        this.id = id;
+        this.name = name;
+        this.children = children;
+        this.state = state;
+        this.completePercent = completePercent;
+        this.type = type;
+        this.title = title;
+        this.seqContainerName = seqContainerName;
+        this.nextSibling = nextSibling;
+        this.sequential = sequential;
+        this.synthetic = synthetic;
+        this.pauseDurationMillis = "Queued " + Util.getTimeSpanString(pauseDurationMillis);
+        this.startTimeMillis =
+                "Started " + Util.getTimeSpanString(Math.abs(startTimeMillis - new Date().getTime())) + " ago";
+        this.totalDurationMillis = "Took " + Util.getTimeSpanString(totalDurationMillis);
+    }
 
-  public String getPauseDurationMillis() {
-    return pauseDurationMillis;
-  }
+    public String getPauseDurationMillis() {
+        return pauseDurationMillis;
+    }
 
-  public String getStartTimeMillis() {
-    return startTimeMillis;
-  }
+    public String getStartTimeMillis() {
+        return startTimeMillis;
+    }
 
-  public String getTotalDurationMillis() {
-    return totalDurationMillis;
-  }
+    public String getTotalDurationMillis() {
+        return totalDurationMillis;
+    }
 
-  public PipelineStage getNextSibling() {
-    return nextSibling;
-  }
+    public PipelineStage getNextSibling() {
+        return nextSibling;
+    }
 
-  // TODO clean up naming
-  // HACK: blue ocean has a broken name for this 'isSequential'
-  public boolean getIsSequential() {
-    return sequential;
-  }
+    // TODO clean up naming
+    // HACK: blue ocean has a broken name for this 'isSequential'
+    public boolean getIsSequential() {
+        return sequential;
+    }
 
-  public String getSeqContainerName() {
-    return seqContainerName;
-  }
+    public String getSeqContainerName() {
+        return seqContainerName;
+    }
 
-  public String getId() {
-    return id;
-  }
+    public String getId() {
+        return id;
+    }
 
-  public String getName() {
-    return name;
-  }
+    public String getName() {
+        return name;
+    }
 
-  public List<PipelineStage> getChildren() {
-    return children;
-  }
+    public List<PipelineStage> getChildren() {
+        return children;
+    }
 
-  public String getState() {
-    return state;
-  }
+    public String getState() {
+        return state;
+    }
 
-  public int getCompletePercent() {
-    return completePercent;
-  }
+    public int getCompletePercent() {
+        return completePercent;
+    }
 
-  public String getType() {
-    return type;
-  }
+    public String getType() {
+        return type;
+    }
 
-  public String getTitle() {
-    return title;
-  }
+    public String getTitle() {
+        return title;
+    }
 
-  public boolean isSynthetic() {
-    return synthetic;
-  }
+    public boolean isSynthetic() {
+        return synthetic;
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStageInternal.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStageInternal.java
@@ -6,139 +6,139 @@ import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.TimingInfo;
 
 public class PipelineStageInternal {
 
-  private String name;
-  private List<String> parents;
-  private String state; // TODO enum
-  private int completePercent; // TODO int is fine?
-  private String type; // TODO enum
-  private String title;
-  private String id;
-  private String seqContainerName;
-  private PipelineStageInternal nextSibling;
-  private boolean sequential;
-  private boolean synthetic;
-  private Long pauseDurationMillis;
-  private Long startTimeMillis;
-  private Long totalDurationMillis;
+    private String name;
+    private List<String> parents;
+    private String state; // TODO enum
+    private int completePercent; // TODO int is fine?
+    private String type; // TODO enum
+    private String title;
+    private String id;
+    private String seqContainerName;
+    private PipelineStageInternal nextSibling;
+    private boolean sequential;
+    private boolean synthetic;
+    private Long pauseDurationMillis;
+    private Long startTimeMillis;
+    private Long totalDurationMillis;
 
-  public PipelineStageInternal(
-      String id,
-      String name,
-      List<String> parents,
-      String state,
-      int completePercent,
-      String type,
-      String title,
-      boolean synthetic,
-      TimingInfo times) {
-    this.id = id;
-    this.name = name;
-    this.parents = parents;
-    this.state = state;
-    this.completePercent = completePercent;
-    this.type = type;
-    this.title = title;
-    this.synthetic = synthetic;
-    this.pauseDurationMillis = times.getPauseDurationMillis();
-    this.startTimeMillis = times.getStartTimeMillis();
-    this.totalDurationMillis = times.getTotalDurationMillis();
-  }
+    public PipelineStageInternal(
+            String id,
+            String name,
+            List<String> parents,
+            String state,
+            int completePercent,
+            String type,
+            String title,
+            boolean synthetic,
+            TimingInfo times) {
+        this.id = id;
+        this.name = name;
+        this.parents = parents;
+        this.state = state;
+        this.completePercent = completePercent;
+        this.type = type;
+        this.title = title;
+        this.synthetic = synthetic;
+        this.pauseDurationMillis = times.getPauseDurationMillis();
+        this.startTimeMillis = times.getStartTimeMillis();
+        this.totalDurationMillis = times.getTotalDurationMillis();
+    }
 
-  public boolean isSequential() {
-    return sequential;
-  }
+    public boolean isSequential() {
+        return sequential;
+    }
 
-  public void setId(String id) {
-    this.id = id;
-  }
+    public void setId(String id) {
+        this.id = id;
+    }
 
-  public void setSequential(boolean sequential) {
-    this.sequential = sequential;
-  }
+    public void setSequential(boolean sequential) {
+        this.sequential = sequential;
+    }
 
-  public void setState(String state) {
-    this.state = state;
-  }
+    public void setState(String state) {
+        this.state = state;
+    }
 
-  public void setCompletePercent(int completePercent) {
-    this.completePercent = completePercent;
-  }
+    public void setCompletePercent(int completePercent) {
+        this.completePercent = completePercent;
+    }
 
-  public void setType(String type) {
-    this.type = type;
-  }
+    public void setType(String type) {
+        this.type = type;
+    }
 
-  public void setTitle(String title) {
-    this.title = title;
-  }
+    public void setTitle(String title) {
+        this.title = title;
+    }
 
-  public void setNextSibling(PipelineStageInternal nextSibling) {
-    this.nextSibling = nextSibling;
-  }
+    public void setNextSibling(PipelineStageInternal nextSibling) {
+        this.nextSibling = nextSibling;
+    }
 
-  public void setSeqContainerName(String seqContainerName) {
-    this.seqContainerName = seqContainerName;
-  }
+    public void setSeqContainerName(String seqContainerName) {
+        this.seqContainerName = seqContainerName;
+    }
 
-  public void setName(String name) {
-    this.name = name;
-  }
+    public void setName(String name) {
+        this.name = name;
+    }
 
-  public String getSeqContainerName() {
-    return seqContainerName;
-  }
+    public String getSeqContainerName() {
+        return seqContainerName;
+    }
 
-  public String getId() {
-    return id;
-  }
+    public String getId() {
+        return id;
+    }
 
-  public String getName() {
-    return name;
-  }
+    public String getName() {
+        return name;
+    }
 
-  public List<String> getParents() {
-    return parents;
-  }
+    public List<String> getParents() {
+        return parents;
+    }
 
-  public String getState() {
-    return state;
-  }
+    public String getState() {
+        return state;
+    }
 
-  public int getCompletePercent() {
-    return completePercent;
-  }
+    public int getCompletePercent() {
+        return completePercent;
+    }
 
-  public String getType() {
-    return type;
-  }
+    public String getType() {
+        return type;
+    }
 
-  public String getTitle() {
-    return title;
-  }
+    public String getTitle() {
+        return title;
+    }
 
-  public boolean isSynthetic() {
-    return synthetic;
-  }
+    public boolean isSynthetic() {
+        return synthetic;
+    }
 
-  public void setSynthetic(boolean synthetic) {
-    this.synthetic = synthetic;
-  }
+    public void setSynthetic(boolean synthetic) {
+        this.synthetic = synthetic;
+    }
 
-  public PipelineStage toPipelineStage(List<PipelineStage> children) {
-    return new PipelineStage(
-        id,
-        name,
-        children,
-        state,
-        completePercent,
-        type,
-        title,
-        seqContainerName,
-        nextSibling != null ? nextSibling.toPipelineStage(Collections.emptyList()) : null,
-        sequential,
-        synthetic,
-        pauseDurationMillis,
-        startTimeMillis,
-        totalDurationMillis);
-  }
+    public PipelineStage toPipelineStage(List<PipelineStage> children) {
+        return new PipelineStage(
+                id,
+                name,
+                children,
+                state,
+                completePercent,
+                type,
+                title,
+                seqContainerName,
+                nextSibling != null ? nextSibling.toPipelineStage(Collections.emptyList()) : null,
+                sequential,
+                synthetic,
+                pauseDurationMillis,
+                startTimeMillis,
+                totalDurationMillis);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStep.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStep.java
@@ -2,78 +2,78 @@ package io.jenkins.plugins.pipelinegraphview.utils;
 
 public class PipelineStep {
 
-  private String name;
-  private String state; // TODO enum
-  private int completePercent; // TODO int is fine?
-  private String type; // TODO enum
-  private String title;
-  private int id;
-  private String stageId;
-  private String pauseDurationMillis;
-  private String startTimeMillis;
-  private String totalDurationMillis;
+    private String name;
+    private String state; // TODO enum
+    private int completePercent; // TODO int is fine?
+    private String type; // TODO enum
+    private String title;
+    private int id;
+    private String stageId;
+    private String pauseDurationMillis;
+    private String startTimeMillis;
+    private String totalDurationMillis;
 
-  public PipelineStep(
-      int id,
-      String name,
-      String state,
-      int completePercent,
-      String type,
-      String title,
-      String stageId,
-      String pauseDurationMillis,
-      String startTimeMillis,
-      String totalDurationMillis) {
+    public PipelineStep(
+            int id,
+            String name,
+            String state,
+            int completePercent,
+            String type,
+            String title,
+            String stageId,
+            String pauseDurationMillis,
+            String startTimeMillis,
+            String totalDurationMillis) {
 
-    this.id = id;
-    this.name = name;
-    this.state = state;
-    this.completePercent = completePercent;
-    this.type = type;
-    this.title = title;
-    this.stageId = stageId;
-    this.pauseDurationMillis = pauseDurationMillis;
-    this.startTimeMillis = startTimeMillis;
-    this.totalDurationMillis = totalDurationMillis;
-  }
+        this.id = id;
+        this.name = name;
+        this.state = state;
+        this.completePercent = completePercent;
+        this.type = type;
+        this.title = title;
+        this.stageId = stageId;
+        this.pauseDurationMillis = pauseDurationMillis;
+        this.startTimeMillis = startTimeMillis;
+        this.totalDurationMillis = totalDurationMillis;
+    }
 
-  public String getPauseDurationMillis() {
-    return pauseDurationMillis;
-  }
+    public String getPauseDurationMillis() {
+        return pauseDurationMillis;
+    }
 
-  public String getStartTimeMillis() {
-    return startTimeMillis;
-  }
+    public String getStartTimeMillis() {
+        return startTimeMillis;
+    }
 
-  public String getTotalDurationMillis() {
-    return totalDurationMillis;
-  }
+    public String getTotalDurationMillis() {
+        return totalDurationMillis;
+    }
 
-  public int getId() {
-    return id;
-  }
+    public int getId() {
+        return id;
+    }
 
-  public String getName() {
-    return name;
-  }
+    public String getName() {
+        return name;
+    }
 
-  public String getState() {
-    return state;
-  }
+    public String getState() {
+        return state;
+    }
 
-  public int getCompletePercent() {
-    return completePercent;
-  }
+    public int getCompletePercent() {
+        return completePercent;
+    }
 
-  public String getType() {
-    return type;
-  }
+    public String getType() {
+        return type;
+    }
 
-  public String getTitle() {
-    return title;
-  }
+    public String getTitle() {
+        return title;
+    }
 
-  public String getStageId() {
-    return stageId;
-  }
+    public String getStageId() {
+        return stageId;
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
@@ -10,93 +10,89 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PipelineStepApi {
-  private static final Logger logger = LoggerFactory.getLogger(PipelineStepApi.class);
-  private final transient WorkflowRun run;
+    private static final Logger logger = LoggerFactory.getLogger(PipelineStepApi.class);
+    private final transient WorkflowRun run;
 
-  public PipelineStepApi(WorkflowRun run) {
-    this.run = run;
-  }
-
-  private List<PipelineStep> parseSteps(List<FlowNodeWrapper> stepNodes, String stageId) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("PipelineStepApi steps: '" + stepNodes + "'.");
+    public PipelineStepApi(WorkflowRun run) {
+        this.run = run;
     }
-    List<PipelineStep> steps =
-        stepNodes.stream()
-            .map(
-                flowNodeWrapper -> {
-                  String state =
-                      flowNodeWrapper.getStatus().getResult().name().toLowerCase(Locale.ROOT);
-                  if (flowNodeWrapper.getStatus().getState() != BlueRun.BlueRunState.FINISHED) {
-                    state = flowNodeWrapper.getStatus().getState().name().toLowerCase(Locale.ROOT);
-                  }
-                  String displayName = flowNodeWrapper.getDisplayName();
 
-                  if (flowNodeWrapper.getType() == FlowNodeWrapper.NodeType.UNHANDLED_EXCEPTION) {
-                    displayName = "Pipeline error";
-                  } else {
-                    String stepArguments = flowNodeWrapper.getArgumentsAsString();
-                    if (stepArguments != null && !stepArguments.isEmpty()) {
-                      displayName = stepArguments + " - " + displayName;
+    private List<PipelineStep> parseSteps(List<FlowNodeWrapper> stepNodes, String stageId) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("PipelineStepApi steps: '" + stepNodes + "'.");
+        }
+        List<PipelineStep> steps = stepNodes.stream()
+                .map(flowNodeWrapper -> {
+                    String state =
+                            flowNodeWrapper.getStatus().getResult().name().toLowerCase(Locale.ROOT);
+                    if (flowNodeWrapper.getStatus().getState() != BlueRun.BlueRunState.FINISHED) {
+                        state = flowNodeWrapper.getStatus().getState().name().toLowerCase(Locale.ROOT);
                     }
-                    // Use the step label as the displayName if set
-                    String labelDisplayName = flowNodeWrapper.getLabelDisplayName();
-                    if (labelDisplayName != null && !labelDisplayName.isEmpty()) {
-                      displayName = labelDisplayName;
-                    }
-                  }
-                  // Remove non-printable chars (e.g. ANSI color codes).
-                  logger.debug("DisplayName Before: '" + displayName + "'.");
-                  displayName = cleanTextContent(displayName);
-                  logger.debug("DisplayName After: '" + displayName + "'.");
+                    String displayName = flowNodeWrapper.getDisplayName();
 
-                  return new PipelineStep(
-                      Integer.parseInt(flowNodeWrapper.getId()),
-                      displayName,
-                      state,
-                      50, // TODO how ???
-                      flowNodeWrapper.getType().name(),
-                      flowNodeWrapper
-                          .getDisplayName(), // TODO blue ocean uses timing information: "Passed in
-                      // 0s"
-                      stageId,
-                      "Queued "
-                          + Util.getTimeSpanString(
-                              flowNodeWrapper.getTiming().getPauseDurationMillis()),
-                      "Started "
-                          + Util.getTimeSpanString(
-                              System.currentTimeMillis()
-                                  - flowNodeWrapper.getTiming().getStartTimeMillis())
-                          + " ago",
-                      "Took "
-                          + Util.getTimeSpanString(
-                              flowNodeWrapper.getTiming().getTotalDurationMillis()));
+                    if (flowNodeWrapper.getType() == FlowNodeWrapper.NodeType.UNHANDLED_EXCEPTION) {
+                        displayName = "Pipeline error";
+                    } else {
+                        String stepArguments = flowNodeWrapper.getArgumentsAsString();
+                        if (stepArguments != null && !stepArguments.isEmpty()) {
+                            displayName = stepArguments + " - " + displayName;
+                        }
+                        // Use the step label as the displayName if set
+                        String labelDisplayName = flowNodeWrapper.getLabelDisplayName();
+                        if (labelDisplayName != null && !labelDisplayName.isEmpty()) {
+                            displayName = labelDisplayName;
+                        }
+                    }
+                    // Remove non-printable chars (e.g. ANSI color codes).
+                    logger.debug("DisplayName Before: '" + displayName + "'.");
+                    displayName = cleanTextContent(displayName);
+                    logger.debug("DisplayName After: '" + displayName + "'.");
+
+                    return new PipelineStep(
+                            Integer.parseInt(flowNodeWrapper.getId()),
+                            displayName,
+                            state,
+                            50, // TODO how ???
+                            flowNodeWrapper.getType().name(),
+                            flowNodeWrapper.getDisplayName(), // TODO blue ocean uses timing information: "Passed in
+                            // 0s"
+                            stageId,
+                            "Queued "
+                                    + Util.getTimeSpanString(
+                                            flowNodeWrapper.getTiming().getPauseDurationMillis()),
+                            "Started "
+                                    + Util.getTimeSpanString(System.currentTimeMillis()
+                                            - flowNodeWrapper.getTiming().getStartTimeMillis())
+                                    + " ago",
+                            "Took "
+                                    + Util.getTimeSpanString(
+                                            flowNodeWrapper.getTiming().getTotalDurationMillis()));
                 })
-            .collect(Collectors.toList());
-    return steps;
-  }
-
-  private static String cleanTextContent(String text) {
-    // strips off all ANSI color codes
-    text = text.replaceAll("\\[\\d+m", "");
-    return text.trim();
-  }
-
-  public PipelineStepList getSteps(String stageId) {
-    PipelineStepVisitor builder = new PipelineStepVisitor(run);
-    List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
-    return new PipelineStepList(parseSteps(stepNodes, stageId));
-  }
-
-  /* Returns a PipelineStepList, sorted by stageId and Id. */
-  public PipelineStepList getAllSteps() {
-    PipelineStepVisitor builder = new PipelineStepVisitor(run);
-    Map<String, List<FlowNodeWrapper>> stepNodes = builder.getAllSteps();
-    PipelineStepList allSteps = new PipelineStepList();
-    for (Map.Entry<String, List<FlowNodeWrapper>> entry : stepNodes.entrySet()) {
-      allSteps.addAll(parseSteps(entry.getValue(), entry.getKey()));
+                .collect(Collectors.toList());
+        return steps;
     }
-    allSteps.sort();
-    return allSteps;
-  }
+
+    private static String cleanTextContent(String text) {
+        // strips off all ANSI color codes
+        text = text.replaceAll("\\[\\d+m", "");
+        return text.trim();
+    }
+
+    public PipelineStepList getSteps(String stageId) {
+        PipelineStepVisitor builder = new PipelineStepVisitor(run);
+        List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
+        return new PipelineStepList(parseSteps(stepNodes, stageId));
+    }
+
+    /* Returns a PipelineStepList, sorted by stageId and Id. */
+    public PipelineStepList getAllSteps() {
+        PipelineStepVisitor builder = new PipelineStepVisitor(run);
+        Map<String, List<FlowNodeWrapper>> stepNodes = builder.getAllSteps();
+        PipelineStepList allSteps = new PipelineStepList();
+        for (Map.Entry<String, List<FlowNodeWrapper>> entry : stepNodes.entrySet()) {
+            allSteps.addAll(parseSteps(entry.getValue(), entry.getKey()));
+        }
+        allSteps.sort();
+        return allSteps;
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepList.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepList.java
@@ -5,34 +5,32 @@ import java.util.List;
 
 public class PipelineStepList {
 
-  private List<PipelineStep> steps;
+    private List<PipelineStep> steps;
 
-  public PipelineStepList() {
-    this.steps = new ArrayList<PipelineStep>();
-  }
+    public PipelineStepList() {
+        this.steps = new ArrayList<PipelineStep>();
+    }
 
-  public PipelineStepList(List<PipelineStep> steps) {
-    this.steps = steps;
-  }
+    public PipelineStepList(List<PipelineStep> steps) {
+        this.steps = steps;
+    }
 
-  public List<PipelineStep> getSteps() {
-    return steps;
-  }
+    public List<PipelineStep> getSteps() {
+        return steps;
+    }
 
-  /* Sorts the list of PipelineSteps by stageId and Id. */
-  public void sort() {
-    this.steps.sort(
-        (lhs, rhs) -> {
-          if (lhs.getStageId().equals(rhs.getStageId())) {
-            return Integer.compare(
-                Integer.parseInt(lhs.getStageId()), Integer.parseInt(rhs.getStageId()));
-          } else {
-            return Integer.compare(lhs.getId(), rhs.getId());
-          }
+    /* Sorts the list of PipelineSteps by stageId and Id. */
+    public void sort() {
+        this.steps.sort((lhs, rhs) -> {
+            if (lhs.getStageId().equals(rhs.getStageId())) {
+                return Integer.compare(Integer.parseInt(lhs.getStageId()), Integer.parseInt(rhs.getStageId()));
+            } else {
+                return Integer.compare(lhs.getId(), rhs.getId());
+            }
         });
-  }
+    }
 
-  public void addAll(List<PipelineStep> steps) {
-    this.steps.addAll(steps);
-  }
+    public void addAll(List<PipelineStep> steps) {
+        this.steps.addAll(steps);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepVisitor.java
@@ -43,387 +43,358 @@ import org.slf4j.LoggerFactory;
  * @author Tim Brown
  */
 public class PipelineStepVisitor extends StandardChunkVisitor {
-  private final WorkflowRun run;
+    private final WorkflowRun run;
 
-  private final ArrayDeque<FlowNodeWrapper> stageSteps = new ArrayDeque<>();
+    private final ArrayDeque<FlowNodeWrapper> stageSteps = new ArrayDeque<>();
 
-  private final Map<String, FlowNodeWrapper> stepMap = new HashMap<>();
-  private final Map<String, List<FlowNodeWrapper>> stageStepMap = new HashMap<>();
+    private final Map<String, FlowNodeWrapper> stepMap = new HashMap<>();
+    private final Map<String, List<FlowNodeWrapper>> stageStepMap = new HashMap<>();
 
-  private final ArrayDeque<FlowNode> pendingBlocks = new ArrayDeque<>();
+    private final ArrayDeque<FlowNode> pendingBlocks = new ArrayDeque<>();
 
-  private FlowNode currentStage;
+    private FlowNode currentStage;
 
-  private InputAction inputAction;
+    private InputAction inputAction;
 
-  private final boolean declarative;
+    private final boolean declarative;
 
-  private ErrorAction unhandledException;
-  private FlowNode nodeThatThrewException;
+    private ErrorAction unhandledException;
+    private FlowNode nodeThatThrewException;
 
-  private boolean isLastNode;
-  private FlowExecution execution;
-  private static final Logger logger = LoggerFactory.getLogger(PipelineStepVisitor.class);
+    private boolean isLastNode;
+    private FlowExecution execution;
+    private static final Logger logger = LoggerFactory.getLogger(PipelineStepVisitor.class);
 
-  public PipelineStepVisitor(WorkflowRun run) {
-    this.run = run;
-    this.inputAction = run.getAction(InputAction.class);
-    declarative = run.getAction(ExecutionModelAction.class) != null;
-    this.isLastNode = true;
-    this.execution = run.getExecution();
-    if (this.execution != null) {
-      try {
-        ForkScanner.visitSimpleChunks(execution.getCurrentHeads(), this, new StageChunkFinder());
-      } catch (final Throwable t) {
-        // Log run ID, because the eventual exception handler (probably Stapler) isn't specific
-        // enough to do so
-        logger.debug(
-            "Caught a "
-                + t.getClass().getSimpleName()
-                + " traversing the graph for run "
-                + run.getExternalizableId());
-        throw t;
-      }
-    } else {
-      logger.debug("Could not find execution for run " + run.getExternalizableId());
-    }
-  }
-
-  @Override
-  public void parallelBranchStart(
-      @NonNull FlowNode parallelStartNode,
-      @NonNull FlowNode branchStartNode,
-      @NonNull ForkScanner scanner) {
-    FlowNode finishedBlock = null;
-    if (!pendingBlocks.isEmpty()) {
-      finishedBlock = pendingBlocks.pop();
-      // Finished processing atom nodes in this block
-      if (logger.isDebugEnabled()) {
-        logger.debug(
-            "parallelBranchStart. Removed Node ID: "
-                + finishedBlock.getId()
-                + "("
-                + finishedBlock.getDisplayName()
-                + "-"
-                + ") from pendingBlocks.");
-      }
-    }
-    if (logger.isDebugEnabled()) {
-      logger.debug(
-          "parallelBranchStart. Node ID: "
-              + branchStartNode.getId()
-              + " - "
-              + branchStartNode.getDisplayName()
-              + " - "
-              + PipelineNodeUtil.isStage(branchStartNode)
-              + " - "
-              + PipelineNodeUtil.isParallelBranch(branchStartNode)
-              + " - "
-              + PipelineNodeUtil.isSyntheticStage(branchStartNode)
-              + " .");
-    }
-
-    if (logger.isDebugEnabled()) {
-      logger.debug("Pushing steps to stage in parallelBranchStart.");
-    }
-    // Record which stage the steps belong to this parallel block.
-    pushStageStepsToMap(branchStartNode);
-  }
-
-  @Override
-  public void parallelBranchEnd(
-      @NonNull FlowNode parallelStartNode,
-      @NonNull FlowNode branchEndNode,
-      @NonNull ForkScanner scanner) {
-    if (branchEndNode instanceof StepEndNode) {
-      FlowNode branchStartNode = ((StepEndNode) branchEndNode).getStartNode();
-      if (logger.isDebugEnabled()) {
-        logger.debug(
-            "Node ID: "
-                + branchStartNode.getId()
-                + " - "
-                + PipelineNodeUtil.isStage(branchStartNode)
-                + " - "
-                + PipelineNodeUtil.isParallelBranch(branchStartNode)
-                + " - "
-                + PipelineNodeUtil.isSyntheticStage(branchStartNode)
-                + " .");
-      }
-      pendingBlocks.push(branchStartNode);
-    }
-  }
-
-  @Override
-  public void chunkStart(
-      @NonNull FlowNode startNode,
-      @CheckForNull FlowNode beforeBlock,
-      @NonNull ForkScanner scanner) {
-    super.chunkStart(startNode, beforeBlock, scanner);
-    FlowNode finishedBlock = null;
-    if (!pendingBlocks.isEmpty()) {
-      finishedBlock = pendingBlocks.pop();
-      // Finished processing atom nodes in this block
-      if (logger.isDebugEnabled()) {
-        logger.debug(
-            "chunkStart. Removed Node ID: "
-                + finishedBlock.getId()
-                + "("
-                + finishedBlock.getDisplayName()
-                + "} from pendingBlocks.");
-      }
-    }
-    if (logger.isDebugEnabled()) {
-      logger.debug(
-          "Node ID: "
-              + startNode.getId()
-              + " - "
-              + startNode.getDisplayName()
-              + " - "
-              + PipelineNodeUtil.isStage(startNode)
-              + " - "
-              + PipelineNodeUtil.isParallelBranch(startNode)
-              + " - "
-              + PipelineNodeUtil.isSyntheticStage(startNode)
-              + " .");
-    }
-    // Do not add steps to this stage if it's parent is a parallel block  and it's a declarative
-    // step - (it should get addded to
-    // that instead).
-    // This could be a quirk of how the GraphVisitor works - possible
-    if (PipelineNodeUtil.isParallelBranch(pendingBlocks.peek()) && isDeclarative()) {
-      if (logger.isDebugEnabled()) {
-        logger.debug(
-            "Not pushing steps to stage '"
-                + startNode.getDisplayName()
-                + "' in chunkStart as parent is parallel block in declarative pipeline.");
-      }
-    } else {
-      if (logger.isDebugEnabled()) {
-        logger.debug("Pushing step to stage in chunkStart.");
-      }
-      // Record which stage the steps belong to.
-      pushStageStepsToMap(startNode);
-    }
-  }
-
-  @Override
-  public void chunkEnd(
-      @NonNull FlowNode endNode, @CheckForNull FlowNode afterChunk, @NonNull ForkScanner scanner) {
-    super.chunkEnd(endNode, afterChunk, scanner);
-    if (endNode instanceof StepEndNode) {
-      FlowNode startNode = ((StepEndNode) endNode).getStartNode();
-      if (logger.isDebugEnabled()) {
-        logger.debug(
-            "chunkEnd. Node ID: "
-                + startNode.getId()
-                + " - "
-                + startNode.getDisplayName()
-                + " - "
-                + PipelineNodeUtil.isStage(startNode)
-                + " - "
-                + PipelineNodeUtil.isParallelBranch(startNode)
-                + " - "
-                + PipelineNodeUtil.isSyntheticStage(startNode)
-                + " .");
-      }
-      pendingBlocks.push(startNode);
-    }
-    if (endNode instanceof StepEndNode
-        && PipelineNodeUtil.isStage(((StepEndNode) endNode).getStartNode())) {
-      currentStage = ((StepEndNode) endNode).getStartNode();
-    } else {
-      final String id = endNode.getEnclosingId();
-      currentStage =
-          endNode.getEnclosingBlocks().stream()
-              .filter((block) -> block.getId().equals(id))
-              .findFirst()
-              .orElse(null);
-    }
-
-    if (this.isLastNode) {
-      this.isLastNode = false;
-      // Check for an unhandled exception.
-      NodeRunStatus status;
-      ErrorAction errorAction = endNode.getAction(ErrorAction.class);
-      // If this is a Jenkins failure exception, then we don't need to add a new node - it will come
-      // from an existing step.
-      if (errorAction != null
-          && !PipelineNodeUtil.isJenkinsFailureException(errorAction.getError())) {
-        // Store node that threw exception as step so we can find it's parent stage later.
-        logger.debug("Found unhandled exception: " + errorAction.getError().getMessage());
-        this.nodeThatThrewException =
-            errorAction.findOrigin(errorAction.getError(), this.execution);
-        if (this.nodeThatThrewException != null) {
-          logger.debug(
-              "Found that node '"
-                  + this.nodeThatThrewException.getId()
-                  + "' threw unhandled exception: "
-                  + this.nodeThatThrewException.getDisplayName());
-        }
-      }
-    }
-    // If this the the node that created the unhandled exception.
-    if (this.nodeThatThrewException == endNode) {
-      if (logger.isDebugEnabled()) {
-        logger.debug("Found endNode that threw exception.");
-      }
-      pushExceptionNodeToStepsMap(endNode);
-    }
-    // if we're using marker-based (and not block-scoped) stages, add the last node as part of its
-    // contents
-    if (!(endNode instanceof BlockEndNode)) {
-      atomNode(null, endNode, afterChunk, scanner);
-    }
-  }
-
-  @Override
-  public void atomNode(
-      @CheckForNull FlowNode before,
-      @NonNull FlowNode atomNode,
-      @CheckForNull FlowNode after,
-      @NonNull ForkScanner scan) {
-
-    long pause = PauseAction.getPauseDuration(atomNode);
-    TimingInfo times = StatusAndTiming.computeChunkTiming(run, pause, atomNode, atomNode, after);
-    if (times == null) {
-      times = new TimingInfo();
-    }
-    NodeRunStatus status;
-    InputStep inputStep = null;
-    if (atomNode instanceof StepAtomNode
-        && !PipelineNodeUtil.isSkippedStage(
-            currentStage)) { // if skipped stage, we don't collect its steps
-
-      if (PipelineNodeUtil.isPausedForInputStep((StepAtomNode) atomNode, inputAction)) {
-        status = new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.PAUSED);
-        try {
-          for (InputStepExecution execution : inputAction.getExecutions()) {
-            FlowNode node = execution.getContext().get(FlowNode.class);
-            if (node != null && node.equals(atomNode)) {
-              inputStep = execution.getInput();
-              break;
+    public PipelineStepVisitor(WorkflowRun run) {
+        this.run = run;
+        this.inputAction = run.getAction(InputAction.class);
+        declarative = run.getAction(ExecutionModelAction.class) != null;
+        this.isLastNode = true;
+        this.execution = run.getExecution();
+        if (this.execution != null) {
+            try {
+                ForkScanner.visitSimpleChunks(execution.getCurrentHeads(), this, new StageChunkFinder());
+            } catch (final Throwable t) {
+                // Log run ID, because the eventual exception handler (probably Stapler) isn't specific
+                // enough to do so
+                logger.debug("Caught a "
+                        + t.getClass().getSimpleName()
+                        + " traversing the graph for run "
+                        + run.getExternalizableId());
+                throw t;
             }
-          }
-        } catch (IOException | InterruptedException | TimeoutException e) {
-          logger.error("Error getting FlowNode from execution context: " + e.getMessage(), e);
+        } else {
+            logger.debug("Could not find execution for run " + run.getExternalizableId());
         }
-      } else {
-        status = new NodeRunStatus(atomNode);
-      }
-
-      FlowNodeWrapper stepNode = new FlowNodeWrapper(atomNode, status, times, inputStep, run);
-      stepMap.put(stepNode.getId(), stepNode);
-      if (logger.isDebugEnabled()) {
-        logger.debug(
-            "Pushing step: "
-                + stepNode.getId()
-                + "("
-                + stepNode.getArgumentsAsString()
-                + ") to stack.");
-      }
-      if (!stageSteps.contains(stepNode)) {
-        stageSteps.push(stepNode);
-      }
-      if (logger.isDebugEnabled()) {
-        logger.debug("Steps in stack:");
-        for (FlowNodeWrapper step : stageSteps) {
-          logger.debug(" - " + step.getArgumentsAsString() + " - " + step.getId());
-        }
-      }
-    }
-    // If this the the node that created the unhandled exception.
-    if (this.nodeThatThrewException == atomNode) {
-      if (logger.isDebugEnabled()) {
-        logger.debug("Found atomNode that threw exception.");
-      }
-      pushExceptionNodeToStepsMap(atomNode);
-    }
-  }
-
-  public List<FlowNodeWrapper> getStageSteps(String startNodeId) {
-    return stageStepMap.getOrDefault(startNodeId, new ArrayList<>());
-  }
-
-  public Map<String, List<FlowNodeWrapper>> getAllSteps() {
-    return stageStepMap;
-  }
-
-  public FlowNodeWrapper getStep(String id) {
-    return stepMap.get(id);
-  }
-
-  public boolean isDeclarative() {
-    return declarative;
-  }
-
-  private void pushStageStepsToMap(FlowNode stage) {
-    List<FlowNodeWrapper> stageStepsList =
-        stageStepMap.getOrDefault(stage.getId(), new ArrayList<>());
-    for (FlowNodeWrapper step : stageSteps) {
-      if (logger.isDebugEnabled()) {
-        logger.debug(
-            "Adding step '"
-                + step.getArgumentsAsString()
-                + "' to '"
-                + stage.getId()
-                + "' "
-                + "("
-                + stage.getDisplayName()
-                + ") .");
-      }
-
-      stageStepsList.add(step);
-    }
-    if (logger.isDebugEnabled()) {
-      logger.debug("Assigning parent stage for " + stageSteps.size() + " steps.");
-    }
-
-    stageSteps.clear();
-    stageStepMap.put(stage.getId(), stageStepsList);
-  }
-
-  private void pushExceptionNodeToStepsMap(FlowNode exceptionNode) {
-    long pause = PauseAction.getPauseDuration(exceptionNode);
-    TimingInfo times =
-        StatusAndTiming.computeChunkTiming(run, pause, exceptionNode, exceptionNode, null);
-    if (times == null) {
-      times = new TimingInfo();
-    }
-    NodeRunStatus status;
-    status = new NodeRunStatus(exceptionNode);
-    pause = PauseAction.getPauseDuration(exceptionNode);
-    times = StatusAndTiming.computeChunkTiming(run, pause, exceptionNode, exceptionNode, null);
-    if (times == null) {
-      times = new TimingInfo();
-    }
-    FlowNodeWrapper erroredStep = new FlowNodeWrapper(exceptionNode, status, times, null, run);
-    stepMap.put(erroredStep.getId(), erroredStep);
-    if (logger.isDebugEnabled()) {
-      logger.debug(
-          "Found step exception from step: "
-              + erroredStep.getId()
-              + "("
-              + erroredStep.getArgumentsAsString()
-              + ") to stack.\nError:\n"
-              + erroredStep.nodeError());
-    }
-    if (!stageSteps.contains(erroredStep)) {
-      stageSteps.push(erroredStep);
-    }
-  }
-
-  static class LocalAtomNode extends AtomNode {
-    private final String cause;
-
-    public LocalAtomNode(MemoryFlowChunk chunk, String cause) {
-      super(
-          chunk.getFirstNode().getExecution(), UUID.randomUUID().toString(), chunk.getFirstNode());
-      this.cause = cause;
     }
 
     @Override
-    protected String getTypeDisplayName() {
-      return cause;
+    public void parallelBranchStart(
+            @NonNull FlowNode parallelStartNode, @NonNull FlowNode branchStartNode, @NonNull ForkScanner scanner) {
+        FlowNode finishedBlock = null;
+        if (!pendingBlocks.isEmpty()) {
+            finishedBlock = pendingBlocks.pop();
+            // Finished processing atom nodes in this block
+            if (logger.isDebugEnabled()) {
+                logger.debug("parallelBranchStart. Removed Node ID: "
+                        + finishedBlock.getId()
+                        + "("
+                        + finishedBlock.getDisplayName()
+                        + "-"
+                        + ") from pendingBlocks.");
+            }
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("parallelBranchStart. Node ID: "
+                    + branchStartNode.getId()
+                    + " - "
+                    + branchStartNode.getDisplayName()
+                    + " - "
+                    + PipelineNodeUtil.isStage(branchStartNode)
+                    + " - "
+                    + PipelineNodeUtil.isParallelBranch(branchStartNode)
+                    + " - "
+                    + PipelineNodeUtil.isSyntheticStage(branchStartNode)
+                    + " .");
+        }
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Pushing steps to stage in parallelBranchStart.");
+        }
+        // Record which stage the steps belong to this parallel block.
+        pushStageStepsToMap(branchStartNode);
     }
-  }
+
+    @Override
+    public void parallelBranchEnd(
+            @NonNull FlowNode parallelStartNode, @NonNull FlowNode branchEndNode, @NonNull ForkScanner scanner) {
+        if (branchEndNode instanceof StepEndNode) {
+            FlowNode branchStartNode = ((StepEndNode) branchEndNode).getStartNode();
+            if (logger.isDebugEnabled()) {
+                logger.debug("Node ID: "
+                        + branchStartNode.getId()
+                        + " - "
+                        + PipelineNodeUtil.isStage(branchStartNode)
+                        + " - "
+                        + PipelineNodeUtil.isParallelBranch(branchStartNode)
+                        + " - "
+                        + PipelineNodeUtil.isSyntheticStage(branchStartNode)
+                        + " .");
+            }
+            pendingBlocks.push(branchStartNode);
+        }
+    }
+
+    @Override
+    public void chunkStart(
+            @NonNull FlowNode startNode, @CheckForNull FlowNode beforeBlock, @NonNull ForkScanner scanner) {
+        super.chunkStart(startNode, beforeBlock, scanner);
+        FlowNode finishedBlock = null;
+        if (!pendingBlocks.isEmpty()) {
+            finishedBlock = pendingBlocks.pop();
+            // Finished processing atom nodes in this block
+            if (logger.isDebugEnabled()) {
+                logger.debug("chunkStart. Removed Node ID: "
+                        + finishedBlock.getId()
+                        + "("
+                        + finishedBlock.getDisplayName()
+                        + "} from pendingBlocks.");
+            }
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("Node ID: "
+                    + startNode.getId()
+                    + " - "
+                    + startNode.getDisplayName()
+                    + " - "
+                    + PipelineNodeUtil.isStage(startNode)
+                    + " - "
+                    + PipelineNodeUtil.isParallelBranch(startNode)
+                    + " - "
+                    + PipelineNodeUtil.isSyntheticStage(startNode)
+                    + " .");
+        }
+        // Do not add steps to this stage if it's parent is a parallel block  and it's a declarative
+        // step - (it should get addded to
+        // that instead).
+        // This could be a quirk of how the GraphVisitor works - possible
+        if (PipelineNodeUtil.isParallelBranch(pendingBlocks.peek()) && isDeclarative()) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Not pushing steps to stage '"
+                        + startNode.getDisplayName()
+                        + "' in chunkStart as parent is parallel block in declarative pipeline.");
+            }
+        } else {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Pushing step to stage in chunkStart.");
+            }
+            // Record which stage the steps belong to.
+            pushStageStepsToMap(startNode);
+        }
+    }
+
+    @Override
+    public void chunkEnd(@NonNull FlowNode endNode, @CheckForNull FlowNode afterChunk, @NonNull ForkScanner scanner) {
+        super.chunkEnd(endNode, afterChunk, scanner);
+        if (endNode instanceof StepEndNode) {
+            FlowNode startNode = ((StepEndNode) endNode).getStartNode();
+            if (logger.isDebugEnabled()) {
+                logger.debug("chunkEnd. Node ID: "
+                        + startNode.getId()
+                        + " - "
+                        + startNode.getDisplayName()
+                        + " - "
+                        + PipelineNodeUtil.isStage(startNode)
+                        + " - "
+                        + PipelineNodeUtil.isParallelBranch(startNode)
+                        + " - "
+                        + PipelineNodeUtil.isSyntheticStage(startNode)
+                        + " .");
+            }
+            pendingBlocks.push(startNode);
+        }
+        if (endNode instanceof StepEndNode && PipelineNodeUtil.isStage(((StepEndNode) endNode).getStartNode())) {
+            currentStage = ((StepEndNode) endNode).getStartNode();
+        } else {
+            final String id = endNode.getEnclosingId();
+            currentStage = endNode.getEnclosingBlocks().stream()
+                    .filter((block) -> block.getId().equals(id))
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        if (this.isLastNode) {
+            this.isLastNode = false;
+            // Check for an unhandled exception.
+            NodeRunStatus status;
+            ErrorAction errorAction = endNode.getAction(ErrorAction.class);
+            // If this is a Jenkins failure exception, then we don't need to add a new node - it will come
+            // from an existing step.
+            if (errorAction != null && !PipelineNodeUtil.isJenkinsFailureException(errorAction.getError())) {
+                // Store node that threw exception as step so we can find it's parent stage later.
+                logger.debug(
+                        "Found unhandled exception: " + errorAction.getError().getMessage());
+                this.nodeThatThrewException = errorAction.findOrigin(errorAction.getError(), this.execution);
+                if (this.nodeThatThrewException != null) {
+                    logger.debug("Found that node '"
+                            + this.nodeThatThrewException.getId()
+                            + "' threw unhandled exception: "
+                            + this.nodeThatThrewException.getDisplayName());
+                }
+            }
+        }
+        // If this the the node that created the unhandled exception.
+        if (this.nodeThatThrewException == endNode) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Found endNode that threw exception.");
+            }
+            pushExceptionNodeToStepsMap(endNode);
+        }
+        // if we're using marker-based (and not block-scoped) stages, add the last node as part of its
+        // contents
+        if (!(endNode instanceof BlockEndNode)) {
+            atomNode(null, endNode, afterChunk, scanner);
+        }
+    }
+
+    @Override
+    public void atomNode(
+            @CheckForNull FlowNode before,
+            @NonNull FlowNode atomNode,
+            @CheckForNull FlowNode after,
+            @NonNull ForkScanner scan) {
+
+        long pause = PauseAction.getPauseDuration(atomNode);
+        TimingInfo times = StatusAndTiming.computeChunkTiming(run, pause, atomNode, atomNode, after);
+        if (times == null) {
+            times = new TimingInfo();
+        }
+        NodeRunStatus status;
+        InputStep inputStep = null;
+        if (atomNode instanceof StepAtomNode
+                && !PipelineNodeUtil.isSkippedStage(currentStage)) { // if skipped stage, we don't collect its steps
+
+            if (PipelineNodeUtil.isPausedForInputStep((StepAtomNode) atomNode, inputAction)) {
+                status = new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.PAUSED);
+                try {
+                    for (InputStepExecution execution : inputAction.getExecutions()) {
+                        FlowNode node = execution.getContext().get(FlowNode.class);
+                        if (node != null && node.equals(atomNode)) {
+                            inputStep = execution.getInput();
+                            break;
+                        }
+                    }
+                } catch (IOException | InterruptedException | TimeoutException e) {
+                    logger.error("Error getting FlowNode from execution context: " + e.getMessage(), e);
+                }
+            } else {
+                status = new NodeRunStatus(atomNode);
+            }
+
+            FlowNodeWrapper stepNode = new FlowNodeWrapper(atomNode, status, times, inputStep, run);
+            stepMap.put(stepNode.getId(), stepNode);
+            if (logger.isDebugEnabled()) {
+                logger.debug(
+                        "Pushing step: " + stepNode.getId() + "(" + stepNode.getArgumentsAsString() + ") to stack.");
+            }
+            if (!stageSteps.contains(stepNode)) {
+                stageSteps.push(stepNode);
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("Steps in stack:");
+                for (FlowNodeWrapper step : stageSteps) {
+                    logger.debug(" - " + step.getArgumentsAsString() + " - " + step.getId());
+                }
+            }
+        }
+        // If this the the node that created the unhandled exception.
+        if (this.nodeThatThrewException == atomNode) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Found atomNode that threw exception.");
+            }
+            pushExceptionNodeToStepsMap(atomNode);
+        }
+    }
+
+    public List<FlowNodeWrapper> getStageSteps(String startNodeId) {
+        return stageStepMap.getOrDefault(startNodeId, new ArrayList<>());
+    }
+
+    public Map<String, List<FlowNodeWrapper>> getAllSteps() {
+        return stageStepMap;
+    }
+
+    public FlowNodeWrapper getStep(String id) {
+        return stepMap.get(id);
+    }
+
+    public boolean isDeclarative() {
+        return declarative;
+    }
+
+    private void pushStageStepsToMap(FlowNode stage) {
+        List<FlowNodeWrapper> stageStepsList = stageStepMap.getOrDefault(stage.getId(), new ArrayList<>());
+        for (FlowNodeWrapper step : stageSteps) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Adding step '"
+                        + step.getArgumentsAsString()
+                        + "' to '"
+                        + stage.getId()
+                        + "' "
+                        + "("
+                        + stage.getDisplayName()
+                        + ") .");
+            }
+
+            stageStepsList.add(step);
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("Assigning parent stage for " + stageSteps.size() + " steps.");
+        }
+
+        stageSteps.clear();
+        stageStepMap.put(stage.getId(), stageStepsList);
+    }
+
+    private void pushExceptionNodeToStepsMap(FlowNode exceptionNode) {
+        long pause = PauseAction.getPauseDuration(exceptionNode);
+        TimingInfo times = StatusAndTiming.computeChunkTiming(run, pause, exceptionNode, exceptionNode, null);
+        if (times == null) {
+            times = new TimingInfo();
+        }
+        NodeRunStatus status;
+        status = new NodeRunStatus(exceptionNode);
+        pause = PauseAction.getPauseDuration(exceptionNode);
+        times = StatusAndTiming.computeChunkTiming(run, pause, exceptionNode, exceptionNode, null);
+        if (times == null) {
+            times = new TimingInfo();
+        }
+        FlowNodeWrapper erroredStep = new FlowNodeWrapper(exceptionNode, status, times, null, run);
+        stepMap.put(erroredStep.getId(), erroredStep);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Found step exception from step: "
+                    + erroredStep.getId()
+                    + "("
+                    + erroredStep.getArgumentsAsString()
+                    + ") to stack.\nError:\n"
+                    + erroredStep.nodeError());
+        }
+        if (!stageSteps.contains(erroredStep)) {
+            stageSteps.push(erroredStep);
+        }
+    }
+
+    static class LocalAtomNode extends AtomNode {
+        private final String cause;
+
+        public LocalAtomNode(MemoryFlowChunk chunk, String cause) {
+            super(chunk.getFirstNode().getExecution(), UUID.randomUUID().toString(), chunk.getFirstNode());
+            this.cause = cause;
+        }
+
+        @Override
+        protected String getTypeDisplayName() {
+            return cause;
+        }
+    }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -17,144 +17,142 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class PipelineConsoleViewActionTest {
-  @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
-  private static final String TEXT = "Hello, World!" + System.lineSeparator();
+    private static final String TEXT = "Hello, World!" + System.lineSeparator();
 
-  @Issue("GH#224")
-  @Test
-  public void getConsoleLogReturnLogText() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "hello_world_scripted", "helloWorldScriptedPipeline.jenkinsfile", Result.SUCCESS);
+    @Issue("GH#224")
+    @Test
+    public void getConsoleLogReturnLogText() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "hello_world_scripted", "helloWorldScriptedPipeline.jenkinsfile", Result.SUCCESS);
 
-    PipelineStepVisitor builder = new PipelineStepVisitor(run);
-    String stageId = TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
-    List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
-    FlowNodeWrapper echoStep = stepNodes.get(0);
+        PipelineStepVisitor builder = new PipelineStepVisitor(run);
+        String stageId =
+                TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
+        List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
+        FlowNodeWrapper echoStep = stepNodes.get(0);
 
-    PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
-    JSONObject consoleJson = consoleAction.getConsoleOutputJson(echoStep.getId(), 0L);
-    assertThat(consoleJson.getString("endByte"), is(String.valueOf(TEXT.length())));
-    assertThat(consoleJson.getString("startByte"), is("0"));
-    assertThat(consoleJson.getString("text"), is(TEXT));
-  }
+        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
+        JSONObject consoleJson = consoleAction.getConsoleOutputJson(echoStep.getId(), 0L);
+        assertThat(consoleJson.getString("endByte"), is(String.valueOf(TEXT.length())));
+        assertThat(consoleJson.getString("startByte"), is("0"));
+        assertThat(consoleJson.getString("text"), is(TEXT));
+    }
 
-  @Issue("GH#224")
-  @Test
-  public void getConsoleLogReturnsErrorText() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "hello_world_scripted", "simpleError.jenkinsfile", Result.FAILURE);
+    @Issue("GH#224")
+    @Test
+    public void getConsoleLogReturnsErrorText() throws Exception {
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "hello_world_scripted", "simpleError.jenkinsfile", Result.FAILURE);
 
-    PipelineStepVisitor builder = new PipelineStepVisitor(run);
-    String stageId = TestUtils.getNodesByDisplayName(run, "A").get(0).getId();
-    List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
-    FlowNodeWrapper errorStep = stepNodes.get(0);
+        PipelineStepVisitor builder = new PipelineStepVisitor(run);
+        String stageId = TestUtils.getNodesByDisplayName(run, "A").get(0).getId();
+        List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
+        FlowNodeWrapper errorStep = stepNodes.get(0);
 
-    PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
-    JSONObject consoleJson = consoleAction.getConsoleOutputJson(errorStep.getId(), 0L);
-    assertThat(consoleJson.getString("endByte"), is("16"));
-    assertThat(consoleJson.getString("startByte"), is("0"));
-    assertThat(consoleJson.getString("text"), is("This is an error"));
-  }
+        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
+        JSONObject consoleJson = consoleAction.getConsoleOutputJson(errorStep.getId(), 0L);
+        assertThat(consoleJson.getString("endByte"), is("16"));
+        assertThat(consoleJson.getString("startByte"), is("0"));
+        assertThat(consoleJson.getString("text"), is("This is an error"));
+    }
 
-  @Issue("GH#224")
-  @Test
-  public void getConsoleLogReturnLogTextWithOffset() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "hello_world_scripted", "helloWorldScriptedPipeline.jenkinsfile", Result.SUCCESS);
+    @Issue("GH#224")
+    @Test
+    public void getConsoleLogReturnLogTextWithOffset() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "hello_world_scripted", "helloWorldScriptedPipeline.jenkinsfile", Result.SUCCESS);
 
-    PipelineStepVisitor builder = new PipelineStepVisitor(run);
-    String stageId = TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
-    List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
-    FlowNodeWrapper echoStep = stepNodes.get(0);
+        PipelineStepVisitor builder = new PipelineStepVisitor(run);
+        String stageId =
+                TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
+        List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
+        FlowNodeWrapper echoStep = stepNodes.get(0);
 
-    PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
-    JSONObject consoleJson = consoleAction.getConsoleOutputJson(echoStep.getId(), 7L);
-    assertThat(consoleJson.getString("endByte"), is(String.valueOf(TEXT.length())));
-    assertThat(consoleJson.getString("startByte"), is("7"));
-    assertThat(consoleJson.getString("text"), is("World!" + System.lineSeparator()));
-  }
+        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
+        JSONObject consoleJson = consoleAction.getConsoleOutputJson(echoStep.getId(), 7L);
+        assertThat(consoleJson.getString("endByte"), is(String.valueOf(TEXT.length())));
+        assertThat(consoleJson.getString("startByte"), is("7"));
+        assertThat(consoleJson.getString("text"), is("World!" + System.lineSeparator()));
+    }
 
-  @Issue("GH#224")
-  @Test
-  public void getConsoleLogReturnLogTextWithNegativeOffset() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "hello_world_scripted", "helloWorldScriptedPipeline.jenkinsfile", Result.SUCCESS);
+    @Issue("GH#224")
+    @Test
+    public void getConsoleLogReturnLogTextWithNegativeOffset() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "hello_world_scripted", "helloWorldScriptedPipeline.jenkinsfile", Result.SUCCESS);
 
-    PipelineStepVisitor builder = new PipelineStepVisitor(run);
-    String stageId = TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
-    List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
-    FlowNodeWrapper echoStep = stepNodes.get(0);
+        PipelineStepVisitor builder = new PipelineStepVisitor(run);
+        String stageId =
+                TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
+        List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
+        FlowNodeWrapper echoStep = stepNodes.get(0);
 
-    PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
-    JSONObject consoleJson = consoleAction.getConsoleOutputJson(echoStep.getId(), -7L);
-    // 14-7
-    assertThat(consoleJson.getString("endByte"), is(String.valueOf(TEXT.length())));
-    assertThat(
-        consoleJson.getString("startByte"),
-        is(String.valueOf(7 + (Functions.isWindows() ? 1 : 0))));
-    String value = (Functions.isWindows() ? "" : "W") + "orld!" + System.lineSeparator();
-    assertThat(consoleJson.getString("text"), is(value));
-  }
+        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
+        JSONObject consoleJson = consoleAction.getConsoleOutputJson(echoStep.getId(), -7L);
+        // 14-7
+        assertThat(consoleJson.getString("endByte"), is(String.valueOf(TEXT.length())));
+        assertThat(consoleJson.getString("startByte"), is(String.valueOf(7 + (Functions.isWindows() ? 1 : 0))));
+        String value = (Functions.isWindows() ? "" : "W") + "orld!" + System.lineSeparator();
+        assertThat(consoleJson.getString("text"), is(value));
+    }
 
-  @Issue("GH#224")
-  @Test
-  public void getConsoleLogReturnLogTextWithLargeNegativeOffset() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "hello_world_scripted", "helloWorldScriptedPipeline.jenkinsfile", Result.SUCCESS);
+    @Issue("GH#224")
+    @Test
+    public void getConsoleLogReturnLogTextWithLargeNegativeOffset() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "hello_world_scripted", "helloWorldScriptedPipeline.jenkinsfile", Result.SUCCESS);
 
-    PipelineStepVisitor builder = new PipelineStepVisitor(run);
-    String stageId = TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
-    List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
-    FlowNodeWrapper echoStep = stepNodes.get(0);
+        PipelineStepVisitor builder = new PipelineStepVisitor(run);
+        String stageId =
+                TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
+        List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
+        FlowNodeWrapper echoStep = stepNodes.get(0);
 
-    PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
-    JSONObject consoleJson = consoleAction.getConsoleOutputJson(echoStep.getId(), -1000L);
-    assertThat(consoleJson.getString("endByte"), is(String.valueOf(TEXT.length())));
-    assertThat(consoleJson.getString("startByte"), is("0"));
-    assertThat(consoleJson.getString("text"), is(TEXT));
-  }
+        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
+        JSONObject consoleJson = consoleAction.getConsoleOutputJson(echoStep.getId(), -1000L);
+        assertThat(consoleJson.getString("endByte"), is(String.valueOf(TEXT.length())));
+        assertThat(consoleJson.getString("startByte"), is("0"));
+        assertThat(consoleJson.getString("text"), is(TEXT));
+    }
 
-  @Issue("GH#224")
-  @Test
-  public void getConsoleLogReturnLogTextWithLargeOffset() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "hello_world_scripted", "helloWorldScriptedPipeline.jenkinsfile", Result.SUCCESS);
+    @Issue("GH#224")
+    @Test
+    public void getConsoleLogReturnLogTextWithLargeOffset() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "hello_world_scripted", "helloWorldScriptedPipeline.jenkinsfile", Result.SUCCESS);
 
-    PipelineStepVisitor builder = new PipelineStepVisitor(run);
-    String stageId = TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
-    List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
-    FlowNodeWrapper echoStep = stepNodes.get(0);
+        PipelineStepVisitor builder = new PipelineStepVisitor(run);
+        String stageId =
+                TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
+        List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
+        FlowNodeWrapper echoStep = stepNodes.get(0);
 
-    PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
-    JSONObject consoleJson = consoleAction.getConsoleOutputJson(echoStep.getId(), 1000L);
-    assertThat(consoleJson, is(nullValue()));
-  }
+        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
+        JSONObject consoleJson = consoleAction.getConsoleOutputJson(echoStep.getId(), 1000L);
+        assertThat(consoleJson, is(nullValue()));
+    }
 
-  @Issue("GH#224")
-  @Test
-  public void getConsoleLogOfStepWithOutputAndException() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "exec_returns_error", "execStepReturnsError.jenkinsfile", Result.FAILURE);
+    @Issue("GH#224")
+    @Test
+    public void getConsoleLogOfStepWithOutputAndException() throws Exception {
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "exec_returns_error", "execStepReturnsError.jenkinsfile", Result.FAILURE);
 
-    PipelineStepVisitor builder = new PipelineStepVisitor(run);
-    String stageId = TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
-    List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
-    // There is an 'isUnix()' step before this.
-    FlowNodeWrapper execStep = stepNodes.get(1);
+        PipelineStepVisitor builder = new PipelineStepVisitor(run);
+        String stageId =
+                TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
+        List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
+        // There is an 'isUnix()' step before this.
+        FlowNodeWrapper execStep = stepNodes.get(1);
 
-    PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
-    JSONObject consoleJson = consoleAction.getConsoleOutputJson(execStep.getId(), 0L);
-    assertThat(consoleJson.getString("startByte"), is("0"));
-    assertThat(
-        consoleJson.getString("text"),
-        stringContainsInOrder("echo", "Hello, world!", "script returned exit code 1"));
-  }
+        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
+        JSONObject consoleJson = consoleAction.getConsoleOutputJson(execStep.getId(), 0L);
+        assertThat(consoleJson.getString("startByte"), is("0"));
+        assertThat(
+                consoleJson.getString("text"),
+                stringContainsInOrder("echo", "Hello, world!", "script returned exit code 1"));
+    }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
@@ -13,117 +13,100 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 public class PipelineGraphApiTest {
 
-  @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
-  @Test
-  public void createTree_unstableSmokes() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "unstableSmokes", "unstableSmokes.jenkinsfile", Result.FAILURE);
-    PipelineGraphApi api = new PipelineGraphApi(run);
-    PipelineGraph graph = api.createTree();
+    @Test
+    public void createTree_unstableSmokes() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(j, "unstableSmokes", "unstableSmokes.jenkinsfile", Result.FAILURE);
+        PipelineGraphApi api = new PipelineGraphApi(run);
+        PipelineGraph graph = api.createTree();
 
-    List<PipelineStage> stages = graph.getStages();
+        List<PipelineStage> stages = graph.getStages();
 
-    String stagesString =
-        TestUtils.collectStagesAsString(
-            stages,
-            (PipelineStage stage) ->
-                String.format(
-                    "{%d,%s,%s,%s,%s}",
-                    stage.getCompletePercent(),
-                    stage.getName(),
-                    stage.getTitle(),
-                    stage.getType(),
-                    stage.getState()));
-    assertThat(
-        stagesString,
-        is(
-            String.join(
-                "",
-                "{50,unstable-one,unstable-one,STAGE,UNSTABLE},",
-                "{50,success,success,STAGE,SUCCESS},",
-                "{50,unstable-two,unstable-two,STAGE,UNSTABLE},",
-                "{50,failure,failure,STAGE,FAILURE}")));
-  }
+        String stagesString = TestUtils.collectStagesAsString(
+                stages,
+                (PipelineStage stage) -> String.format(
+                        "{%d,%s,%s,%s,%s}",
+                        stage.getCompletePercent(),
+                        stage.getName(),
+                        stage.getTitle(),
+                        stage.getType(),
+                        stage.getState()));
+        assertThat(
+                stagesString,
+                is(String.join(
+                        "",
+                        "{50,unstable-one,unstable-one,STAGE,UNSTABLE},",
+                        "{50,success,success,STAGE,SUCCESS},",
+                        "{50,unstable-two,unstable-two,STAGE,UNSTABLE},",
+                        "{50,failure,failure,STAGE,FAILURE}")));
+    }
 
-  @Test
-  public void createTree_complexSmokes() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(j, "complexSmokes", "complexSmokes.jenkinsfile", Result.SUCCESS);
-    PipelineGraphApi api = new PipelineGraphApi(run);
-    PipelineGraph graph = api.createTree();
+    @Test
+    public void createTree_complexSmokes() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(j, "complexSmokes", "complexSmokes.jenkinsfile", Result.SUCCESS);
+        PipelineGraphApi api = new PipelineGraphApi(run);
+        PipelineGraph graph = api.createTree();
 
-    List<PipelineStage> stages = graph.getStages();
+        List<PipelineStage> stages = graph.getStages();
 
-    String stagesString = TestUtils.collectStagesAsString(stages, PipelineStage::getName);
-    assertThat(
-        stagesString,
-        is(
-            String.join(
-                "",
-                "Non-Parallel Stage,",
-                "Parallel Stage[Branch A,Branch B,Branch C[Nested 1,Nested 2]],",
-                "Skipped stage,",
-                "Parallel Stage 2[Branch A,Branch B,Branch C[Nested 1,Nested 2]]")));
-  }
+        String stagesString = TestUtils.collectStagesAsString(stages, PipelineStage::getName);
+        assertThat(
+                stagesString,
+                is(String.join(
+                        "",
+                        "Non-Parallel Stage,",
+                        "Parallel Stage[Branch A,Branch B,Branch C[Nested 1,Nested 2]],",
+                        "Skipped stage,",
+                        "Parallel Stage 2[Branch A,Branch B,Branch C[Nested 1,Nested 2]]")));
+    }
 
-  @Test
-  public void createTree_scriptedParallel() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "scriptedParallel", "scriptedParallel.jenkinsfile", Result.SUCCESS);
-    PipelineGraphApi api = new PipelineGraphApi(run);
-    PipelineGraph graph = api.createTree();
+    @Test
+    public void createTree_scriptedParallel() throws Exception {
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "scriptedParallel", "scriptedParallel.jenkinsfile", Result.SUCCESS);
+        PipelineGraphApi api = new PipelineGraphApi(run);
+        PipelineGraph graph = api.createTree();
 
-    List<PipelineStage> stages = graph.getStages();
+        List<PipelineStage> stages = graph.getStages();
 
-    String stagesString = TestUtils.collectStagesAsString(stages, PipelineStage::getName);
-    assertThat(stagesString, is("A,Parallel[B[BA,BB],C[CA,CB]],D[E[EA,EB],F[FA,FB]],G"));
-  }
+        String stagesString = TestUtils.collectStagesAsString(stages, PipelineStage::getName);
+        assertThat(stagesString, is("A,Parallel[B[BA,BB],C[CA,CB]],D[E[EA,EB],F[FA,FB]],G"));
+    }
 
-  @Issue("GH#85")
-  @Test
-  public void createTree_syntheticStages() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "syntheticStages", "syntheticStages.jenkinsfile", Result.SUCCESS);
-    PipelineGraphApi api = new PipelineGraphApi(run);
-    PipelineGraph graph = api.createTree();
+    @Issue("GH#85")
+    @Test
+    public void createTree_syntheticStages() throws Exception {
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "syntheticStages", "syntheticStages.jenkinsfile", Result.SUCCESS);
+        PipelineGraphApi api = new PipelineGraphApi(run);
+        PipelineGraph graph = api.createTree();
 
-    List<PipelineStage> stages = graph.getStages();
+        List<PipelineStage> stages = graph.getStages();
 
-    String stagesString =
-        TestUtils.collectStagesAsString(
-            stages,
-            (PipelineStage stage) ->
-                String.format("{%s,%s}", stage.getName(), stage.isSynthetic() ? "true" : "false"));
-    assertThat(
-        stagesString,
-        is(
-            String.join(
-                "",
-                "{Checkout SCM,true},",
-                "{Stage 1,false},",
-                "{Stage 2,false},",
-                "{Post Actions,true}")));
-  }
+        String stagesString = TestUtils.collectStagesAsString(
+                stages,
+                (PipelineStage stage) ->
+                        String.format("{%s,%s}", stage.getName(), stage.isSynthetic() ? "true" : "false"));
+        assertThat(
+                stagesString,
+                is(String.join(
+                        "", "{Checkout SCM,true},", "{Stage 1,false},", "{Stage 2,false},", "{Post Actions,true}")));
+    }
 
-  @Issue("GH#87")
-  @Test
-  public void createTree_skippedParallel() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "skippedParallel", "skippedParallel.jenkinsfile", Result.SUCCESS);
-    PipelineGraphApi api = new PipelineGraphApi(run);
-    PipelineGraph graph = api.createTree();
+    @Issue("GH#87")
+    @Test
+    public void createTree_skippedParallel() throws Exception {
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "skippedParallel", "skippedParallel.jenkinsfile", Result.SUCCESS);
+        PipelineGraphApi api = new PipelineGraphApi(run);
+        PipelineGraph graph = api.createTree();
 
-    List<PipelineStage> stages = graph.getStages();
+        List<PipelineStage> stages = graph.getStages();
 
-    String stagesString =
-        TestUtils.collectStagesAsString(
-            stages,
-            (PipelineStage stage) -> String.format("{%s,%s}", stage.getName(), stage.getState()));
-    assertThat(stagesString, is("{Stage 1,SUCCESS},{Parallel stage,skipped},{Stage 2,SUCCESS}"));
-  }
+        String stagesString = TestUtils.collectStagesAsString(
+                stages, (PipelineStage stage) -> String.format("{%s,%s}", stage.getName(), stage.getState()));
+        assertThat(stagesString, is("{Stage 1,SUCCESS},{Parallel stage,skipped},{Stage 2,SUCCESS}"));
+    }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtilTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtilTest.java
@@ -14,56 +14,51 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class PipelineNodeUtilTest {
-  @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
-  @Issue("GH#224")
-  @Test
-  public void canGetLogTextFromStep() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "hello_world_scripted", "helloWorldScriptedPipeline.jenkinsfile", Result.SUCCESS);
+    @Issue("GH#224")
+    @Test
+    public void canGetLogTextFromStep() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "hello_world_scripted", "helloWorldScriptedPipeline.jenkinsfile", Result.SUCCESS);
 
-    PipelineStepVisitor builder = new PipelineStepVisitor(run);
-    String stageId = TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
-    List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
-    FlowNodeWrapper echoStep = stepNodes.get(0);
-    AnnotatedLargeText<? extends FlowNode> logText =
-        PipelineNodeUtil.getLogText(echoStep.getNode());
-    String logString = PipelineNodeUtil.convertLogToString(logText);
-    assertThat(logString, is("Hello, World!" + System.lineSeparator()));
-  }
+        PipelineStepVisitor builder = new PipelineStepVisitor(run);
+        String stageId =
+                TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
+        List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
+        FlowNodeWrapper echoStep = stepNodes.get(0);
+        AnnotatedLargeText<? extends FlowNode> logText = PipelineNodeUtil.getLogText(echoStep.getNode());
+        String logString = PipelineNodeUtil.convertLogToString(logText);
+        assertThat(logString, is("Hello, World!" + System.lineSeparator()));
+    }
 
-  @Issue("GH#224")
-  @Test
-  public void canGetErrorTextFromStep() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(j, "simple_error", "simpleError.jenkinsfile", Result.FAILURE);
-    PipelineStepVisitor builder = new PipelineStepVisitor(run);
-    String stageId = TestUtils.getNodesByDisplayName(run, "A").get(0).getId();
-    List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
-    FlowNodeWrapper errorStep = stepNodes.get(0);
-    assertThat(PipelineNodeUtil.getExceptionText(errorStep.getNode()), is("This is an error"));
-  }
+    @Issue("GH#224")
+    @Test
+    public void canGetErrorTextFromStep() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(j, "simple_error", "simpleError.jenkinsfile", Result.FAILURE);
+        PipelineStepVisitor builder = new PipelineStepVisitor(run);
+        String stageId = TestUtils.getNodesByDisplayName(run, "A").get(0).getId();
+        List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
+        FlowNodeWrapper errorStep = stepNodes.get(0);
+        assertThat(PipelineNodeUtil.getExceptionText(errorStep.getNode()), is("This is an error"));
+    }
 
-  @Issue("GH#213")
-  @Test
-  public void pipelineCallsUndefinedVar() throws Exception {
-    // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
-    // long time)
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j,
-            "githubIssue213_callsUnknownVariable",
-            "callsUnknownVariable.jenkinsfile",
-            Result.FAILURE);
+    @Issue("GH#213")
+    @Test
+    public void pipelineCallsUndefinedVar() throws Exception {
+        // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
+        // long time)
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "githubIssue213_callsUnknownVariable", "callsUnknownVariable.jenkinsfile", Result.FAILURE);
 
-    PipelineStepVisitor builder = new PipelineStepVisitor(run);
-    String stageId = TestUtils.getNodesByDisplayName(run, "failure").get(0).getId();
-    List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
-    FlowNodeWrapper errorStep = stepNodes.get(1);
-    assertThat(
-        PipelineNodeUtil.getExceptionText(errorStep.getNode()),
-        startsWith(
-            "Found unhandled groovy.lang.MissingPropertyException exception:\nNo such property: undefined for class: groovy.lang.Binding"));
-  }
+        PipelineStepVisitor builder = new PipelineStepVisitor(run);
+        String stageId = TestUtils.getNodesByDisplayName(run, "failure").get(0).getId();
+        List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
+        FlowNodeWrapper errorStep = stepNodes.get(1);
+        assertThat(
+                PipelineNodeUtil.getExceptionText(errorStep.getNode()),
+                startsWith(
+                        "Found unhandled groovy.lang.MissingPropertyException exception:\nNo such property: undefined for class: groovy.lang.Binding"));
+    }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
@@ -13,300 +13,309 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class PipelineStepApiTest {
-  @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
-  @Test
-  public void unstableSmokes() throws Exception {
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "unstableSmokes", "unstableSmokes.jenkinsfile", Result.FAILURE);
-    PipelineStepApi api = new PipelineStepApi(run);
+    @Test
+    public void unstableSmokes() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(j, "unstableSmokes", "unstableSmokes.jenkinsfile", Result.FAILURE);
+        PipelineStepApi api = new PipelineStepApi(run);
 
-    String unstableOneId = TestUtils.getNodesByDisplayName(run, "unstable-one").get(0).getId();
-    String successId = TestUtils.getNodesByDisplayName(run, "success").get(0).getId();
-    String unstableTwoId = TestUtils.getNodesByDisplayName(run, "unstable-two").get(0).getId();
-    String failureID = TestUtils.getNodesByDisplayName(run, "failure").get(0).getId();
+        String unstableOneId =
+                TestUtils.getNodesByDisplayName(run, "unstable-one").get(0).getId();
+        String successId =
+                TestUtils.getNodesByDisplayName(run, "success").get(0).getId();
+        String unstableTwoId =
+                TestUtils.getNodesByDisplayName(run, "unstable-two").get(0).getId();
+        String failureID =
+                TestUtils.getNodesByDisplayName(run, "failure").get(0).getId();
 
-    List<PipelineStep> steps = api.getSteps(unstableOneId).getSteps();
-    assertThat(steps, hasSize(3));
-    assertThat(steps.get(0).getName(), is("foo - Print Message"));
-    assertThat(steps.get(1).getName(), is("oops-one - Set stage result to unstable"));
-    assertThat(steps.get(2).getName(), is("bar - Print Message"));
+        List<PipelineStep> steps = api.getSteps(unstableOneId).getSteps();
+        assertThat(steps, hasSize(3));
+        assertThat(steps.get(0).getName(), is("foo - Print Message"));
+        assertThat(steps.get(1).getName(), is("oops-one - Set stage result to unstable"));
+        assertThat(steps.get(2).getName(), is("bar - Print Message"));
 
-    steps = api.getSteps(successId).getSteps();
-    assertThat(steps, hasSize(1));
-    assertThat(steps.get(0).getName(), is("baz - Print Message"));
+        steps = api.getSteps(successId).getSteps();
+        assertThat(steps, hasSize(1));
+        assertThat(steps.get(0).getName(), is("baz - Print Message"));
 
-    steps = api.getSteps(unstableTwoId).getSteps();
-    assertThat(steps, hasSize(2));
-    assertThat(steps.get(0).getName(), is("will-be-caught - Error signal"));
-    assertThat(steps.get(1).getName(), is("oops-two - Set stage result to unstable"));
+        steps = api.getSteps(unstableTwoId).getSteps();
+        assertThat(steps, hasSize(2));
+        assertThat(steps.get(0).getName(), is("will-be-caught - Error signal"));
+        assertThat(steps.get(1).getName(), is("oops-two - Set stage result to unstable"));
 
-    steps = api.getSteps(failureID).getSteps();
-    assertThat(steps, hasSize(2));
-    assertThat(steps.get(0).getName(), is("oops-masked - Set stage result to unstable"));
-    assertThat(steps.get(1).getName(), is("oops-failure - Error signal"));
-  }
+        steps = api.getSteps(failureID).getSteps();
+        assertThat(steps, hasSize(2));
+        assertThat(steps.get(0).getName(), is("oops-masked - Set stage result to unstable"));
+        assertThat(steps.get(1).getName(), is("oops-failure - Error signal"));
+    }
 
-  @Test
-  public void complexParallelBranchesHaveCorrectSteps() throws Exception {
-    // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
-    // long time)
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "complexParallelSmokes", "complexParallelSmokes.jenkinsfile", Result.SUCCESS);
+    @Test
+    public void complexParallelBranchesHaveCorrectSteps() throws Exception {
+        // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
+        // long time)
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "complexParallelSmokes", "complexParallelSmokes.jenkinsfile", Result.SUCCESS);
 
-    // Dynamically find the nodes which will be returned by the GraphAPI
-    String nonParallelId =
-        TestUtils.getNodesByDisplayName(run, "Non-Parallel Stage").get(0).getId();
-    // We need to prefix with 'Branch: ' as these are Declarative parallel stages.
-    String branchAId = TestUtils.getNodesByDisplayName(run, "Branch: Branch A").get(0).getId();
-    String branchBId = TestUtils.getNodesByDisplayName(run, "Branch: Branch B").get(0).getId();
-    String branchCId = TestUtils.getNodesByDisplayName(run, "Branch: Branch C").get(0).getId();
-    String branchNested1Id = TestUtils.getNodesByDisplayName(run, "Nested 1").get(0).getId();
-    String branchNested2Id = TestUtils.getNodesByDisplayName(run, "Nested 2").get(0).getId();
+        // Dynamically find the nodes which will be returned by the GraphAPI
+        String nonParallelId = TestUtils.getNodesByDisplayName(run, "Non-Parallel Stage")
+                .get(0)
+                .getId();
+        // We need to prefix with 'Branch: ' as these are Declarative parallel stages.
+        String branchAId =
+                TestUtils.getNodesByDisplayName(run, "Branch: Branch A").get(0).getId();
+        String branchBId =
+                TestUtils.getNodesByDisplayName(run, "Branch: Branch B").get(0).getId();
+        String branchCId =
+                TestUtils.getNodesByDisplayName(run, "Branch: Branch C").get(0).getId();
+        String branchNested1Id =
+                TestUtils.getNodesByDisplayName(run, "Nested 1").get(0).getId();
+        String branchNested2Id =
+                TestUtils.getNodesByDisplayName(run, "Nested 2").get(0).getId();
 
-    // Check 'Non-Parallel Stage'
-    PipelineStepApi api = new PipelineStepApi(run);
-    List<PipelineStep> steps = api.getSteps(nonParallelId).getSteps();
-    assertThat(steps, hasSize(2));
-    assertThat(steps.get(0).getName(), is("This stage will be executed first. - Print Message"));
-    assertThat(steps.get(1).getName(), is("Print Message"));
+        // Check 'Non-Parallel Stage'
+        PipelineStepApi api = new PipelineStepApi(run);
+        List<PipelineStep> steps = api.getSteps(nonParallelId).getSteps();
+        assertThat(steps, hasSize(2));
+        assertThat(steps.get(0).getName(), is("This stage will be executed first. - Print Message"));
+        assertThat(steps.get(1).getName(), is("Print Message"));
 
-    // Check 'Branch A'
-    steps = api.getSteps(branchAId).getSteps();
-    assertThat(steps, hasSize(2));
-    assertThat(steps.get(0).getName(), is("On Branch A - 1 - Print Message"));
-    assertThat(steps.get(1).getName(), is("On Branch A - 2 - Print Message"));
+        // Check 'Branch A'
+        steps = api.getSteps(branchAId).getSteps();
+        assertThat(steps, hasSize(2));
+        assertThat(steps.get(0).getName(), is("On Branch A - 1 - Print Message"));
+        assertThat(steps.get(1).getName(), is("On Branch A - 2 - Print Message"));
 
-    // Check 'Branch B'
-    steps = api.getSteps(branchBId).getSteps();
-    assertThat(steps, hasSize(2));
-    assertThat(steps.get(0).getName(), is("On Branch B - 1 - Print Message"));
-    assertThat(steps.get(1).getName(), is("On Branch B - 2 - Print Message"));
+        // Check 'Branch B'
+        steps = api.getSteps(branchBId).getSteps();
+        assertThat(steps, hasSize(2));
+        assertThat(steps.get(0).getName(), is("On Branch B - 1 - Print Message"));
+        assertThat(steps.get(1).getName(), is("On Branch B - 2 - Print Message"));
 
-    // Check 'Branch C'
-    steps = api.getSteps(branchCId).getSteps();
-    assertThat(steps, hasSize(0));
+        // Check 'Branch C'
+        steps = api.getSteps(branchCId).getSteps();
+        assertThat(steps, hasSize(0));
 
-    // Check 'Nested 1'
-    steps = api.getSteps(branchNested1Id).getSteps();
-    assertThat(steps, hasSize(2));
-    assertThat(steps.get(0).getName(), is("In stage Nested 1 - 1 within Branch C - Print Message"));
-    assertThat(steps.get(1).getName(), is("In stage Nested 1 - 2 within Branch C - Print Message"));
+        // Check 'Nested 1'
+        steps = api.getSteps(branchNested1Id).getSteps();
+        assertThat(steps, hasSize(2));
+        assertThat(steps.get(0).getName(), is("In stage Nested 1 - 1 within Branch C - Print Message"));
+        assertThat(steps.get(1).getName(), is("In stage Nested 1 - 2 within Branch C - Print Message"));
 
-    // Check 'Nested 2'
-    steps = api.getSteps(branchNested2Id).getSteps();
-    assertThat(steps, hasSize(2));
-    assertThat(steps.get(0).getName(), is("In stage Nested 2 - 1 within Branch C - Print Message"));
-    assertThat(steps.get(1).getName(), is("In stage Nested 2 - 2 within Branch C - Print Message"));
-  }
+        // Check 'Nested 2'
+        steps = api.getSteps(branchNested2Id).getSteps();
+        assertThat(steps, hasSize(2));
+        assertThat(steps.get(0).getName(), is("In stage Nested 2 - 1 within Branch C - Print Message"));
+        assertThat(steps.get(1).getName(), is("In stage Nested 2 - 2 within Branch C - Print Message"));
+    }
 
-  @Test
-  public void nestedStagesHaveCorrectSteps() throws Exception {
-    // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
-    // long time)
-    WorkflowRun run =
-        TestUtils.createAndRunJob(j, "nestedStages", "nestedStages.jenkinsfile", Result.SUCCESS);
+    @Test
+    public void nestedStagesHaveCorrectSteps() throws Exception {
+        // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
+        // long time)
+        WorkflowRun run = TestUtils.createAndRunJob(j, "nestedStages", "nestedStages.jenkinsfile", Result.SUCCESS);
 
-    String childAId = TestUtils.getNodesByDisplayName(run, "Child A").get(0).getId();
-    String childBId = TestUtils.getNodesByDisplayName(run, "Child B").get(0).getId();
-    String grandchildBId = TestUtils.getNodesByDisplayName(run, "Grandchild B").get(0).getId();
-    String childCId = TestUtils.getNodesByDisplayName(run, "Child C").get(0).getId();
-    String grandchildCId = TestUtils.getNodesByDisplayName(run, "Grandchild C").get(0).getId();
-    String greatGrandchildCId =
-        TestUtils.getNodesByDisplayName(run, "Great-grandchild C").get(0).getId();
+        String childAId = TestUtils.getNodesByDisplayName(run, "Child A").get(0).getId();
+        String childBId = TestUtils.getNodesByDisplayName(run, "Child B").get(0).getId();
+        String grandchildBId =
+                TestUtils.getNodesByDisplayName(run, "Grandchild B").get(0).getId();
+        String childCId = TestUtils.getNodesByDisplayName(run, "Child C").get(0).getId();
+        String grandchildCId =
+                TestUtils.getNodesByDisplayName(run, "Grandchild C").get(0).getId();
+        String greatGrandchildCId = TestUtils.getNodesByDisplayName(run, "Great-grandchild C")
+                .get(0)
+                .getId();
 
-    PipelineStepApi api = new PipelineStepApi(run);
+        PipelineStepApi api = new PipelineStepApi(run);
 
-    // Check 'Child A'
-    List<PipelineStep> steps = api.getSteps(childAId).getSteps();
-    assertThat(steps, hasSize(1));
-    assertThat(steps.get(0).getName(), is("In child A - Print Message"));
+        // Check 'Child A'
+        List<PipelineStep> steps = api.getSteps(childAId).getSteps();
+        assertThat(steps, hasSize(1));
+        assertThat(steps.get(0).getName(), is("In child A - Print Message"));
 
-    // Check 'Child A'
-    steps = api.getSteps(childBId).getSteps();
-    assertThat(steps, hasSize(0));
+        // Check 'Child A'
+        steps = api.getSteps(childBId).getSteps();
+        assertThat(steps, hasSize(0));
 
-    // Check 'Grandchild B'
-    steps = api.getSteps(grandchildBId).getSteps();
-    assertThat(steps, hasSize(1));
-    assertThat(steps.get(0).getName(), is("In grandchild B - Print Message"));
+        // Check 'Grandchild B'
+        steps = api.getSteps(grandchildBId).getSteps();
+        assertThat(steps, hasSize(1));
+        assertThat(steps.get(0).getName(), is("In grandchild B - Print Message"));
 
-    // Check 'Child C'
-    steps = api.getSteps(childCId).getSteps();
-    assertThat(steps, hasSize(0));
+        // Check 'Child C'
+        steps = api.getSteps(childCId).getSteps();
+        assertThat(steps, hasSize(0));
 
-    // Check 'Grandchild C'
-    steps = api.getSteps(grandchildCId).getSteps();
-    assertThat(steps, hasSize(0));
+        // Check 'Grandchild C'
+        steps = api.getSteps(grandchildCId).getSteps();
+        assertThat(steps, hasSize(0));
 
-    // Check 'Great-Grandchild C'
-    steps = api.getSteps(greatGrandchildCId).getSteps();
-    assertThat(steps, hasSize(1));
-    assertThat(steps.get(0).getName(), is("In great-grandchild C - Print Message"));
-  }
+        // Check 'Great-Grandchild C'
+        steps = api.getSteps(greatGrandchildCId).getSteps();
+        assertThat(steps, hasSize(1));
+        assertThat(steps.get(0).getName(), is("In great-grandchild C - Print Message"));
+    }
 
-  @Test
-  public void getAllStepsReturnsStepsForComplexParallelBranches() throws Exception {
-    // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
-    // long time)
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "complexParallelSmokes", "complexParallelSmokes.jenkinsfile", Result.SUCCESS);
+    @Test
+    public void getAllStepsReturnsStepsForComplexParallelBranches() throws Exception {
+        // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
+        // long time)
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "complexParallelSmokes", "complexParallelSmokes.jenkinsfile", Result.SUCCESS);
 
-    // Check 'Non-Parallel Stage'
-    PipelineStepApi api = new PipelineStepApi(run);
+        // Check 'Non-Parallel Stage'
+        PipelineStepApi api = new PipelineStepApi(run);
 
-    List<PipelineStep> steps = api.getAllSteps().getSteps();
-    assertThat(steps, hasSize(10));
-    assertThat(steps.get(0).getName(), is("This stage will be executed first. - Print Message"));
-    assertThat(steps.get(1).getName(), is("Print Message"));
-    assertThat(steps.get(2).getName(), is("On Branch A - 1 - Print Message"));
-    assertThat(steps.get(3).getName(), is("On Branch A - 2 - Print Message"));
-    assertThat(steps.get(4).getName(), is("On Branch B - 1 - Print Message"));
-    assertThat(steps.get(5).getName(), is("On Branch B - 2 - Print Message"));
+        List<PipelineStep> steps = api.getAllSteps().getSteps();
+        assertThat(steps, hasSize(10));
+        assertThat(steps.get(0).getName(), is("This stage will be executed first. - Print Message"));
+        assertThat(steps.get(1).getName(), is("Print Message"));
+        assertThat(steps.get(2).getName(), is("On Branch A - 1 - Print Message"));
+        assertThat(steps.get(3).getName(), is("On Branch A - 2 - Print Message"));
+        assertThat(steps.get(4).getName(), is("On Branch B - 1 - Print Message"));
+        assertThat(steps.get(5).getName(), is("On Branch B - 2 - Print Message"));
 
-    assertThat(steps.get(6).getName(), is("In stage Nested 1 - 1 within Branch C - Print Message"));
-    assertThat(steps.get(7).getName(), is("In stage Nested 1 - 2 within Branch C - Print Message"));
-    assertThat(steps.get(8).getName(), is("In stage Nested 2 - 1 within Branch C - Print Message"));
-    assertThat(steps.get(9).getName(), is("In stage Nested 2 - 2 within Branch C - Print Message"));
-  }
+        assertThat(steps.get(6).getName(), is("In stage Nested 1 - 1 within Branch C - Print Message"));
+        assertThat(steps.get(7).getName(), is("In stage Nested 1 - 2 within Branch C - Print Message"));
+        assertThat(steps.get(8).getName(), is("In stage Nested 2 - 1 within Branch C - Print Message"));
+        assertThat(steps.get(9).getName(), is("In stage Nested 2 - 2 within Branch C - Print Message"));
+    }
 
-  @Test
-  public void getAllStepsReturnsStepsForNestedStages() throws Exception {
-    // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
-    // long time)
-    WorkflowRun run =
-        TestUtils.createAndRunJob(j, "nestedStages", "nestedStages.jenkinsfile", Result.SUCCESS);
+    @Test
+    public void getAllStepsReturnsStepsForNestedStages() throws Exception {
+        // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
+        // long time)
+        WorkflowRun run = TestUtils.createAndRunJob(j, "nestedStages", "nestedStages.jenkinsfile", Result.SUCCESS);
 
-    PipelineStepApi api = new PipelineStepApi(run);
+        PipelineStepApi api = new PipelineStepApi(run);
 
-    List<PipelineStep> steps = api.getAllSteps().getSteps();
-    assertThat(steps, hasSize(3));
-    assertThat(steps.get(0).getName(), is("In child A - Print Message"));
-    assertThat(steps.get(1).getName(), is("In grandchild B - Print Message"));
-    assertThat(steps.get(2).getName(), is("In great-grandchild C - Print Message"));
-  }
+        List<PipelineStep> steps = api.getAllSteps().getSteps();
+        assertThat(steps, hasSize(3));
+        assertThat(steps.get(0).getName(), is("In child A - Print Message"));
+        assertThat(steps.get(1).getName(), is("In grandchild B - Print Message"));
+        assertThat(steps.get(2).getName(), is("In great-grandchild C - Print Message"));
+    }
 
-  @Issue("GH#92")
-  @Test
-  public void githubIssue92RegressionTest() throws Exception {
-    // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
-    // long time)
-    WorkflowRun run =
-        TestUtils.createAndRunJob(j, "githubIssue92", "githubIssue92.jenkinsfile", Result.SUCCESS);
+    @Issue("GH#92")
+    @Test
+    public void githubIssue92RegressionTest() throws Exception {
+        // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
+        // long time)
+        WorkflowRun run = TestUtils.createAndRunJob(j, "githubIssue92", "githubIssue92.jenkinsfile", Result.SUCCESS);
 
-    PipelineStepApi api = new PipelineStepApi(run);
+        PipelineStepApi api = new PipelineStepApi(run);
 
-    // Linux 8
-    String linux8CheckoutId =
-        TestUtils.getNodesByDisplayName(run, "Checkout (linux-8)").get(0).getId();
-    String linux8BuildId = TestUtils.getNodesByDisplayName(run, "Build (linux-8)").get(0).getId();
-    String linux8ArchiveId =
-        TestUtils.getNodesByDisplayName(run, "Archive (linux-8)").get(0).getId();
+        // Linux 8
+        String linux8CheckoutId = TestUtils.getNodesByDisplayName(run, "Checkout (linux-8)")
+                .get(0)
+                .getId();
+        String linux8BuildId =
+                TestUtils.getNodesByDisplayName(run, "Build (linux-8)").get(0).getId();
+        String linux8ArchiveId =
+                TestUtils.getNodesByDisplayName(run, "Archive (linux-8)").get(0).getId();
 
-    // Linux 11
-    String linux11CheckoutId =
-        TestUtils.getNodesByDisplayName(run, "Checkout (linux-11)").get(0).getId();
-    String linux11BuildId = TestUtils.getNodesByDisplayName(run, "Build (linux-11)").get(0).getId();
-    String linux11ArchiveId =
-        TestUtils.getNodesByDisplayName(run, "Archive (linux-11)").get(0).getId();
+        // Linux 11
+        String linux11CheckoutId = TestUtils.getNodesByDisplayName(run, "Checkout (linux-11)")
+                .get(0)
+                .getId();
+        String linux11BuildId =
+                TestUtils.getNodesByDisplayName(run, "Build (linux-11)").get(0).getId();
+        String linux11ArchiveId = TestUtils.getNodesByDisplayName(run, "Archive (linux-11)")
+                .get(0)
+                .getId();
 
-    String deployStageId = TestUtils.getNodesByDisplayName(run, "Deploy").get(0).getId();
+        String deployStageId =
+                TestUtils.getNodesByDisplayName(run, "Deploy").get(0).getId();
 
-    List<PipelineStep> steps = api.getSteps(linux8CheckoutId).getSteps();
-    assertThat(steps, hasSize(1));
-    assertThat(steps.get(0).getName(), is("Checking out linux-8 - Print Message"));
+        List<PipelineStep> steps = api.getSteps(linux8CheckoutId).getSteps();
+        assertThat(steps, hasSize(1));
+        assertThat(steps.get(0).getName(), is("Checking out linux-8 - Print Message"));
 
-    steps = api.getSteps(linux8BuildId).getSteps();
-    assertThat(steps, hasSize(1));
-    assertThat(steps.get(0).getName(), is("Building linux-8 - Print Message"));
+        steps = api.getSteps(linux8BuildId).getSteps();
+        assertThat(steps, hasSize(1));
+        assertThat(steps.get(0).getName(), is("Building linux-8 - Print Message"));
 
-    steps = api.getSteps(linux8ArchiveId).getSteps();
-    assertThat(steps, hasSize(1));
-    assertThat(steps.get(0).getName(), is("Archiving linux-8 - Print Message"));
+        steps = api.getSteps(linux8ArchiveId).getSteps();
+        assertThat(steps, hasSize(1));
+        assertThat(steps.get(0).getName(), is("Archiving linux-8 - Print Message"));
 
-    steps = api.getSteps(linux11CheckoutId).getSteps();
-    assertThat(steps, hasSize(1));
-    assertThat(steps.get(0).getName(), is("Checking out linux-11 - Print Message"));
+        steps = api.getSteps(linux11CheckoutId).getSteps();
+        assertThat(steps, hasSize(1));
+        assertThat(steps.get(0).getName(), is("Checking out linux-11 - Print Message"));
 
-    steps = api.getSteps(linux11BuildId).getSteps();
-    assertThat(steps, hasSize(1));
-    assertThat(steps.get(0).getName(), is("Building linux-11 - Print Message"));
+        steps = api.getSteps(linux11BuildId).getSteps();
+        assertThat(steps, hasSize(1));
+        assertThat(steps.get(0).getName(), is("Building linux-11 - Print Message"));
 
-    steps = api.getSteps(linux11ArchiveId).getSteps();
-    assertThat(steps, hasSize(1));
-    assertThat(steps.get(0).getName(), is("Archiving linux-11 - Print Message"));
+        steps = api.getSteps(linux11ArchiveId).getSteps();
+        assertThat(steps, hasSize(1));
+        assertThat(steps.get(0).getName(), is("Archiving linux-11 - Print Message"));
 
-    steps = api.getSteps(deployStageId).getSteps();
-    assertThat(steps, hasSize(1));
-    assertThat(steps.get(0).getName(), is("Deploying... - Print Message"));
-  }
+        steps = api.getSteps(deployStageId).getSteps();
+        assertThat(steps, hasSize(1));
+        assertThat(steps.get(0).getName(), is("Deploying... - Print Message"));
+    }
 
-  @Issue("GH#213")
-  @Test
-  public void githubIssue213RegressionTest_scriptedError() throws Exception {
-    // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
-    // long time)
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "githubIssue213", "unstableSmokes.jenkinsfile", Result.FAILURE);
+    @Issue("GH#213")
+    @Test
+    public void githubIssue213RegressionTest_scriptedError() throws Exception {
+        // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
+        // long time)
+        WorkflowRun run = TestUtils.createAndRunJob(j, "githubIssue213", "unstableSmokes.jenkinsfile", Result.FAILURE);
 
-    PipelineStepApi api = new PipelineStepApi(run);
+        PipelineStepApi api = new PipelineStepApi(run);
 
-    String failureStage = TestUtils.getNodesByDisplayName(run, "failure").get(0).getId();
+        String failureStage =
+                TestUtils.getNodesByDisplayName(run, "failure").get(0).getId();
 
-    List<PipelineStep> steps = api.getSteps(failureStage).getSteps();
-    assertThat(steps, hasSize(2));
-    PipelineStep errorStep = steps.get(1);
-    assertThat(errorStep.getName(), is("oops-failure - Error signal"));
-    FlowNode node = run.getExecution().getNode(String.valueOf(errorStep.getId()));
-    String errorText = PipelineNodeUtil.getExceptionText(node);
-    assertThat(errorText, is("oops-failure"));
-  }
+        List<PipelineStep> steps = api.getSteps(failureStage).getSteps();
+        assertThat(steps, hasSize(2));
+        PipelineStep errorStep = steps.get(1);
+        assertThat(errorStep.getName(), is("oops-failure - Error signal"));
+        FlowNode node = run.getExecution().getNode(String.valueOf(errorStep.getId()));
+        String errorText = PipelineNodeUtil.getExceptionText(node);
+        assertThat(errorText, is("oops-failure"));
+    }
 
-  @Issue("GH#213")
-  @Test
-  public void githubIssue213RegressionTest_errorStep() throws Exception {
-    // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
-    // long time)
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j, "githubIssue213_errorStep", "unstableSmokes.jenkinsfile", Result.FAILURE);
+    @Issue("GH#213")
+    @Test
+    public void githubIssue213RegressionTest_errorStep() throws Exception {
+        // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
+        // long time)
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "githubIssue213_errorStep", "unstableSmokes.jenkinsfile", Result.FAILURE);
 
-    PipelineStepApi api = new PipelineStepApi(run);
+        PipelineStepApi api = new PipelineStepApi(run);
 
-    String failureStage = TestUtils.getNodesByDisplayName(run, "failure").get(0).getId();
+        String failureStage =
+                TestUtils.getNodesByDisplayName(run, "failure").get(0).getId();
 
-    List<PipelineStep> steps = api.getSteps(failureStage).getSteps();
-    assertThat(steps, hasSize(2));
-    PipelineStep errorStep = steps.get(1);
-    assertThat(errorStep.getName(), is("oops-failure - Error signal"));
-    FlowNode node = run.getExecution().getNode(String.valueOf(errorStep.getId()));
-    String errorText = PipelineNodeUtil.getExceptionText(node);
-    assertThat(errorText, is("oops-failure"));
-  }
+        List<PipelineStep> steps = api.getSteps(failureStage).getSteps();
+        assertThat(steps, hasSize(2));
+        PipelineStep errorStep = steps.get(1);
+        assertThat(errorStep.getName(), is("oops-failure - Error signal"));
+        FlowNode node = run.getExecution().getNode(String.valueOf(errorStep.getId()));
+        String errorText = PipelineNodeUtil.getExceptionText(node);
+        assertThat(errorText, is("oops-failure"));
+    }
 
-  @Issue("GH#213")
-  @Test
-  public void githubIssue213RegressionTest_pipelineCallsUndefinedVar() throws Exception {
-    // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
-    // long time)
-    WorkflowRun run =
-        TestUtils.createAndRunJob(
-            j,
-            "githubIssue213_callsUnknownVariable",
-            "callsUnknownVariable.jenkinsfile",
-            Result.FAILURE);
+    @Issue("GH#213")
+    @Test
+    public void githubIssue213RegressionTest_pipelineCallsUndefinedVar() throws Exception {
+        // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
+        // long time)
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "githubIssue213_callsUnknownVariable", "callsUnknownVariable.jenkinsfile", Result.FAILURE);
 
-    PipelineStepApi api = new PipelineStepApi(run);
+        PipelineStepApi api = new PipelineStepApi(run);
 
-    String failureStage = TestUtils.getNodesByDisplayName(run, "failure").get(0).getId();
+        String failureStage =
+                TestUtils.getNodesByDisplayName(run, "failure").get(0).getId();
 
-    List<PipelineStep> steps = api.getAllSteps().getSteps();
-    assertThat(steps, hasSize(2));
-    PipelineStep errorStep = steps.get(1);
-    assertThat(errorStep.getName(), is("Pipeline error"));
-  }
+        List<PipelineStep> steps = api.getAllSteps().getSteps();
+        assertThat(steps, hasSize(2));
+        PipelineStep errorStep = steps.get(1);
+        assertThat(errorStep.getName(), is("Pipeline error"));
+    }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/TestUtils.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/TestUtils.java
@@ -20,54 +20,47 @@ import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class TestUtils {
-  private static final Logger LOGGER = Logger.getLogger(TestUtils.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(TestUtils.class.getName());
 
-  public static WorkflowRun createAndRunJob(
-      JenkinsRule jenkins, String jobName, String jenkinsFileName, Result expectedResult)
-      throws Exception {
-    WorkflowJob job = TestUtils.createJob(jenkins, jobName, jenkinsFileName);
-    jenkins.assertBuildStatus(expectedResult, job.scheduleBuild2(0));
-    return job.getLastBuild();
-  }
-
-  public static WorkflowJob createJob(JenkinsRule jenkins, String jobName, String jenkinsFileName)
-      throws java.io.IOException {
-    WorkflowJob job = jenkins.createProject(WorkflowJob.class, jobName);
-
-    URL resource = Resources.getResource(TestUtils.class, jenkinsFileName);
-    String jenkinsFile = Resources.toString(resource, Charsets.UTF_8);
-    job.setDefinition(new CpsFlowDefinition(jenkinsFile, true));
-    return job;
-  }
-
-  public static List<FlowNode> getNodesByDisplayName(WorkflowRun run, String displayName)
-      throws java.io.IOException {
-    FlowExecution execution = run.getExecution();
-    FlowGraphTable graphTable = new FlowGraphTable(execution);
-    graphTable.build();
-    List<FlowNode> matchingNodes = new ArrayList<>();
-    for (Row row : graphTable.getRows()) {
-      if (row.getDisplayName().contains(" (" + displayName + ")")) {
-        FlowNode node = row.getNode();
-        LOGGER.log(
-            Level.INFO, "Found matching node: '" + displayName + "' with ID " + node.getId());
-        matchingNodes.add(node);
-      }
+    public static WorkflowRun createAndRunJob(
+            JenkinsRule jenkins, String jobName, String jenkinsFileName, Result expectedResult) throws Exception {
+        WorkflowJob job = TestUtils.createJob(jenkins, jobName, jenkinsFileName);
+        jenkins.assertBuildStatus(expectedResult, job.scheduleBuild2(0));
+        return job.getLastBuild();
     }
-    return matchingNodes;
-  }
 
-  public static String collectStagesAsString(
-      List<PipelineStage> stages, Function<PipelineStage, String> converter) {
-    return stages.stream()
-        .map(
-            (PipelineStage stage) ->
-                stage.getChildren().isEmpty()
-                    ? converter.apply(stage)
-                    : String.format(
-                        "%s[%s]",
-                        converter.apply(stage),
-                        collectStagesAsString(stage.getChildren(), converter)))
-        .collect(Collectors.joining(","));
-  }
+    public static WorkflowJob createJob(JenkinsRule jenkins, String jobName, String jenkinsFileName)
+            throws java.io.IOException {
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class, jobName);
+
+        URL resource = Resources.getResource(TestUtils.class, jenkinsFileName);
+        String jenkinsFile = Resources.toString(resource, Charsets.UTF_8);
+        job.setDefinition(new CpsFlowDefinition(jenkinsFile, true));
+        return job;
+    }
+
+    public static List<FlowNode> getNodesByDisplayName(WorkflowRun run, String displayName) throws java.io.IOException {
+        FlowExecution execution = run.getExecution();
+        FlowGraphTable graphTable = new FlowGraphTable(execution);
+        graphTable.build();
+        List<FlowNode> matchingNodes = new ArrayList<>();
+        for (Row row : graphTable.getRows()) {
+            if (row.getDisplayName().contains(" (" + displayName + ")")) {
+                FlowNode node = row.getNode();
+                LOGGER.log(Level.INFO, "Found matching node: '" + displayName + "' with ID " + node.getId());
+                matchingNodes.add(node);
+            }
+        }
+        return matchingNodes;
+    }
+
+    public static String collectStagesAsString(List<PipelineStage> stages, Function<PipelineStage, String> converter) {
+        return stages.stream()
+                .map((PipelineStage stage) -> stage.getChildren().isEmpty()
+                        ? converter.apply(stage)
+                        : String.format(
+                                "%s[%s]",
+                                converter.apply(stage), collectStagesAsString(stage.getChildren(), converter)))
+                .collect(Collectors.joining(","));
+    }
 }


### PR DESCRIPTION
This repository had its own custom Spotless configuration. Moving to the project-wide upstream configuration should make it easier to maintain this plugin. If the maintainers would rather retain the existing configuration I have no problem with this PR being closed, but I think it would be better to standardize on a project-wide configuration to make it easier to hop from one repository to the next as a code reader.