### PR TITLE
Suppress FlowInterruptedException stack traces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-definition</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>pipeline-build-step</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -157,7 +157,10 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
         if (isUnhandledException(nodeId)) {
             // Set logText to exception text. This is a little hacky - maybe it would be better update the
             // frontend to handle steps and exceptions differently?
-            text += getNodeExceptionText(nodeId);
+            String nodeExceptionText = getNodeExceptionText(nodeId);
+            if (nodeExceptionText != null) {
+                text += nodeExceptionText;
+            }
             endByte += text.length();
         }
         HashMap<String, Object> response = new HashMap<>();

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
@@ -272,7 +272,10 @@ public class PipelineNodeUtil {
                 } else {
                     // If this is not a Jenkins failure exception, then we should print everything.
                     log = "Found unhandled " + exception.getClass().getName() + " exception:\n";
-                    log += exception.getMessage() + "\n\t";
+                    String message = exception.getMessage();
+                    if (message != null) {
+                        log += message + "\n\t";
+                    }
                     log += Arrays.stream(exception.getStackTrace())
                             .map(s -> s.toString())
                             .collect(Collectors.joining("\n\t"));

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
@@ -28,6 +28,7 @@ import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.support.actions.PauseAction;
 import org.jenkinsci.plugins.workflow.support.steps.ExecutorStep;
@@ -283,7 +284,7 @@ public class PipelineNodeUtil {
     }
 
     public static boolean isJenkinsFailureException(Throwable exception) {
-        if (exception instanceof AbortException) {
+        if (exception instanceof AbortException || exception instanceof FlowInterruptedException) {
             return true;
         }
         return false;

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
@@ -326,8 +326,7 @@ public class PipelineStepApiTest {
 
         // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
         // long time)
-        WorkflowRun run = TestUtils.createAndRunJob(
-                j, "githubIssue274", "githubIssue274.jenkinsfile", Result.FAILURE);
+        WorkflowRun run = TestUtils.createAndRunJob(j, "githubIssue274", "githubIssue274.jenkinsfile", Result.FAILURE);
 
         PipelineStepApi api = new PipelineStepApi(run);
 
@@ -339,6 +338,9 @@ public class PipelineStepApiTest {
         PipelineStep errorStep = steps.get(0);
         FlowNode node = run.getExecution().getNode(String.valueOf(errorStep.getId()));
         String errorText = PipelineNodeUtil.getExceptionText(node);
-        assertThat(errorText, not(containsString("Found unhandled org.jenkinsci.plugins.workflow.steps.FlowInterruptedException exception")));
+        assertThat(
+                errorText,
+                not(containsString(
+                        "Found unhandled org.jenkinsci.plugins.workflow.steps.FlowInterruptedException exception")));
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
@@ -318,4 +318,27 @@ public class PipelineStepApiTest {
         PipelineStep errorStep = steps.get(1);
         assertThat(errorStep.getName(), is("Pipeline error"));
     }
+
+    @Issue("GH#274")
+    @Test
+    public void githubIssue274RegressionTest_suppressFlowInterruptedExceptions() throws Exception {
+        TestUtils.createJob(j, "simpleError", "simpleError.jenkinsfile");
+
+        // It's a bit dirty, but do this in one to avoid reloading and rerunning the job (as it takes a
+        // long time)
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "githubIssue274", "githubIssue274.jenkinsfile", Result.FAILURE);
+
+        PipelineStepApi api = new PipelineStepApi(run);
+
+        String failureStage =
+                TestUtils.getNodesByDisplayName(run, "failure").get(0).getId();
+
+        List<PipelineStep> steps = api.getSteps(failureStage).getSteps();
+        assertThat(steps, hasSize(2));
+        PipelineStep errorStep = steps.get(0);
+        FlowNode node = run.getExecution().getNode(String.valueOf(errorStep.getId()));
+        String errorText = PipelineNodeUtil.getExceptionText(node);
+        assertThat(errorText, not(containsString("Found unhandled org.jenkinsci.plugins.workflow.steps.FlowInterruptedException exception")));
+    }
 }

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/githubIssue274.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/githubIssue274.jenkinsfile
@@ -1,0 +1,9 @@
+node {
+	stage("failure") {
+		try {
+			build("simpleError")
+		} finally {
+			echo("post build step")
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Include [`FlowInterruptedException`](https://javadoc.jenkins.io/plugin/workflow-step-api/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.html) as a "JenkinsFailureException" which avoids it being considered an unhandled exception type. This prevents the strack trace being logged. Also, avoid logging `null` exception messages.

Fixes #274.

### Testing done
Added a new test `githubIssue274RegressionTest_suppressFlowInterruptedExceptions` which verifies that `PipelineNodeUtil#getExceptionText` no longer returns a stack trace for `FlowInterruptedException` exceptions.

Manually tested the change against the example pipeline described in #274.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
