### PR TITLE
Upgrade baseline to 2.479; migrate to EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.1</version>
     <relativePath />
   </parent>
 
@@ -33,7 +33,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/pipeline-graph-view-plugin</gitHubRepo>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.464</jenkins.version>
+    <jenkins.version>2.479</jenkins.version>
     <node.version>20.18.0</node.version>
     <npm.version>10.9.0</npm.version>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -16,8 +16,8 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.framework.io.CharSpool;
 import org.kohsuke.stapler.framework.io.LineEndNormalizingWriter;
@@ -68,7 +68,7 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
     // running).
     @GET
     @WebMethod(name = "steps")
-    public HttpResponse getSteps(StaplerRequest req) throws IOException {
+    public HttpResponse getSteps(StaplerRequest2 req) throws IOException {
         String nodeId = req.getParameter("nodeId");
         if (nodeId != null) {
             return HttpResponses.okJSON(getSteps(nodeId));
@@ -92,7 +92,7 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
     // - remove dependency of getting list of stages in frontend.
     @GET
     @WebMethod(name = "allSteps")
-    public HttpResponse getAllSteps(StaplerRequest req) throws IOException {
+    public HttpResponse getAllSteps(StaplerRequest2 req) throws IOException {
         return HttpResponses.okJSON(getAllSteps());
     }
 
@@ -107,7 +107,7 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
     }
 
     @WebMethod(name = "log")
-    public HttpResponse getConsoleText(StaplerRequest req, StaplerResponse rsp) throws IOException {
+    public HttpResponse getConsoleText(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
         String nodeId = req.getParameter("nodeId");
         if (nodeId == null) {
             logger.error("'consoleText' was not passed 'nodeId'.");
@@ -156,7 +156,7 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
      */
     @GET
     @WebMethod(name = "consoleOutput")
-    public HttpResponse getConsoleOutput(StaplerRequest req) throws IOException {
+    public HttpResponse getConsoleOutput(StaplerRequest2 req) throws IOException {
         String nodeId = req.getParameter("nodeId");
         if (nodeId == null) {
             logger.error("'consoleJson' was not passed 'nodeId'.");

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction.java
@@ -17,7 +17,7 @@ import org.jenkins.ui.icon.IconSpec;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.verb.GET;
 
@@ -53,7 +53,7 @@ public class MultiPipelineGraphViewAction implements Action, IconSpec {
 
     @GET
     @WebMethod(name = "tree")
-    public HttpResponse getTree(StaplerRequest req) throws JsonProcessingException {
+    public HttpResponse getTree(StaplerRequest2 req) throws JsonProcessingException {
         String runId = req.getParameter("runId");
         WorkflowRun run = target.getBuildByNumber(Integer.parseInt(runId));
         PipelineGraphApi api = new PipelineGraphApi(run);

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -15,7 +15,7 @@ import net.sf.json.JSONObject;
 import org.jenkins.ui.icon.IconSpec;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.WebMethod;
 
 public abstract class AbstractPipelineViewAction implements Action, IconSpec {
@@ -95,7 +95,7 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
     }
 
     @WebMethod(name = "replay")
-    public HttpResponse replayRun(StaplerRequest req) {
+    public HttpResponse replayRun(StaplerRequest2 req) {
 
         JSONObject result = new JSONObject();
 


### PR DESCRIPTION
This is not required for production use cases, but I saw that this plugin was close to a 2.479 baseline anyway, so why not migrate from the compatibility layer to pure EE 9. If we want to delay this baseline bump until later, I am fine with that as well. Or we could merge but not release this and let it get released whenever.