### PR TITLE
RFC: Add a way to get last queue number and pass the relative url

### DIFF
--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -6,7 +6,7 @@ if (rebuildButton) {
     const rebuildAction = window[`${rebuildButton.dataset.proxyName}`];
     rebuildAction.doRebuild(function (success) {
       const result = success.responseJSON;
-      if (result) {
+      if (result && result.success) {
         window.hoverNotification(rebuildButton.dataset.successMessage, rebuildButton);
       }
     });


### PR DESCRIPTION
This patch try understand to find a way to calculate the next job and then show a popup to the user include
it to let him to decide to switch to the queue build

It's important to evaluate it and propose change. Right now I have some limited idea how to create
nicer popup