### PR TITLE
Fix test flake preventing BOM release

### DIFF
--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/complexParallelSmokes.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/complexParallelSmokes.jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
         }
         stage('Skipped stage') {
             when {
-                branch 'master'
+                branch 'some-pattern'
             }
             steps {
                 echo 'This stage will be skipped.'


### PR DESCRIPTION
This test was flaky, as it passed locally and passed in https://github.com/jenkinsci/bom/pull/3137 but has failed twice on the main branch (e.g. https://ci.jenkins.io/job/Tools/job/bom/job/master/2712/testReport/) with

```
java.lang.AssertionError: 

Expected: is "Get contextual object from internal APIs"
     but: was "This stage will be skipped."
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at io.jenkins.plugins.pipelinegraphview.utils.PipelineStepApiLegacyTest.getAllStepsReturnsStepsForComplexParallelBranches(PipelineStepApiLegacyTest.java:217)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:656)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

Looking into this further, it seems that PCT builds on the main branch have defined `BRANCH_NAME=master` as an environment variable and this causes the test to fail. I could reproduce this locally with `export BRANCH_NAME=master`. The test seemed to be trying to get a stage to be skipped, but when running on `master` the stage wasn't skipped and the test started failing. By changing the test to not rely on `master` I could get the test to pass regardless of what that environment variable was defined to.

### Testing done

As described above