### PR TITLE
Use the result of a WarningAction set on a stage node instead of computing the chunk status

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
@@ -5,8 +5,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.plugins.pipelinegraphview.utils.BlueRun;
 import io.jenkins.plugins.pipelinegraphview.utils.NodeRunStatus;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineNodeUtil;
+import org.jenkinsci.plugins.workflow.actions.WarningAction;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.GenericStatus;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.StatusAndTiming;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.TimingInfo;
 import org.jenkinsci.plugins.workflow.support.actions.PauseAction;
@@ -108,6 +110,11 @@ public class NodeRelationship {
             return new NodeRunStatus(BlueRun.BlueRunResult.NOT_BUILT, BlueRun.BlueRunState.SKIPPED);
         } else if (PipelineNodeUtil.isPaused(this.end)) {
             return new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.PAUSED);
+        } else if (PipelineNodeUtil.isStage(start)) {
+            WarningAction warningAction = start.getPersistentAction(WarningAction.class);
+            if (warningAction != null) {
+                return new NodeRunStatus(GenericStatus.fromResult(warningAction.getResult()));
+            }
         }
         if (isDebugEnabled) {
             logger.debug(

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiLegacyTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiLegacyTest.java
@@ -149,4 +149,30 @@ class PipelineGraphApiLegacyTest {
                 (PipelineStage stage) -> String.format("{%s,%s}", stage.getName(), stage.getState()));
         assertThat(newStagesString, is(stagesString));
     }
+
+    @Issue("GH#616")
+    @Test
+    void createLegacyTree_stageResult(JenkinsRule j) throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(j, "gh616_stageResult", "gh_stageResult.jenkinsfile", Result.UNSTABLE, false);
+        PipelineGraphApi api = new PipelineGraphApi(run);
+        PipelineGraph graph = api.createLegacyTree();
+
+        List<PipelineStage> stages = graph.getStages();
+
+        String stagesString = TestUtils.collectStagesAsString(
+                stages,
+                (PipelineStage stage) -> String.format(
+                        "{%s,%s,%s,%s}",
+                        stage.getName(),
+                        stage.getTitle(),
+                        stage.getType(),
+                        stage.getState()));
+        assertThat(
+                stagesString,
+                is(String.join(
+                    "",
+                    "{success-stage,success-stage,STAGE,success},",
+                    "{failure-stage,failure-stage,STAGE,failure},",
+                    "{unstable-stage,unstable-stage,STAGE,unstable}")));
+    }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiLegacyTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiLegacyTest.java
@@ -153,7 +153,7 @@ class PipelineGraphApiLegacyTest {
     @Issue("GH#616")
     @Test
     void createLegacyTree_stageResult(JenkinsRule j) throws Exception {
-        WorkflowRun run = TestUtils.createAndRunJob(j, "gh616_stageResult", "gh_stageResult.jenkinsfile", Result.UNSTABLE, false);
+        WorkflowRun run = TestUtils.createAndRunJob(j, "gh616_stageResult", "gh616_stageResult.jenkinsfile", Result.UNSTABLE, false);
         PipelineGraphApi api = new PipelineGraphApi(run);
         PipelineGraph graph = api.createLegacyTree();
 

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiLegacyTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiLegacyTest.java
@@ -153,7 +153,8 @@ class PipelineGraphApiLegacyTest {
     @Issue("GH#616")
     @Test
     void createLegacyTree_stageResult(JenkinsRule j) throws Exception {
-        WorkflowRun run = TestUtils.createAndRunJob(j, "gh616_stageResult", "gh616_stageResult.jenkinsfile", Result.UNSTABLE, false);
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "gh616_stageResult", "gh616_stageResult.jenkinsfile", Result.UNSTABLE, false);
         PipelineGraphApi api = new PipelineGraphApi(run);
         PipelineGraph graph = api.createLegacyTree();
 
@@ -162,17 +163,13 @@ class PipelineGraphApiLegacyTest {
         String stagesString = TestUtils.collectStagesAsString(
                 stages,
                 (PipelineStage stage) -> String.format(
-                        "{%s,%s,%s,%s}",
-                        stage.getName(),
-                        stage.getTitle(),
-                        stage.getType(),
-                        stage.getState()));
+                        "{%s,%s,%s,%s}", stage.getName(), stage.getTitle(), stage.getType(), stage.getState()));
         assertThat(
                 stagesString,
                 is(String.join(
-                    "",
-                    "{success-stage,success-stage,STAGE,success},",
-                    "{failure-stage,failure-stage,STAGE,failure},",
-                    "{unstable-stage,unstable-stage,STAGE,unstable}")));
+                        "",
+                        "{success-stage,success-stage,STAGE,success},",
+                        "{failure-stage,failure-stage,STAGE,failure},",
+                        "{unstable-stage,unstable-stage,STAGE,unstable}")));
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
@@ -476,4 +476,26 @@ class PipelineGraphApiTest {
         assertThat(externalStage.getName(), equalTo("External"));
         assertThat(externalStage.getAgent(), equalTo(agent.getNodeName()));
     }
+
+    @Issue("GH#616")
+    @Test
+    void createTree_stageResult() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(j, "stageResult", "gh616_stageResult.jenkinsfile", Result.UNSTABLE, false);
+        PipelineGraphApi api = new PipelineGraphApi(run);
+        PipelineGraph graph = api.createTree();
+
+        List<PipelineStage> stages = graph.getStages();
+
+        String stagesString = TestUtils.collectStagesAsString(
+                stages,
+                (PipelineStage stage) -> String.format(
+                        "{%s,%s,%s,%s}", stage.getName(), stage.getTitle(), stage.getType(), stage.getState()));
+        assertThat(
+                stagesString,
+                equalTo(String.join(
+                        "",
+                        "{success-stage,success-stage,STAGE,success},",
+                        "{failure-stage,failure-stage,STAGE,failure},",
+                        "{unstable-stage,unstable-stage,STAGE,unstable}")));
+    }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
@@ -480,7 +480,8 @@ class PipelineGraphApiTest {
     @Issue("GH#616")
     @Test
     void createTree_stageResult() throws Exception {
-        WorkflowRun run = TestUtils.createAndRunJob(j, "stageResult", "gh616_stageResult.jenkinsfile", Result.UNSTABLE, false);
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "stageResult", "gh616_stageResult.jenkinsfile", Result.UNSTABLE, false);
         PipelineGraphApi api = new PipelineGraphApi(run);
         PipelineGraph graph = api.createTree();
 

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/TestUtils.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/TestUtils.java
@@ -25,24 +25,38 @@ public class TestUtils {
     private static final Logger LOGGER = Logger.getLogger(TestUtils.class.getName());
 
     public static WorkflowRun createAndRunJob(
-            JenkinsRule jenkins, String jobName, String jenkinsFileName, Result expectedResult) throws Exception {
-        WorkflowJob job = TestUtils.createJob(jenkins, jobName, jenkinsFileName);
+        JenkinsRule jenkins, String jobName, String jenkinsFileName, Result expectedResult) throws Exception {
+            return createAndRunJob(jenkins, jobName, jenkinsFileName, expectedResult, true);
+    }
+
+    public static WorkflowRun createAndRunJob(
+            JenkinsRule jenkins, String jobName, String jenkinsFileName, Result expectedResult, boolean sandbox) throws Exception {
+        WorkflowJob job = TestUtils.createJob(jenkins, jobName, jenkinsFileName, sandbox);
         jenkins.assertBuildStatus(expectedResult, job.scheduleBuild2(0));
         return job.getLastBuild();
     }
 
     public static QueueTaskFuture<WorkflowRun> createAndRunJobNoWait(
             JenkinsRule jenkins, String jobName, String jenkinsFileName) throws Exception {
-        WorkflowJob job = TestUtils.createJob(jenkins, jobName, jenkinsFileName);
+        return createAndRunJobNoWait(jenkins, jobName, jenkinsFileName, true);
+    }
+
+    public static QueueTaskFuture<WorkflowRun> createAndRunJobNoWait(
+            JenkinsRule jenkins, String jobName, String jenkinsFileName, boolean sandbox) throws Exception {
+        WorkflowJob job = TestUtils.createJob(jenkins, jobName, jenkinsFileName, sandbox);
         return job.scheduleBuild2(0);
     }
 
     public static WorkflowJob createJob(JenkinsRule jenkins, String jobName, String jenkinsFileName) throws Exception {
+        return createJob(jenkins, jobName, jenkinsFileName, true);
+    }
+
+    public static WorkflowJob createJob(JenkinsRule jenkins, String jobName, String jenkinsFileName, boolean sandbox) throws Exception {
         WorkflowJob job = jenkins.createProject(WorkflowJob.class, jobName);
 
         URL resource = Resources.getResource(TestUtils.class, jenkinsFileName);
         String jenkinsFile = Resources.toString(resource, Charsets.UTF_8);
-        job.setDefinition(new CpsFlowDefinition(jenkinsFile, true));
+        job.setDefinition(new CpsFlowDefinition(jenkinsFile, sandbox));
         return job;
     }
 

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/TestUtils.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/TestUtils.java
@@ -25,12 +25,13 @@ public class TestUtils {
     private static final Logger LOGGER = Logger.getLogger(TestUtils.class.getName());
 
     public static WorkflowRun createAndRunJob(
-        JenkinsRule jenkins, String jobName, String jenkinsFileName, Result expectedResult) throws Exception {
-            return createAndRunJob(jenkins, jobName, jenkinsFileName, expectedResult, true);
+            JenkinsRule jenkins, String jobName, String jenkinsFileName, Result expectedResult) throws Exception {
+        return createAndRunJob(jenkins, jobName, jenkinsFileName, expectedResult, true);
     }
 
     public static WorkflowRun createAndRunJob(
-            JenkinsRule jenkins, String jobName, String jenkinsFileName, Result expectedResult, boolean sandbox) throws Exception {
+            JenkinsRule jenkins, String jobName, String jenkinsFileName, Result expectedResult, boolean sandbox)
+            throws Exception {
         WorkflowJob job = TestUtils.createJob(jenkins, jobName, jenkinsFileName, sandbox);
         jenkins.assertBuildStatus(expectedResult, job.scheduleBuild2(0));
         return job.getLastBuild();
@@ -51,7 +52,8 @@ public class TestUtils {
         return createJob(jenkins, jobName, jenkinsFileName, true);
     }
 
-    public static WorkflowJob createJob(JenkinsRule jenkins, String jobName, String jenkinsFileName, boolean sandbox) throws Exception {
+    public static WorkflowJob createJob(JenkinsRule jenkins, String jobName, String jenkinsFileName, boolean sandbox)
+            throws Exception {
         WorkflowJob job = jenkins.createProject(WorkflowJob.class, jobName);
 
         URL resource = Resources.getResource(TestUtils.class, jenkinsFileName);

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh616_stageResult.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh616_stageResult.jenkinsfile
@@ -1,0 +1,26 @@
+import hudson.model.Result
+import io.jenkins.plugins.pipelinegraphview.utils.PipelineNodeUtil
+import org.jenkinsci.plugins.workflow.actions.WarningAction
+import org.jenkinsci.plugins.workflow.graph.FlowNode
+
+void setStageResult(Result result) {
+    FlowNode stageNode = getContext(FlowNode.class).getEnclosingBlocks().find { PipelineNodeUtil.isStage(it) }
+    if (stageNode) {
+        stageNode.addOrReplaceAction(new WarningAction(result));
+    }
+}
+
+stage("success-stage") {
+    unstable("unstable-step")
+    setStageResult(Result.SUCCESS)
+}
+
+stage("failure-stage") {
+    echo("foo")
+    setStageResult(Result.FAILURE)
+}
+
+stage("unstable-stage") {
+    echo("foo")
+    setStageResult(Result.UNSTABLE)
+}


### PR DESCRIPTION
Fix for #616. Add logic to use the result of a `WarningAction` set on a stage node instead of computing the chunk status.

### Testing done

Added new tests to validate that the stage node status reflects the result of any `WarningAction` set on the node.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
