### PR TITLE
Set `Content-Type` header for console logs

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -130,6 +130,7 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
 
             Writer writer;
             if (count > 0) {
+                rsp.setContentType("text/plain;charset=UTF-8");
                 writer = (count > 4096) ? rsp.getCompressedWriter(req) : rsp.getWriter();
                 spool.flush();
                 spool.writeTo(new LineEndNormalizingWriter(writer));


### PR DESCRIPTION
Fixes #520

As in https://github.com/jenkinsci/workflow-job-plugin/blob/38410d755a27ac1afa2ddff481d5fa318402f369/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java#L1132.

### Testing done

Before https://github.com/jenkinsci/jenkins/pull/9379 and before this fix, installed this plugin and verified that for < 4K the console log was not downloaded (correct) and for > 4K the console log was downloaded (incorrect).

After https://github.com/jenkinsci/jenkins/pull/9379 and before this fix, installed this plugin and verified that for both < 4K and > 4K the console log was downloaded (incorrect).

After https://github.com/jenkinsci/jenkins/pull/9379 and after this fix, installed this plugin and verified that the console log was never downloaded (correct).