### PR TITLE
Update stage buttons to be links

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
@@ -53,8 +53,17 @@ function TreeNode({ stage, selected, onSelect }: TreeNodeProps) {
   return (
     <div className="task">
       <div className="pgv-tree-node-header">
-        <button
+        <a
+          href={`?selected-node=` + stage.id}
           onClick={(e) => {
+            // Only prevent left clicks
+            if (e.button !== 0 || e.metaKey || e.ctrlKey) {
+              return;
+            }
+
+            e.preventDefault();
+
+            history.replaceState({}, "", `?selected-node=` + stage.id);
             if (!isSelected) {
               onSelect(e, String(stage.id));
             }
@@ -78,7 +87,7 @@ function TreeNode({ stage, selected, onSelect }: TreeNodeProps) {
               </span>
             )}
           </div>
-        </button>
+        </a>
 
         {hasChildren && (
           <button


### PR DESCRIPTION
Small PR to change the stage buttons on the left to links.

<img width="371" alt="image" src="https://github.com/user-attachments/assets/94196f8e-5924-49af-9bec-725a612d9758" />

This gives several advantages:
* Allow for users to open stages in new tabs/windows if they desire
* CMD+Click/middle click works
* We also replace the URL in the title now so that on page refresh it goes to the expected stage

Let me know your thoughts.

### Testing done

* Links behave as expected
* History is replaced

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
