### PR TITLE
Allow PipelineGraphDisplayURLProvider to activate by default, preserve direct tests/artifacts/changes links, and do not try to handle non-Pipeline builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,12 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>display-url-api</artifactId>
+      <!-- TODO: Remove once included in BOM -->
+      <version>2.3.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <optional>true</optional>
     </dependency>

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphDisplayURLProvider.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphDisplayURLProvider.java
@@ -2,12 +2,13 @@ package io.jenkins.plugins.pipelinegraphview;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import hudson.Util;
+import hudson.model.Job;
 import hudson.model.Run;
-import org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
-@Extension
-public class PipelineGraphDisplayURLProvider extends ClassicDisplayURLProvider {
+@Extension(ordinal = 50) // Take precedence over Blue Ocean if both are installed and there is no configured provider.
+public class PipelineGraphDisplayURLProvider extends DisplayURLProvider {
 
     @Override
     @NonNull
@@ -24,6 +25,30 @@ public class PipelineGraphDisplayURLProvider extends ClassicDisplayURLProvider {
     @Override
     @NonNull
     public String getRunURL(Run<?, ?> run) {
-        return getRoot() + Util.encode(run.getUrl()) + "pipeline-graph";
+        if (run instanceof WorkflowRun) {
+            return DisplayURLProvider.getDefault().getRunURL(run) + "pipeline-graph";
+        }
+        return DisplayURLProvider.getDefault().getRunURL(run);
+    }
+
+    @Override
+    public String getArtifactsURL(Run<?, ?> run) {
+        return DisplayURLProvider.getDefault().getArtifactsURL(run);
+    }
+
+    @Override
+    public String getChangesURL(Run<?, ?> run) {
+        return DisplayURLProvider.getDefault().getChangesURL(run);
+    }
+
+    @Override
+    public String getTestsURL(Run<?, ?> run) {
+        return DisplayURLProvider.getDefault().getTestsURL(run);
+    }
+
+    @Override
+    public String getJobURL(Job<?, ?> job) {
+        // TODO: Could redirect this to MultiPipelineGraphViewAction
+        return DisplayURLProvider.getDefault().getJobURL(job);
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

While working on https://github.com/jenkinsci/display-url-api-plugin/pull/202 I realized that `DisplayURLProvider` is pretty awkward, which leads to a lot of subtle issues depending on how exactly you implement it.

This PR adjusts #6.

### Testing done

Here is a demo of the changes, let me know if you would like any particular kind of automated test.

https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/1068968/d71f30cd-9c84-40bc-87de-5819176cbc0a

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
