### PR TITLE
Fix display for ANSI colors

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -67,10 +67,14 @@
   padding-left: 16px;
 }
 
-.console-text div {
-  text-indent: 0;
+.console-text {
   padding-left: 15px;
   padding-right: 5px;
+}
+
+.console-text div {
+  text-indent: 0;
+  display: inline-block;
 }
 
 div.show-more-console {


### PR DESCRIPTION
In console view, shell lines containing ANSI color codes in the middle are currently not displayed properly.

Here is an example of a log that shows the issue:

![image](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/11692280/e7804236-9705-4efd-990a-dd4f6c19b98b)

This commit applies a tiny change to the CSS of the console view to fix this: 

![image](https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/11692280/3105e574-1d6e-40e0-aeb9-b612e86e1de1)
