### PR TITLE
Fix classic console and View as plain text buttons missing in console view overflow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/pipeline-graph-view-plugin</gitHubRepo>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.440.1</jenkins.version>
+    <jenkins.version>2.450</jenkins.version>
     <node.version>20.12.2</node.version>
     <npm.version>10.7.0</npm.version>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:dd="/lib/layout/dropdowns">
     <l:layout title="${%Build log} [${it.buildDisplayName}]" type="one-column">
         <l:main-panel>
             <div class="jenkins-app-bar">
@@ -41,18 +41,12 @@
                         </a>
                     </l:hasPermission>
                     <l:overflowButton>
-                        <a class="jenkins-dropdown__item" href="../console">
-                            <div class="jenkins-dropdown__item__icon">
-                                <l:icon src="symbol-terminal" />
-                            </div>
-                            ${%View classic console}
-                        </a>
-                        <a class="jenkins-dropdown__item" href="../consoleText">
-                            <div class="jenkins-dropdown__item__icon">
-                                <l:icon src="symbol-document-text" />
-                            </div>
-                            ${%View as plain text}
-                        </a>
+                        <dd:item icon="symbol-terminal"
+                                 text="${%View classic console}"
+                                 href="../console" />
+                        <dd:item icon="symbol-document-text"
+                                 text="${%View as plain text}"
+                                 href="../consoleText" />
                     </l:overflowButton>
                 </div>
                 <script src="${rootURL}/plugin/pipeline-graph-view/js/build.js"/>


### PR DESCRIPTION
See https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/391

<img width="254" alt="image" src="https://github.com/jenkinsci/pipeline-graph-view-plugin/assets/43062514/893ff85d-c031-4868-8f71-eaa6e8c60180">

Jenkins 2.450 introduced a new way of implementing dropdowns which broke this plugin's dropdown. I've updated it to use the new components.

### Testing done

* Links work as expected

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
