### PR TITLE
Improve reliablity of finding 'after' nodes.

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
@@ -5,17 +5,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.plugins.pipelinegraphview.utils.BlueRun;
 import io.jenkins.plugins.pipelinegraphview.utils.NodeRunStatus;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineNodeUtil;
-import org.jenkinsci.plugins.workflow.actions.ErrorAction;
-import org.jenkinsci.plugins.workflow.actions.TimingAction;
-import org.jenkinsci.plugins.workflow.actions.WarningAction;
-import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
-import org.jenkinsci.plugins.workflow.graph.FlowStartNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.GenericStatus;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.StatusAndTiming;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.TimingInfo;
-import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.support.actions.PauseAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,62 +112,11 @@ public class NodeRelationship {
         } else if (PipelineNodeUtil.isPaused(this.end)) {
             return new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.PAUSED);
         }
-        // StatusAndTiming.computeChunkStatus2 assumes that a Stage is running if there
-        // is no after node. There are instances where this can happen (might be a bug
-        // in this code). To work around this we catch this case and explicitly generate
-        // the status ourselves.
-        if (this.after == null && !isRunning(run)) {
-            return new NodeRunStatus(getFinishNodeStatus());
-        }
         dump(
                 "Calculating Chunk Status start: %s, end: %s after: %s",
                 this.start.getId(), this.end.getId(), (this.after != null) ? this.after.getId() : "null");
         // Catch-all if none of the above are applicable.
         return new NodeRunStatus(
                 StatusAndTiming.computeChunkStatus2(run, this.before, this.start, this.end, this.after));
-    }
-
-    /*
-     * Determine if the current block is still executing.
-     * Note: This doesn't seem efficient, but I couldn't see another way.
-     */
-    private boolean isRunning(WorkflowRun run) {
-        FlowExecution exec = run.getExecution();
-        if (exec != null) {
-            for (FlowNode head : exec.getCurrentHeads()) {
-                // If out start node is a head, then our npde/block is still running.
-                if (head.getId() == this.start.getId() ||
-                        head.getAllEnclosingIds().contains(this.start.getId())) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /*
-     * Generate status for finished node.
-     * Source:
-     * https://github.com/jenkinsci/pipeline-graph-analysis-plugin/blob/master/src/
-     * main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/
-     * StatusAndTiming.java#L295
-     */
-    private GenericStatus getFinishNodeStatus() {
-        ErrorAction err = this.end.getError();
-        if (err != null) {
-            Throwable rootCause = err.getError();
-            if (rootCause instanceof FlowInterruptedException) {
-                return GenericStatus.fromResult(((FlowInterruptedException) rootCause).getResult());
-            } else {
-                return GenericStatus.FAILURE;
-            }
-        }
-        WarningAction warning = StatusAndTiming.findWorstWarningBetween(start, end);
-        if (warning != null) {
-            return GenericStatus.fromResult(warning.getResult());
-        }
-
-        // Previous chunk before end. If flow continued beyond this, it didn't fail.
-        return GenericStatus.SUCCESS;
     }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
@@ -6,9 +6,11 @@ import io.jenkins.plugins.pipelinegraphview.utils.BlueRun;
 import io.jenkins.plugins.pipelinegraphview.utils.NodeRunStatus;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineNodeUtil;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
+import org.jenkinsci.plugins.workflow.actions.TimingAction;
 import org.jenkinsci.plugins.workflow.actions.WarningAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.graph.FlowStartNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.GenericStatus;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.StatusAndTiming;
@@ -140,7 +142,9 @@ public class NodeRelationship {
         FlowExecution exec = run.getExecution();
         if (exec != null) {
             for (FlowNode head : exec.getCurrentHeads()) {
-                if (head.getAllEnclosingIds().contains(this.start.getId())) {
+                // If out start node is a head, then our npde/block is still running.
+                if (head.getId() == this.start.getId() ||
+                        head.getAllEnclosingIds().contains(this.start.getId())) {
                     return true;
                 }
             }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationshipFinder.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationshipFinder.java
@@ -91,7 +91,7 @@ public class NodeRelationshipFinder {
         if (subsequentStepRelationship != null) {
             after = subsequentStepRelationship.getStart();
             dump("Getting after node (%s) from subsequentStepRelationship", after.getId());
-        } else {
+        } else if (!pendingEndNodes.isEmpty()){
             after = pendingEndNodes.peek();
             dump(
                     "Getting after node (%s) from endNodes stack (size: %s)",
@@ -99,6 +99,7 @@ public class NodeRelationshipFinder {
         }
         NodeRelationship nodeRelationship = new NodeRelationship(step, step, after);
         relationships.put(step.getId(), nodeRelationship);
+        // Reset this so the next step will use this step as it's after node (if it's in the same block).
         subsequentStepRelationship = nodeRelationship;
     }
 

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationshipFinder.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationshipFinder.java
@@ -9,8 +9,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,16 +22,24 @@ public class NodeRelationshipFinder {
     private boolean isDebugEnabled = logger.isDebugEnabled();
 
     private LinkedHashMap<String, FlowNode> endNodes = new LinkedHashMap<>();
-    private ArrayDeque<FlowNode> pendingEndNodes = new ArrayDeque<>();
-    private ArrayDeque<FlowNode> pendingStartNodes = new ArrayDeque<>();
 
-    // Somewhere to temporarily store the parallel branches information whilst we
-    // are handing a parallel block.
-    // The StatusAndTiming API requires us to the structure of the parallel block to
-    // get the status of a branch.
+    /* Stack of stacks to store the last seen node for each nested block we have gone into.
+     * Used to assign the after node for relationships.
+     * This can be a different type, depending on situation:
+     *  - For the last Atom node in a block, will be the BlockEndNode (or null if the step is running).
+     *  - For nodes that have later siblings, this will be the previous sibling we found.
+     *    - This might be a AtomNode or a BlockStartNode (when a step is followed by a StepBlock).
+     */
+    private ArrayDeque<ArrayDeque<FlowNode>> lastSeenNodes = new ArrayDeque<>();
+    private Map<String, ArrayDeque<FlowNode>> seenChildNodes = new LinkedHashMap<>();
+
+    /*  Somewhere to temporarily store the parallel branches information whilst we
+     * are handing a parallel block.
+     * The StatusAndTiming API requires us to the structure of the parallel block to
+     * get the status of a branch.
+     */
     private ArrayDeque<NodeRelationship> pendingBranchRelationships = new ArrayDeque<>();
 
-    private NodeRelationship subsequentStepRelationship = null;
     private LinkedHashMap<String, NodeRelationship> relationships = new LinkedHashMap<>();
 
     // Print debug message if 'isDebugEnabled' is true.
@@ -57,6 +67,9 @@ public class NodeRelationshipFinder {
         dump("Sorted Ids: %s", String.join(", ", sortedIds));
         for (String id : sortedIds) {
             getRelationshipForNode(nodeMap.get(id));
+            // Add this node to the parents's stack as the last of it's child nodes that
+            //  we have seen.
+            addSeenNodes(nodeMap.get(id));
         }
         return relationships;
     }
@@ -73,8 +86,6 @@ public class NodeRelationshipFinder {
     }
 
     private void handleBlockStart(@NonNull FlowNode node) {
-        // Reset step relationship - shouldn't carry over between blocks.
-        subsequentStepRelationship = null;
         // Assign end node to start node.
         if (FlowNodeWrapper.isStart(node)) {
             addBlockRelationship(node);
@@ -83,33 +94,68 @@ public class NodeRelationshipFinder {
         }
     }
 
+    private void addSeenNodes(FlowNode node) {
+        if (!seenChildNodes.keySet().contains(node.getEnclosingId())) {
+            seenChildNodes.put(node.getEnclosingId(), new ArrayDeque<FlowNode>());
+        }
+        dump("Adding %s to seenChildNodes %s", node.getId(), node.getEnclosingId());
+        seenChildNodes.get(node.getEnclosingId()).push(node);
+    }
+
+    @CheckForNull
+    private FlowNode getAfterNode(FlowNode node) {
+        FlowNode after = null;
+        // The after node is the last child of the enclosing node, except for the last node in
+        // a block, then it's the last node in the enclosing nodes list (likely, this blocks end node).
+        FlowNode parentStartNode = getFirstEnclosingNode(node);
+        ArrayDeque<FlowNode> laterSiblings = getProcessedChildren(parentStartNode);
+        if (parentStartNode != null && laterSiblings.isEmpty()) {
+            // If there are no later siblings, get the parents later sibling.
+            ArrayDeque<FlowNode> parentsLaterSiblings = getProcessedChildren(getFirstEnclosingNode(parentStartNode));
+            after = parentsLaterSiblings.isEmpty() ? null : parentsLaterSiblings.peek();
+            dump(parentsLaterSiblings.toString());
+        } else {
+            dump(laterSiblings.toString());
+            after = laterSiblings.peek();
+        }
+        return after;
+    }
+
+    @CheckForNull
+    private BlockStartNode getFirstEnclosingNode(FlowNode node) {
+        return node.getEnclosingBlocks().isEmpty()
+                ? null
+                : node.getEnclosingBlocks().get(0);
+    }
+
+    private ArrayDeque<FlowNode> getProcessedChildren(@CheckForNull FlowNode node) {
+        if (node != null && seenChildNodes.keySet().contains(node.getId())) {
+            return seenChildNodes.get(node.getId());
+        }
+        return new ArrayDeque<FlowNode>();
+    }
+
     private void addStepRelationship(@NonNull StepAtomNode step) {
         dump("Generating relationship for step %s", step.getId());
-        FlowNode after = null;
-        // If we are followed by a step, that will be our after node, otherwise use the
-        // end node of the block.
-        if (subsequentStepRelationship != null) {
-            after = subsequentStepRelationship.getStart();
-            dump("Getting after node (%s) from subsequentStepRelationship", after.getId());
-        } else if (!pendingEndNodes.isEmpty()){
-            after = pendingEndNodes.peek();
-            dump(
-                    "Getting after node (%s) from endNodes stack (size: %s)",
-                    (after != null) ? after.getId() : "null", endNodes.size());
-        }
+        // FlowNode after = subsequentNode;
+        FlowNode after = getAfterNode(step);
+        dump(
+                "Adding step for %s(%s),%s(%s)",
+                step.getId(),
+                step.getClass().getName(),
+                after == null ? "null" : after.getId(),
+                after == null ? "null" : after.getClass().getName());
         NodeRelationship nodeRelationship = new NodeRelationship(step, step, after);
         relationships.put(step.getId(), nodeRelationship);
-        // Reset this so the next step will use this step as it's after node (if it's in the same block).
-        subsequentStepRelationship = nodeRelationship;
     }
 
     private void handleBlockEnd(@NonNull BlockEndNode<?> endNode) {
         // Blindly push a new start pending reliable way to check for parallel node.
         FlowNode startNode = endNode.getStartNode();
         endNodes.put(startNode.getId(), endNode);
-        pendingEndNodes.push(endNode);
-        dump("Adding %s to pendingEndNodes", endNode.getId());
-        pendingStartNodes.push(startNode);
+        // Create new stack for this block, add the end node and push it to stack of stacks.
+        ArrayDeque<FlowNode> nodeBlockStack = new ArrayDeque<>();
+        lastSeenNodes.push(nodeBlockStack);
     }
 
     private void addBlockRelationship(@NonNull FlowNode node) {
@@ -132,15 +178,11 @@ public class NodeRelationshipFinder {
             if (endNode != node) {
                 relationships.put(endNode.getId(), blockRelationship);
             }
-            // Remove end node from stack (if there is one).
-            if (!pendingEndNodes.isEmpty()) {
-                pendingEndNodes.pop();
-            }
         }
     }
 
     private void addParallelBranchRelationship(@NonNull FlowNode node, @NonNull FlowNode endNode) {
-        FlowNode after = getBlockAfterNode();
+        FlowNode after = getAfterNode(node);
         // Store a parallel branch relationship - these will be used to build up the
         // parent parallel block relationship.
         // Once generated, that relationship will be superseded this one.
@@ -157,7 +199,7 @@ public class NodeRelationshipFinder {
     }
 
     private NodeRelationship addParallelRelationship(@NonNull FlowNode node, @NonNull FlowNode endNode) {
-        FlowNode after = getBlockAfterNode();
+        FlowNode after = getAfterNode(node);
         dump(
                 "Generating relationship for parallel Block %s (with after %s)",
                 node.getId(), (after != null) ? after.getId() : "null");
@@ -177,20 +219,8 @@ public class NodeRelationshipFinder {
         return parallelRelationship;
     }
 
-    @CheckForNull
-    private FlowNode getBlockAfterNode() {
-        FlowNode after = null;
-        if (!pendingEndNodes.isEmpty()) {
-            after = pendingEndNodes.pop();
-        }
-        dump(
-                "Getting after node (%s) from pendingEndNodes stack (size: %s)",
-                (after != null) ? after.getId() : "null", pendingEndNodes.size());
-        return after;
-    }
-
     private NodeRelationship addStageRelationship(@NonNull FlowNode node, @NonNull FlowNode endNode) {
-        FlowNode after = getBlockAfterNode();
+        FlowNode after = getAfterNode(node);
         dump(
                 "Generating relationship for Block %s{%s}->%s{%s} (with after %s{%s})",
                 node.getId(),

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
@@ -16,6 +16,8 @@ import io.jenkins.plugins.pipelinegraphview.treescanner.NodeRelationshipFinder;
 import io.jenkins.plugins.pipelinegraphview.treescanner.ParallelBlockRelationship;
 import io.jenkins.plugins.pipelinegraphview.treescanner.PipelineNodeGraphAdapter;
 import io.jenkins.plugins.pipelinegraphview.treescanner.PipelineNodeTreeScanner;
+import io.jenkins.plugins.pipelinegraphview.utils.PipelineGraphApi;
+
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -499,6 +501,8 @@ public class PipelineStepApiTest {
         WorkflowRun run = futureRun.waitForStart();
         j.waitForMessage("Starting sleep A...", run);
         j.waitForMessage("Starting sleep B...", run);
+        // Sleep to allow Pipeline to reach sleep.
+        Thread.sleep(500L);
         List<PipelineStep> steps = new PipelineStepApi(run).getAllSteps().getSteps();
         String stepsString = TestUtils.collectStepsAsString(steps, (PipelineStep s) -> TestUtils.nodeNameAndStatus(s));
 
@@ -506,7 +510,6 @@ public class PipelineStepApiTest {
         // Wait for Pipeline to end (terminating it means end nodes might not be
         // created).
         j.waitForCompletion(run);
-
         List<PipelineStep> finishedSteps =
                 new PipelineStepApi(run).getAllSteps().getSteps();
         String stepsStringFinished =
@@ -529,7 +532,7 @@ public class PipelineStepApiTest {
         QueueTaskFuture<WorkflowRun> futureRun = job.scheduleBuild2(0);
         WorkflowRun run = futureRun.waitForStart();
         j.waitForMessage("Hello World", run);
-        // Sleep to allow Pipeline to read sleep.
+        // Sleep to allow Pipeline to reach sleep.
         Thread.sleep(500L);
         List<PipelineStep> steps = new PipelineStepApi(run).getAllSteps().getSteps();
         String stepsString = TestUtils.collectStepsAsString(steps, (PipelineStep s) -> TestUtils.nodeNameAndStatus(s));

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
@@ -16,8 +16,6 @@ import io.jenkins.plugins.pipelinegraphview.treescanner.NodeRelationshipFinder;
 import io.jenkins.plugins.pipelinegraphview.treescanner.ParallelBlockRelationship;
 import io.jenkins.plugins.pipelinegraphview.treescanner.PipelineNodeGraphAdapter;
 import io.jenkins.plugins.pipelinegraphview.treescanner.PipelineNodeTreeScanner;
-import io.jenkins.plugins.pipelinegraphview.utils.PipelineGraphApi;
-
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/stepBlockInSteps.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/stepBlockInSteps.jenkinsfile
@@ -1,0 +1,15 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Hello') {
+            steps {
+                echo 'Hello World'
+                retry(1) {
+                    sleep(1)
+                }
+                echo 'Goodbye World'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Update how the NodeRelationshipFinder tracks after nodes.
- keeps a stack of seen nodes for each start node
- when we create a relationship we see if the enclosing node has any seen nodes (which occur later in the graph) if so, that is the after node, if not, we try again for the parent (which will most likely e the enclosing end node).

Fix for #362

### Testing done
Tested locally and added regression test for running step status.