### PR TITLE
Fix incorrect step result when referencing an ErrorAction

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/BlueRun.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/BlueRun.java
@@ -1,5 +1,7 @@
 package io.jenkins.plugins.pipelinegraphview.utils;
 
+import hudson.model.Result;
+
 public class BlueRun {
     public enum BlueRunState {
         QUEUED,
@@ -28,6 +30,22 @@ public class BlueRun {
         UNKNOWN,
 
         /** Aborted run */
-        ABORTED,
+        ABORTED;
+
+        public static BlueRunResult fromResult(Result result) {
+            if (result == Result.SUCCESS) {
+                return BlueRunResult.SUCCESS;
+            } else if (result == Result.UNSTABLE) {
+                return BlueRunResult.UNSTABLE;
+            } else if (result == Result.FAILURE) {
+                return BlueRunResult.FAILURE;
+            } else if (result == Result.NOT_BUILT) {
+                return BlueRunResult.NOT_BUILT;
+            } else if (result == Result.ABORTED) {
+                return BlueRunResult.ABORTED;
+            } else {
+                return BlueRunResult.UNKNOWN;
+            }
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/NodeRunStatus.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/NodeRunStatus.java
@@ -17,21 +17,17 @@ public class NodeRunStatus {
     public final BlueRun.BlueRunState state;
 
     public NodeRunStatus(@NonNull FlowNode endNode) {
-        Result result = null;
         ErrorAction errorAction = endNode.getError();
         WarningAction warningAction = endNode.getPersistentAction(WarningAction.class);
         if (errorAction != null) {
+            Result result = null;
             if (errorAction.getError() instanceof FlowInterruptedException) {
                 result = ((FlowInterruptedException) errorAction.getError()).getResult();
             }
-            if (result == null || result != Result.ABORTED) {
-                this.result = BlueRun.BlueRunResult.FAILURE;
-            } else {
-                this.result = BlueRun.BlueRunResult.ABORTED;
-            }
+            this.result = result != null ? BlueRun.BlueRunResult.fromResult(result) : BlueRun.BlueRunResult.FAILURE;
             this.state = endNode.isActive() ? BlueRun.BlueRunState.RUNNING : BlueRun.BlueRunState.FINISHED;
         } else if (warningAction != null) {
-            this.result = new NodeRunStatus(GenericStatus.fromResult(warningAction.getResult())).result;
+            this.result = BlueRun.BlueRunResult.fromResult(warningAction.getResult());
             this.state = endNode.isActive() ? BlueRun.BlueRunState.RUNNING : BlueRun.BlueRunState.FINISHED;
         } else if (QueueItemAction.getNodeState(endNode) == QueueItemAction.QueueState.QUEUED) {
             this.result = BlueRun.BlueRunResult.UNKNOWN;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fix for https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/350.

The [NodeRunStatus constructor](https://github.com/jenkinsci/pipeline-graph-view-plugin/blob/87c53b9237dd49b0607734665f276e2c9f70132b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/NodeRunStatus.java#L25) was reading the result from the associated [`ErrorAction`](https://javadoc.jenkins.io/plugin/workflow-api/org/jenkinsci/plugins/workflow/actions/ErrorAction.html) but then not directly using it to set [`NodeRunStatus#result`](https://github.com/jenkinsci/pipeline-graph-view-plugin/blob/87c53b9237dd49b0607734665f276e2c9f70132b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/NodeRunStatus.java#L16). Instead `this.result` was always being set to `BlueRunResult.FAILURE` unless the local `result` was equal to `Result.ABORTED`.

I implemented a new method for translating `Result` to `BlueRunResult` and used that to set [`NodeRunStatus#result`](https://github.com/jenkinsci/pipeline-graph-view-plugin/blob/87c53b9237dd49b0607734665f276e2c9f70132b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/NodeRunStatus.java#L16) instead.

**Before**
![Screenshot 2024-03-04 at 8 55 12 PM](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/551572/1443391b-d045-4aca-aeef-0ca605a61332)

**After**
![Screenshot 2024-03-04 at 8 57 40 PM](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/551572/67db092a-3c1d-4634-bdc6-c1f60a177e07)


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
