### PR TITLE
CONTRIBUTING.md: Fix mvn and java requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,16 +33,16 @@ If you are a newcomer contributor and have any questions, please do not hesitate
 
 Prerequisites: _Java_ and _Maven_.
 
-- Ensure Java 11 or 17 is available.
+- Ensure Java 17 or 21 is available.
 
   ```console	
-  $ java -version	
-  openjdk version "11.0.18" 2023-01-17
-  OpenJDK Runtime Environment Temurin-11.0.18+10 (build 11.0.18+10)
-  OpenJDK 64-Bit Server VM Temurin-11.0.18+10 (build 11.0.18+10, mixed mode)
+  $ java -version
+  openjdk 17.0.13 2024-10-15
+  OpenJDK Runtime Environment (build 17.0.13+11-Ubuntu-2ubuntu124.04)
+  OpenJDK 64-Bit Server VM (build 17.0.13+11-Ubuntu-2ubuntu124.04, mixed mode, sharing)
   ```	
 
-- Ensure Maven >= 3.8.1 is installed and included in the PATH environment variable.
+- Ensure Maven >= 3.9.9 is installed and included in the PATH environment variable.
 
   ```console
   $ mvn --version	


### PR DESCRIPTION
In order to build the product a newer version of maven is required otherwise an error is raised during the mvn hpi:run

mvn hpi:run
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs: [ERROR] Unknown packaging: hpi @ io.jenkins.plugins:pipeline-graph-view:${changelist}, /home/panicking/work/michael/pipeline-graph-view-plugin/pom.xml, line 14, column 14
 @
[ERROR] The build could not read 1 project -> [Help 1] [ERROR]
[ERROR]   The project io.jenkins.plugins:pipeline-graph-view:999999-SNAPSHOT (/home/panicking/work/michael/pipeline-graph-view-plugin/pom.xml) has 1 error
[ERROR]     Unknown packaging: hpi @ io.jenkins.plugins:pipeline-graph-view:${changelist}, /home/panicking/work/michael/pipeline-graph-view-plugin/pom.xml, line 14, column 14
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException

Adjust even the jave minimal requirement to java 17

