### PR TITLE
Fix isParameterized: Check the parameters used to build

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.model.Action;
 import hudson.model.BallColor;
+import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.security.Permission;
 import hudson.util.HttpResponses;
@@ -47,6 +48,11 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
     }
 
     public boolean isParameterized() {
+        ParametersAction paramAction = run.getAction(ParametersAction.class);
+        if (paramAction != null && !paramAction.getAllParameters().isEmpty()) {
+            return true;
+        }
+
         ParametersDefinitionProperty property = run.getParent().getProperty(ParametersDefinitionProperty.class);
         return property != null && !property.getParameterDefinitions().isEmpty();
     }


### PR DESCRIPTION
ParametersAction records the parameter values used for a build. This object is associated with the build record so that we remember what parameters were used for what build.

The code is able to detect job configured parameters but not the one that get used for the build. We need to check
for them and if it's the first build we need to fallback for the job one. This fix the detection on gerrit-trigger plugin.
This not fix the fact the rebuild does not work because we need to create a java function to reply the job with all
the old action ones.

### Testing done

Passsing the unit tests and deploy on premise with correct setup

![image](https://github.com/user-attachments/assets/eec9e8f0-923c-49a2-9fb2-334c494a2183)
