### PR TITLE
Fix potential state mismatch in graph overview

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
@@ -162,8 +162,8 @@ export class PipelineGraph extends React.Component {
 
     let nodes = [];
     for (const column of nodeColumns) {
-      const topStageState = column.topStage?.state ?? Result.unknown; 
-    
+      const topStageState = column.topStage?.state ?? Result.unknown;
+
       for (const row of column.rows) {
         for (const node of row) {
           // If the topStage is still running but one of its child nodes has completed,
@@ -172,14 +172,14 @@ export class PipelineGraph extends React.Component {
           // This issue is reproducible in the complexSmokes test.
           if (
             column.topStage &&
-            'stage' in node &&
+            "stage" in node &&
             node.stage &&
             Array.isArray(column.topStage.children) &&
             column.topStage.children.includes(node.stage)
           ) {
             node.stage.state = topStageState;
           }
-    
+
           nodes.push(node);
         }
       }

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
@@ -175,7 +175,8 @@ export class PipelineGraph extends React.Component {
             "stage" in node &&
             node.stage &&
             Array.isArray(column.topStage.children) &&
-            column.topStage.children.includes(node.stage)
+            column.topStage.children.includes(node.stage) &&
+            this.props.collapsed
           ) {
             node.stage.state = topStageState;
           }


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/327

<!-- Please describe your pull request here. -->
This change fixes an issue where when a child stage completes, its status is incorrectly displayed on the parent stage in the graph overview.

This bug is particularly noticeable in the complexSmokes pipeline. While this approach seems reasonable given the available node data, it may not be the definitive solution. A second review would be helpful to confirm its correctness.

(In this before screen cap the state is that of `Branch A`, which is incorrect, we overwrite the state to that of `topStage`)
Before:
<img width="1029" alt="Screenshot 2025-02-17 at 7 50 36 PM" src="https://github.com/user-attachments/assets/56f6a2f5-f614-4c8d-bd97-9c07553d9390" />

After:
<img width="1078" alt="Screenshot 2025-02-17 at 7 50 58 PM" src="https://github.com/user-attachments/assets/d8a5a977-da34-478a-a304-c49b31dc9383" />

### Testing done
Ran this change through the tests nestedStages, skippedParallel, syntheticStages, and complexSmokes, noticed no adverse effects.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue


