### PR TITLE
Don't show empty table heading when no builds

### DIFF
--- a/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/MultiPipelineGraph.tsx
+++ b/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/MultiPipelineGraph.tsx
@@ -16,18 +16,22 @@ export const MultiPipelineGraph = () => {
     }
   }, [runs, poll]);
   return (
-    <table className="jenkins-table sortable">
-      <thead>
-        <tr>
-          <th className="jenkins-table__cell--tight">id</th>
-          <th data-sort-disable="true">pipeline</th>
-        </tr>
-      </thead>
-      <tbody>
-        {runs.map((run) => (
-          <SingleRun key={run.id} run={run} />
-        ))}
-      </tbody>
-    </table>
+    <>
+      {runs.length > 0 && (
+        <table className="jenkins-table sortable">
+          <thead>
+            <tr>
+              <th className="jenkins-table__cell--tight">id</th>
+              <th data-sort-disable="true">pipeline</th>
+            </tr>
+          </thead>
+          <tbody>
+            {runs.map((run) => (
+              <SingleRun key={run.id} run={run} />
+            ))}
+          </tbody>
+        </table>
+      )}
+    </>
   );
 };


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

Previously:
<img width="1081" alt="image" src="https://github.com/user-attachments/assets/9c395817-7fa2-4ff2-825c-a88741a5734d" />

Now:
<img width="421" alt="image" src="https://github.com/user-attachments/assets/6f6aa76f-ccfd-4987-949d-b196993b4df7" />

It will poll and the table will appear after the first build

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
