### PR TITLE
Fix CSS for console lines that wrap

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLine.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLine.tsx
@@ -27,10 +27,14 @@ export const ConsoleLine = (props: ConsoleLineProps) => (
       >
         {props.lineNumber}
       </a>
-      {makeReactChildren(
-        tokenizeANSIString(props.content),
-        `${props.stepId}-${props.lineNumber}`
-      )}
+      <div
+        className="console-text"
+        >
+        {makeReactChildren(
+          tokenizeANSIString(props.content),
+          `${props.stepId}-${props.lineNumber}`
+        )}
+      </div>
     </div>
   </pre>
 );

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -101,6 +101,12 @@
   padding-left: 16px;
 }
 
+.console-text div {
+  text-indent: 0;
+  padding-left: 15px;
+  padding-right: 5px;
+}
+
 div.show-more-console {
   background-color: var(--alert-warning-bg-color);
 }
@@ -269,6 +275,7 @@ a.console-line-number {
   color: var(--link-color);
   white-space: nowrap;
   display: inline-block;
+  flex-shrink: 0;
 }
 
 div.console-output-line-anchor {
@@ -303,6 +310,7 @@ div.stage-detail-group {
   @extend div, .stage-detail-group;
   background-color: transparent !important;
   text-indent: 15px;
+  padding-left: 15px !important;
   padding: 0px !important;
   color: var(--text-color) !important;
   box-shadow: none !important;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -310,7 +310,6 @@ div.stage-detail-group {
   @extend div, .stage-detail-group;
   background-color: transparent !important;
   text-indent: 15px;
-  padding-left: 15px !important;
   padding: 0px !important;
   color: var(--text-color) !important;
   box-shadow: none !important;


### PR DESCRIPTION
Fix how wrapped console lines are displayed in console view.

- Add a new class to handle console text output (don't rely on an inherited class).
- Stop line number width flexing when console text wraps.

Local testing.

Pipeline:
```
pipeline {
    agent any

    stages {
        stage('Hello') {
            steps {
                echo '    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
            }
        }
    }
}
```
Before:
![Screenshot from 2023-11-01 12-35-26](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/4447764/b25b25c4-a743-451d-9e2f-39079f1f3bcd)

After:
![Screenshot from 2023-11-01 12-36-11](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/4447764/d56bd6a2-513b-4af6-bff2-64fc36109968)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```