### PR TITLE
Fix invalid path concatenation when url has a segment

### DIFF
--- a/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/SingleRun.tsx
+++ b/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/SingleRun.tsx
@@ -13,7 +13,9 @@ export const SingleRun: (data: Props) => JSX.Element = ({ run }) => {
   const [stages, setStages] = useState<Array<StageInfo>>([]);
   let path = `tree?runId=${run.id}`;
 
-  const onJobView = !window.location.href.endsWith("multi-pipeline-graph/");
+  const url = new URL(window.location.href);
+
+  const onJobView = !url.pathname.endsWith("multi-pipeline-graph/");
   if (onJobView) {
     path = `multi-pipeline-graph/${path}`;
   }

--- a/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/support/startPollingRunsStatus.ts
+++ b/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/support/startPollingRunsStatus.ts
@@ -11,7 +11,9 @@ export default function startPollingRunsStatus(
 ) {
   let path = "runs";
 
-  if (!window.location.href.endsWith("multi-pipeline-graph/")) {
+  const url = new URL(window.location.href);
+
+  if (!url.pathname.endsWith("multi-pipeline-graph/")) {
     path = `multi-pipeline-graph/${path}`;
   }
 

--- a/src/main/frontend/pipeline-graph-view/app.tsx
+++ b/src/main/frontend/pipeline-graph-view/app.tsx
@@ -8,7 +8,8 @@ import "./pipeline-graph/styles/main.scss";
 
 function handleNodeClick(nodeName: string, id: number) {
   let location = `../pipeline-console?selected-node=${id}`;
-  if (!window.location.href.endsWith("pipeline-graph/")) {
+  const url = new URL(window.location.href);
+  if (!url.pathname.endsWith("pipeline-graph/")) {
     location = `pipeline-console?selected-node=${id}`;
   }
 

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
@@ -81,8 +81,10 @@ export class PipelineGraph extends React.Component {
   }
 
   getTreePath() {
-    if (!window.location.href.endsWith("pipeline-graph/")) {
-      return `pipeline-graph/tree`;
+    const url = new URL(window.location.href);
+
+    if (!url.pathname.endsWith("pipeline-graph/")) {
+      return "pipeline-graph/tree";
     }
 
     return "tree";


### PR DESCRIPTION
## Description
If the URL ends with a `#` symbol (e.g., `https://my-jenkins.com/job/job-name/job/branch/123/pipeline-graph/#`), the application mistakenly sends requests to a nested path, resulting in repeated requests to:
```
https://my-jenkins.com/job/job-name/job/branch/123/pipeline-graph/pipeline-graph/tree
```
These requests are triggered every 3 seconds and result 404 errors.

I was able to reproduce this issue in Safari browser, which adds `/#` in the end of the url after login redirect. 

## Steps to Reproduce:
1. Open a Jenkins job URL such as:
```
https://my-jenkins.com/job/job-name/job/branch/123/pipeline-graph/#
```
2. Now `/tree` requests are sent to `pipeline-graph/pipeline-graph/tree`.

How to reproduce in Safari with auth redirect:
1. Click logout in Jenkins
2. Open a Jenkins job URL `https://my-jenkins.com/job/job-name/job/branch/123/pipeline-graph`
3. Under the hood, the browser performs OAuth redirects (e.g., to Google and back)
4. When Jenkins opens, the URL ends with a /#
5. Lots of 404 in Network tab and empty graph screen

## Solution
Use `URL.pathname` instead of href to get path without query parameters and segments. I have fixed in `getTreePath` and other places.

### Testing done
![image](https://github.com/user-attachments/assets/a0940eab-28e8-4456-acca-9c52147d4eeb)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue