### PR TITLE
Unlimited visibility for branch name

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
@@ -26,7 +26,7 @@ export function decodeResultValue(resultMaybe: any): Result {
 export const defaultLayout = {
   nodeSpacingH: 120,
   parallelSpacingH: 120,
-  nodeSpacingV: 70,
+  nodeSpacingV: 100,
   nodeRadius: 12,
   terminalRadius: 7,
   curveRadius: 12,

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
@@ -166,7 +166,7 @@ export function SequentialContainerLabel({
   const { nodeRadius } = layout;
 
   const seqContainerName = details.text;
-  const y = details.y;
+  const y = details.y - Math.floor(nodeRadius * 2); // Because label Y must be above branch
   const x = details.x - Math.floor(nodeRadius * 2); // Because label X is a "node center"-relative position
 
   const containerStyle: any = {
@@ -174,10 +174,6 @@ export function SequentialContainerLabel({
     left: x,
     marginTop: "-0.5em",
     position: "absolute",
-    maxWidth: sequentialStagesLabelOffset,
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    background: "var(--background, white)",
     padding: "0 7px",
     lineHeight: "1",
     whiteSpace: "nowrap",


### PR DESCRIPTION
Hello!

We met a situation when needed large branch names for parallel stages. But where is no place for big complex names: Fedora 33 - main, Fedora 33 - debug, etc...

This attempt to fix is ugly, but can be a good start point for you.

Maybe it's should be as view option flag.
![before](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/71733602/8bd063d7-e2e1-41f1-a7b3-bffd66914e4b)
![after](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/71733602/96f5405e-dbe8-4150-9561-0144316ff175)
