### PR TITLE
Pull log text if ConsoleLogCard starts expanded.

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.spec.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.spec.tsx
@@ -64,4 +64,20 @@ describe("ConsoleLogCard", () => {
     expect(getByText(/This is a step/));
     expect(findByText(/Hello, world!/));
   });
+
+  it("calls handleMoreConsoleClick on load was card isExpanded set", async () => {
+    console.log = jest.fn();
+    render(<ConsoleLogCard {...DefaultTestProps} isExpanded={true} />);
+    expect(console.log).toHaveBeenCalledWith(
+      "handleMoreConsoleClick triggered"
+    );
+  });
+
+  it("does not call handleMoreConsoleClick on load was card isExpanded set", async () => {
+    console.log = jest.fn();
+    render(<ConsoleLogCard {...DefaultTestProps} />);
+    expect(console.log).not.toHaveBeenCalledWith(
+      "handleMoreConsoleClick triggered"
+    );
+  });
 });

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
@@ -82,11 +82,11 @@ export class ConsoleLogCard extends React.Component<
 
   componentDidMount(): void {
     if (this.props.isExpanded) {
-      console.info(`Getting initial logs for step '${this.props.step.id}'.`);
       // If we start expanded then request logs.
-      this.props.handleMoreConsoleClick(this.props.step.id, this.props.stepBuffer.startByte);
-    } else {
-      console.info(`Step '${this.props.step.id}' not open '${this.props.isExpanded}', so not getting logs.`);
+      this.props.handleMoreConsoleClick(
+        this.props.step.id,
+        this.props.stepBuffer.startByte
+      );
     }
   }
 

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
@@ -80,6 +80,16 @@ export class ConsoleLogCard extends React.Component<
     this.props.handleStepToggle(event, this.props.step.id);
   }
 
+  componentDidMount(): void {
+    if (this.props.isExpanded) {
+      console.info(`Getting initial logs for step '${this.props.step.id}'.`);
+      // If we start expanded then request logs.
+      this.props.handleMoreConsoleClick(this.props.step.id, this.props.stepBuffer.startByte);
+    } else {
+      console.info(`Step '${this.props.step.id}' not open '${this.props.isExpanded}', so not getting logs.`);
+    }
+  }
+
   getTruncatedLogWarning() {
     if (this.props.stepBuffer.lines && this.props.stepBuffer.startByte > 0) {
       return (


### PR DESCRIPTION
Add a `componentDidMount` that pulls the logs if alog card starts expanded.

Before:
![Screenshot from 2024-03-07 09-06-26](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/4447764/6d3ab46c-069f-4bd8-9787-a05f6c74564b)

After:
![Screenshot from 2024-03-07 09-40-29](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/4447764/06902c36-2b8f-44dd-a39c-2254ffc7a58e)

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
