### PR TITLE
Do not show (undefined) start time for skipped runs

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
@@ -38,10 +38,10 @@ const StageSummary = (props: StageSummaryProps) => (
         className="detail-element"
         key={`stage-detail-start-time-container-${props.stage.id}`}
       >
-        <ScheduleIcon
+       { props.stage.startTimeMillis && <ScheduleIcon
           className="detail-icon"
           key={`stage-detail-start-time-icon-${props.stage.id}`}
-        />
+        />}
         {props.stage.startTimeMillis}
       </div>
       <div

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStage.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStage.java
@@ -48,8 +48,9 @@ public class PipelineStage {
         this.sequential = sequential;
         this.synthetic = synthetic;
         this.pauseDurationMillis = "Queued " + Util.getTimeSpanString(pauseDurationMillis);
-        this.startTimeMillis =
-                "Started " + Util.getTimeSpanString(Math.abs(startTimeMillis - new Date().getTime())) + " ago";
+        this.startTimeMillis = startTimeMillis == 0
+                ? ""
+                : "Started " + Util.getTimeSpanString(Math.abs(startTimeMillis - new Date().getTime())) + " ago";
         this.totalDurationMillis = "Took " + Util.getTimeSpanString(totalDurationMillis);
     }
 


### PR DESCRIPTION
For skipped stages we currently get

![image](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/1105305/cb2da68e-b236-4222-a02e-4e3b12919211)

Not sure if the 0 duration should also be hidden or not, but "started 53 years ago" is definitely wrong.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
