### PR TITLE
Support parameterized builds in rebuild button

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.model.Action;
 import hudson.model.BallColor;
+import hudson.model.ParametersDefinitionProperty;
 import hudson.security.Permission;
 import hudson.util.HttpResponses;
 import java.util.concurrent.ExecutionException;
@@ -43,6 +44,11 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
 
     public String getBuildDisplayName() {
         return run.getDisplayName();
+    }
+
+    public boolean isParameterized() {
+        ParametersDefinitionProperty property = run.getParent().getProperty(ParametersDefinitionProperty.class);
+        return property != null && !property.getParameterDefinitions().isEmpty();
     }
 
     public String getFullBuildDisplayName() {

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewAction/index.jelly
@@ -27,7 +27,7 @@
           <j:if test="${it.buildable}">
             <l:hasPermission permission="${it.permission}">
               <button id="pgv-rebuild" data-success-message="${%Build scheduled}" data-build-path="../../build"
-                      class="jenkins-button jenkins-!-build-color">
+                      data-parameterized="${it.parameterized}" class="jenkins-button jenkins-!-build-color">
                 <l:icon src="symbol-play-outline plugin-ionicons-api"/>
                 ${%Rebuild}
               </button>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -25,7 +25,8 @@
                     <j:if test="${it.buildable}">
                         <l:hasPermission permission="${it.permission}">
                             <button id="pgv-rebuild" data-success-message="${%Build scheduled}"
-                                    data-build-path="../../build" class="jenkins-button jenkins-!-build-color">
+                                    data-build-path="../../build" data-parameterized="${it.parameterized}"
+                                    class="jenkins-button jenkins-!-build-color">
                                 <l:icon src="symbol-play-outline plugin-ionicons-api"/>
                                 ${%Rebuild}
                             </button>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction/index.jelly
@@ -8,7 +8,7 @@
         <j:if test="${it.buildable}">
           <l:hasPermission permission="${it.permission}">
             <button id="pgv-rebuild" data-success-message="${%Build scheduled}" data-build-path="../build"
-                    class="jenkins-button jenkins-!-build-color">
+                    data-parameterized="${it.parameterized}" class="jenkins-button jenkins-!-build-color">
               <l:icon src="symbol-play-outline plugin-ionicons-api"/>
               ${%Build}
             </button>

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -3,18 +3,23 @@ const rebuildButton = document.getElementById('pgv-rebuild');
 if (rebuildButton) {
   rebuildButton.addEventListener('click', event => {
     event.preventDefault();
-    fetch(`${rebuildButton.dataset.buildPath}?delay=0sec`, {
-      method: 'post',
-      headers: {
-        [document.head.dataset.crumbHeader]: document.head.dataset.crumbValue
-      }
-    })
-      .then(res => {
-        if (!res.ok) {
-          console.error('Build failed', res);
-        } else {
-          window.hoverNotification(rebuildButton.dataset.successMessage, rebuildButton);
+    const buildUrl = `${rebuildButton.dataset.buildPath}?delay=0sec`
+    if (rebuildButton.dataset.parameterized === 'true') {
+      window.location.href = buildUrl
+    } else {
+      fetch(buildUrl, {
+        method: 'post',
+        headers: {
+          [document.head.dataset.crumbHeader]: document.head.dataset.crumbValue
         }
       })
+        .then(res => {
+          if (!res.ok) {
+            console.error('Build failed', res);
+          } else {
+            window.hoverNotification(rebuildButton.dataset.successMessage, rebuildButton);
+          }
+        })
+    }
   })
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewRebuildTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewRebuildTest.java
@@ -1,0 +1,49 @@
+package io.jenkins.plugins.pipelinegraphview;
+
+import static org.junit.Assert.assertEquals;
+
+import hudson.model.Result;
+import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
+import org.htmlunit.html.HtmlPage;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class PipelineGraphViewRebuildTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Issue("GH#330")
+    @Test
+    public void rebuildButtonStartsNewBuild() throws Exception {
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "hello_world", "helloWorldScriptedPipeline.jenkinsfile", Result.SUCCESS);
+
+        try (JenkinsRule.WebClient webClient = j.createWebClient()) {
+            HtmlPage page = webClient.getPage(run, new PipelineGraphViewAction(run).getUrlName());
+            HtmlPage newPage = page.getElementById("pgv-rebuild").click();
+            assertEquals(page.getBaseURL(), newPage.getBaseURL());
+        }
+    }
+
+    @Issue("GH#330")
+    @Test
+    public void rebuildButtonRedirectsForParameterizedJob() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "echo_parameterized", "gh330_parameterizedBuild.jenkinsfile", Result.SUCCESS);
+
+        try (JenkinsRule.WebClient webClient = j.createWebClient()) {
+            // the build page is returned with a 405 Method Not Allowed status code, but the page
+            // exists and can be worked with; we should not fail on this status code
+            webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+
+            HtmlPage page = webClient.getPage(run, new PipelineGraphViewAction(run).getUrlName());
+            HtmlPage newPage = page.getElementById("pgv-rebuild").click();
+            assertEquals(
+                    j.getURL() + run.getParent().getUrl() + "build?delay=0sec",
+                    newPage.getBaseURL().toExternalForm());
+        }
+    }
+}

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh330_parameterizedBuild.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh330_parameterizedBuild.jenkinsfile
@@ -1,0 +1,13 @@
+pipeline {
+    agent any
+    parameters {
+        string(name: 'MESSAGE', defaultValue: 'Hello world!')
+    }
+    stages {
+        stage('Echo') {
+            steps {
+                echo params.MESSAGE
+            }
+        }
+    }
+}


### PR DESCRIPTION
Allow parameterized builds to be started in the rebuild button by redirecting the user to the build with parameters page so they can start a new build.

Fixes #330.

<!-- Please describe your pull request here. -->

### Testing done

* Manual testing on a local Jenkins environment
* Unit test confirming that rebuilds on jobs with or without parameters completes successfully
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
