### PR TITLE
Small improvements to branch labels

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
@@ -175,18 +175,18 @@ export function SequentialContainerLabel({
 
   const lineHeight = 1.35;
 
-  const containerStyle: any = {
+  const containerStyle = {
     top: y,
     left: x,
     lineHeight,
     marginTop: `-${lineHeight / 2}em`,
-    position: "absolute",
+    position: "absolute" as const,
     maxWidth: sequentialStagesLabelOffset,
     overflow: "hidden",
     textOverflow: "ellipsis",
     background: "var(--background, white)",
     padding: "0 3px",
-    whiteSpace: "nowrap",
+    whiteSpace: "nowrap" as const,
     outline: "1px solid var(--graph-connector-grey, gray)",
     borderRadius: "3px",
   };

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
@@ -182,7 +182,7 @@ export function SequentialContainerLabel({
     overflow: "hidden",
     textOverflow: "ellipsis",
     background: "var(--background, white)",
-    padding: "0 7px",
+    padding: "0 3px",
     lineHeight: "1",
     whiteSpace: "nowrap",
     outline: "1px solid var(--graph-connector-grey, gray)",

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
@@ -185,6 +185,8 @@ export function SequentialContainerLabel({
     padding: "0 7px",
     lineHeight: "1",
     whiteSpace: "nowrap",
+    outline: "1px solid var(--graph-connector-grey, gray)",
+    borderRadius: "3px",
   };
 
   return (

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
@@ -173,17 +173,19 @@ export function SequentialContainerLabel({
   const y = details.y;
   const x = details.x - Math.floor(nodeRadius * 2); // Because label X is a "node center"-relative position
 
+  const lineHeight = 1.35;
+
   const containerStyle: any = {
     top: y,
     left: x,
-    marginTop: "-0.5em",
+    lineHeight,
+    marginTop: `-${lineHeight / 2}em`,
     position: "absolute",
     maxWidth: sequentialStagesLabelOffset,
     overflow: "hidden",
     textOverflow: "ellipsis",
     background: "var(--background, white)",
     padding: "0 3px",
-    lineHeight: "1",
     whiteSpace: "nowrap",
     outline: "1px solid var(--graph-connector-grey, gray)",
     borderRadius: "3px",

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/styles/main.scss
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/styles/main.scss
@@ -12,6 +12,8 @@
   }
 
   .PWGx-PipelineGraph {
+    --graph-connector-grey: #{$graph-connector-grey};
+
     margin-left: auto;
     margin-right: auto;
   }


### PR DESCRIPTION
# Status Quo

![screenshot-2024-04-21_19-20-10](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/50487108/123e4ccb-22c9-4495-b042-cdf4d864edea)


# Give branch labels an outline

Without an outline the contrast between the background and the label is much too low,
and IMO it looks much cleaner with an outline.

Outline instead of a border, because outlines don't take up space in the element.

![screenshot-2024-04-21_19-21-49](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/50487108/220c63e4-1e56-4b49-a2db-b622d63bc506)


# Reduce branch label padding

With only 70 pixels allocated for the label, using 14 pixels for padding is a bit much. 

![screenshot-2024-04-21_19-23-04](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/50487108/47de588a-a059-404f-9ce2-e2a6b534f996)


# Increase branch label height

Previously characters that went below the baseline were clipped.

![screenshot-2024-04-21_19-25-15](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/50487108/2786a039-d5fe-4b52-b126-7427ba6bc59b)


# Remove explicit use of the any type

Type system changes only.

---

### Testing done

- Tested in darkmode.
  ![screenshot-2024-04-21_19-27-50](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/50487108/30c056fc-5db2-4723-921a-e5f8edc2d49e)

- Tested with "Show pipeline graph on build page" (`/jenkins/manage/appearance/`) on.
  ![screenshot-2024-04-21_19-32-28](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/50487108/48eb6f23-4965-48db-bbd2-f6f5abb0629e)


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
