### PR TITLE
Use --accent-color for running steps in the Console View

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -2,6 +2,7 @@
 
 :root {
   --card-background: hsl(212, 30%, 96%);
+  --step-bg-running: var(--accent-color);
   --step-bg-success: var(--success-color);
   --step-bg-unstable: var(--warning-color);
   --step-bg-failure: var(--error-color);
@@ -297,8 +298,11 @@ div.detail-element {
   cursor: pointer;
 }
 
-.step-header-success,
 .step-header-running {
+  background: var(--step-bg-running) !important;
+}
+
+.step-header-success {
   background: var(--step-bg-success) !important;
 }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Separate `.step-header-running` from the `.step-header-success` class to differentiate running steps from complete successful steps.

Use `--accent-color` which by default is a blue color similar to what is used for in progress nodes on the graph view. 

**Running Step**
![image](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/551572/00dee68d-04a6-4c06-9059-d5e0903b28e3)

**Successful Step**
![image](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/551572/58b1d085-8168-4ea7-9bae-e576948c9fef)

Fixes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/344.

### Testing done

Tested locally with a pipeline containing a 60s sleep.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
