### PR TITLE
Use NodeRunStatus(FlowNode) to determine the status for StepNodes

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
@@ -115,6 +115,12 @@ public class NodeRelationship {
         dump(
                 "Calculating Chunk Status start: %s, end: %s after: %s",
                 this.start.getId(), this.end.getId(), (this.after != null) ? this.after.getId() : "null");
+
+        // If start and end are equal this is a StepNode
+        if (this.start.getId().equals(this.end.getId())) {
+            return new NodeRunStatus(this.start);
+        }
+
         // Catch-all if none of the above are applicable.
         return new NodeRunStatus(
                 StatusAndTiming.computeChunkStatus2(run, this.before, this.start, this.end, this.after));


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/384

In cases where the `NodeRelationship`'s `start` and `end` nodes are equal, create a [`NodeRunStatus`](https://github.com/jenkinsci/pipeline-graph-view-plugin/blob/8959b75f3c47e32daf852e78aa33c0000424a6d1/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/NodeRunStatus.java#L20) directly with the `start` node instead of calling [`StatusAndTiming#computeChunkStatus2`](https://github.com/jenkinsci/pipeline-graph-analysis-plugin/blob/9dd4d6c086fbdece95979ab9de078af129ff7a5b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java#L250). The status of the node will be correctly determined based on its associated `WarningAction`.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
