### PR TITLE
Add link to agent a stage is running on to stage summary

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/StageNodeLink.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/StageNodeLink.tsx
@@ -4,9 +4,16 @@ export interface StageNodeLinkProps {
     agent: string;
 }
 
+function getAgentUrl(name: string) {
+    // Wrap built-in in brackets
+    const id = name == "built-in" ? "(built-in)" : name;
+    const rootPath = document.head.dataset.rootUrl
+    return `${rootPath}/computer/${id}/`;
+}
+
 const StageNodeLink = ({agent}: StageNodeLinkProps) => {
     const agentName = agent == "built-in" ? "Jenkins" : agent;
-    const href = `../../../../computer/${agent == "built-in" ? "(built-in)" : agent }/`;
+    const href = getAgentUrl(agent);
     return <>
         Running on <a href={href}>{agentName}</a>
     </>

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/StageNodeLink.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/StageNodeLink.tsx
@@ -7,7 +7,7 @@ export interface StageNodeLinkProps {
 function getAgentUrl(name: string) {
     // Wrap built-in in brackets
     const id = name == "built-in" ? "(built-in)" : name;
-    const rootPath = document.head.dataset.rootUrl
+    const rootPath = document.head.dataset.rooturl
     return `${rootPath}/computer/${id}/`;
 }
 

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/StageNodeLink.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/StageNodeLink.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export interface StageNodeLinkProps {
+    agent: string;
+}
+
+const StageNodeLink = ({agent}: StageNodeLinkProps) => {
+    const agentName = agent == "built-in" ? "Jenkins" : agent;
+    const href = `../../../../computer/${agent == "built-in" ? "(built-in)" : agent }/`;
+    return <>
+        Running on <a href={href}>{agentName}</a>
+    </>
+};
+
+export default StageNodeLink;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
@@ -81,6 +81,23 @@ const StageSummary = (props: StageSummaryProps) => (
           {props.stage.state}
         </span>
       </div>
+      <div
+        className="detail-element"
+        key={`stage-detail-agent-container-${props.stage.id}`}
+      >
+        <InfoIcon
+          className="detail-icon"
+          key={`stage-detail-agent-icon-${props.stage.id}`}
+        />
+        <span
+          className="capitalize"
+          key={`stage-detail-agent-text-${props.stage.id}`}
+        >
+          Running on <a href={`../../../../computer/${props.stage.agent == "built-in" ? "(built-in)" : props.stage.agent }/`}>
+            {props.stage.agent == "built-in" ? "Jenkins" : props.stage.agent }
+          </a>
+        </span>
+      </div>
       {props.failedSteps.map((value: StepInfo) => {
         console.debug(`Found failed step ${value}`);
         return (

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
@@ -6,7 +6,7 @@ import ScheduleIcon from "@mui/icons-material/Schedule";
 import TimerIcon from "@mui/icons-material/Timer";
 import InfoIcon from "@mui/icons-material/Info";
 import LinkIcon from "@mui/icons-material/Link";
-import ComputerIcon from '@mui/icons-material/Computer';
+import ComputerIcon from "@mui/icons-material/Computer";
 
 import {
   StepInfo,
@@ -83,21 +83,23 @@ const StageSummary = (props: StageSummaryProps) => (
           {props.stage.state}
         </span>
       </div>
-      <div
-        className="detail-element"
-        key={`stage-detail-agent-container-${props.stage.id}`}
-      >
-        <ComputerIcon
-          className="detail-icon"
-          key={`stage-detail-agent-icon-${props.stage.id}`}
-        />
-        <span
-          className="capitalize"
-          key={`stage-detail-agent-text-${props.stage.id}`}
+      {props.stage.agent && (
+        <div
+          className="detail-element"
+          key={`stage-detail-agent-container-${props.stage.id}`}
         >
-          <StageNodeLink agent={props.stage.agent}/>
-        </span>
-      </div>
+          <ComputerIcon
+            className="detail-icon"
+            key={`stage-detail-agent-icon-${props.stage.id}`}
+          />
+          <span
+            className="capitalize"
+            key={`stage-detail-agent-text-${props.stage.id}`}
+          >
+            <StageNodeLink agent={props.stage.agent} />
+          </span>
+        </div>
+      )}
       {props.failedSteps.map((value: StepInfo) => {
         console.debug(`Found failed step ${value}`);
         return (

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
@@ -93,7 +93,6 @@ const StageSummary = (props: StageSummaryProps) => (
             key={`stage-detail-agent-icon-${props.stage.id}`}
           />
           <span
-            className="capitalize"
             key={`stage-detail-agent-text-${props.stage.id}`}
           >
             <StageNodeLink agent={props.stage.agent} />

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
@@ -15,6 +15,7 @@ import {
   LOG_FETCH_SIZE,
 } from "./PipelineConsoleModel";
 import { ConsoleLogCard } from "./ConsoleLogCard";
+import StageNodeLink from "./StageNodeLink";
 
 export interface StageSummaryProps {
   stage: StageInfo;
@@ -94,9 +95,7 @@ const StageSummary = (props: StageSummaryProps) => (
           className="capitalize"
           key={`stage-detail-agent-text-${props.stage.id}`}
         >
-          Running on <a href={`../../../../computer/${props.stage.agent == "built-in" ? "(built-in)" : props.stage.agent }/`}>
-            {props.stage.agent == "built-in" ? "Jenkins" : props.stage.agent }
-          </a>
+          <StageNodeLink agent={props.stage.agent}/>
         </span>
       </div>
       {props.failedSteps.map((value: StepInfo) => {

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
@@ -6,6 +6,7 @@ import ScheduleIcon from "@mui/icons-material/Schedule";
 import TimerIcon from "@mui/icons-material/Timer";
 import InfoIcon from "@mui/icons-material/Info";
 import LinkIcon from "@mui/icons-material/Link";
+import ComputerIcon from '@mui/icons-material/Computer';
 
 import {
   StepInfo,
@@ -85,7 +86,7 @@ const StageSummary = (props: StageSummaryProps) => (
         className="detail-element"
         key={`stage-detail-agent-container-${props.stage.id}`}
       >
-        <InfoIcon
+        <ComputerIcon
           className="detail-icon"
           key={`stage-detail-agent-icon-${props.stage.id}`}
         />

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/TestData.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/TestData.tsx
@@ -1,5 +1,5 @@
 import { Result, StageType, StageInfo, StepInfo } from "./PipelineConsoleModel";
-export const defaultStagesList = [
+export const defaultStagesList: StageInfo[] = [
   {
     name: "Stage A",
     title: "",
@@ -11,6 +11,7 @@ export const defaultStagesList = [
     pauseDurationMillis: "",
     startTimeMillis: "",
     totalDurationMillis: "",
+    agent: "built-in",
   },
   {
     name: "Stage B",
@@ -23,6 +24,7 @@ export const defaultStagesList = [
     pauseDurationMillis: "",
     startTimeMillis: "",
     totalDurationMillis: "",
+    agent: "not-built-in",
   },
   {
     name: "Parent C",
@@ -43,11 +45,13 @@ export const defaultStagesList = [
         pauseDurationMillis: "",
         startTimeMillis: "",
         totalDurationMillis: "",
+        agent: "not-built-in",
       },
     ],
     pauseDurationMillis: "",
     startTimeMillis: "",
     totalDurationMillis: "",
+    agent: "built-in",
   },
 ];
 

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.spec.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.spec.ts
@@ -14,6 +14,7 @@ describe("PipelineGraphLayout", () => {
       pauseDurationMillis: "",
       startTimeMillis: "",
       totalDurationMillis: "",
+      agent: "built-in",
     };
 
     const makeStage = (

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
@@ -62,7 +62,7 @@ export interface StageInfo {
   pauseDurationMillis: string;
   startTimeMillis: string;
   totalDurationMillis: string;
-  agent?: string;
+  agent: string;
 }
 
 interface BaseNodeInfo {

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
@@ -62,6 +62,7 @@ export interface StageInfo {
   pauseDurationMillis: string;
   startTimeMillis: string;
   totalDurationMillis: string;
+  agent?: string;
 }
 
 interface BaseNodeInfo {

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
@@ -18,7 +18,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -245,8 +244,8 @@ public class PipelineGraphApi {
             WorkspaceAction ws = n.getAction(WorkspaceAction.class);
             if (ws != null) {
                 logger.debug("Found workspace node: {}", n);
-                if (n.getAllEnclosingIds().contains(flowNode.getId() ) ) {
-                    logger.debug("Found correct stage node: {}", n.getId() );
+                if (n.getAllEnclosingIds().contains(flowNode.getId())) {
+                    logger.debug("Found correct stage node: {}", n.getId());
                     String node = ws.getNode();
                     if (node.isEmpty()) {
                         node = "built-in";

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
@@ -240,8 +240,8 @@ public class PipelineGraphApi {
     private static String getStageNode(FlowNodeWrapper flowNodeWrapper) {
         FlowNode flowNode = flowNodeWrapper.getNode();
         DepthFirstScanner scan = new DepthFirstScanner();
+        logger.debug("Checking node {}", flowNode);
         for (FlowNode n : scan.allNodes(flowNode.getExecution())) {
-            logger.debug("Checking node {}", n);
             WorkspaceAction ws = n.getAction(WorkspaceAction.class);
             if (ws != null) {
                 logger.debug("Found workspace node: {}", n);
@@ -253,7 +253,6 @@ public class PipelineGraphApi {
                     }
                     return node;
                 }
-                break;
             }
         }
         return null;

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
@@ -60,17 +60,6 @@ public class PipelineGraphApi {
                     if (flowNodeWrapper.getStatus().getState() != BlueRun.BlueRunState.FINISHED) {
                         state = flowNodeWrapper.getStatus().getState().name().toLowerCase(Locale.ROOT);
                     }
-                    String agent = null;
-                    for (FlowNode enclosing : flowNodeWrapper.getNode().iterateEnclosingBlocks() ) {
-                        WorkspaceAction ws = enclosing.getAction(WorkspaceAction.class);
-                        if (ws != null) {
-                            agent = ws.getNode();
-                            if (agent.isEmpty()) {
-                                agent = "built-in";
-                            }
-                            break;
-                        }
-                    }
                     return new PipelineStageInternal(
                             flowNodeWrapper.getId(), // TODO no need to parse it BO returns a string even though the
                             // datatype is number on the frontend
@@ -84,7 +73,7 @@ public class PipelineGraphApi {
                             flowNodeWrapper.getDisplayName(), // TODO blue ocean uses timing information: "Passed in 0s"
                             flowNodeWrapper.isSynthetic(),
                             flowNodeWrapper.getTiming(),
-                            agent);
+                            getStageNode(flowNodeWrapper));
                 })
                 .collect(Collectors.toList());
     }
@@ -245,6 +234,21 @@ public class PipelineGraphApi {
             }
         }
         return ancestors;
+    }
+
+    private static String getStageNode(FlowNodeWrapper flowNodeWrapper) {
+        String node = null;
+        for (FlowNode enclosing : flowNodeWrapper.getNode().iterateEnclosingBlocks() ) {
+            WorkspaceAction ws = enclosing.getAction(WorkspaceAction.class);
+            if (ws != null) {
+                node = ws.getNode();
+                if (node.isEmpty()) {
+                    node = "built-in";
+                }
+                break;
+            }
+        }
+        return node;
     }
 
     public PipelineGraph createTree() {

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStage.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStage.java
@@ -10,6 +10,7 @@ public class PipelineStage extends AbstractPipelineNode {
     private final PipelineStage nextSibling;
     private boolean sequential;
     private boolean synthetic;
+    private String agent;
 
     public PipelineStage(
             String id,
@@ -23,13 +24,15 @@ public class PipelineStage extends AbstractPipelineNode {
             PipelineStage nextSibling,
             boolean sequential,
             boolean synthetic,
-            TimingInfo timingInfo) {
+            TimingInfo timingInfo,
+            String agent) {
         super(id, name, state, completePercent, type, title, timingInfo);
         this.children = children;
         this.seqContainerName = seqContainerName;
         this.nextSibling = nextSibling;
         this.sequential = sequential;
         this.synthetic = synthetic;
+        this.agent = agent;
     }
 
     public PipelineStage getNextSibling() {
@@ -52,5 +55,9 @@ public class PipelineStage extends AbstractPipelineNode {
 
     public boolean isSynthetic() {
         return synthetic;
+    }
+
+    public String getAgent() {
+        return agent;
     }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStageInternal.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStageInternal.java
@@ -19,6 +19,7 @@ public class PipelineStageInternal {
     private boolean sequential;
     private boolean synthetic;
     private TimingInfo timingInfo;
+    private String agent;
 
     public PipelineStageInternal(
             String id,
@@ -29,7 +30,8 @@ public class PipelineStageInternal {
             String type,
             String title,
             boolean synthetic,
-            TimingInfo times) {
+            TimingInfo times,
+            String agent) {
         this.id = id;
         this.name = name;
         this.parents = parents;
@@ -39,6 +41,7 @@ public class PipelineStageInternal {
         this.title = title;
         this.synthetic = synthetic;
         this.timingInfo = times;
+        this.agent = agent;
     }
 
     public boolean isSequential() {
@@ -121,6 +124,14 @@ public class PipelineStageInternal {
         this.synthetic = synthetic;
     }
 
+    public String getAgent() {
+        return agent;
+    }
+
+    public void setAgent(String aAgent) {
+        this.agent = aAgent;
+    }
+
     public PipelineStage toPipelineStage(List<PipelineStage> children) {
         return new PipelineStage(
                 id,
@@ -134,6 +145,7 @@ public class PipelineStageInternal {
                 nextSibling != null ? nextSibling.toPipelineStage(Collections.emptyList()) : null,
                 sequential,
                 synthetic,
-                timingInfo);
+                timingInfo,
+                agent);
     }
 }

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/parallelPipelineWithExternalAgent.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/parallelPipelineWithExternalAgent.jenkinsfile
@@ -1,0 +1,21 @@
+pipeline {
+    agent none
+    stages {
+        stage('Parallel') {
+            parallel {
+                stage('Builtin') {
+                    agent { label 'built-in' }
+                    steps {
+                        echo "Hello, from home"
+                    }
+                }
+                stage('External') {
+                    agent { label 'external' }
+                    steps {
+                        echo "Hello, from far away"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/singleStagePipeline.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/singleStagePipeline.jenkinsfile
@@ -1,0 +1,10 @@
+pipeline {
+    agent any
+    stages {
+        stage('Hello') {
+            steps {
+                echo "Hello, world"
+            }
+        }
+    }
+}

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/singleStagePipelineWithExternalAgent.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/singleStagePipelineWithExternalAgent.jenkinsfile
@@ -1,0 +1,11 @@
+pipeline {
+    agent any
+    stages {
+        stage('Hello') {
+            agent { label 'external' }
+            steps {
+                echo "Hello, world"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a line to the console view stage summary, showing which agent the stage is running on. 

Fixes #426 

### Testing done

Ran the plugin on a Jenkins instance with multi-stage pipelines, and so far everything seems to work.

![jenkins_pipeline_agent](https://github.com/user-attachments/assets/5c1d747c-8845-40a1-ad16-0a70b9762d1f)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
