### PR TITLE
Fix some elements shrinking when they shouldn't

### DIFF
--- a/src/main/frontend/common/components/status-icon.scss
+++ b/src/main/frontend/common/components/status-icon.scss
@@ -1,4 +1,6 @@
 .pgv-status-icon {
+  flex-shrink: 0;
+
   * {
     transition: var(--elastic-transition);
     transform-origin: center;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/console-log-card.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/console-log-card.scss
@@ -25,6 +25,7 @@
     grid-template-columns: 1fr auto;
     align-items: center;
     justify-content: stretch;
+    gap: 1rem;
     text-decoration: none;
     color: var(--text-color);
     min-height: 38px;
@@ -63,6 +64,10 @@
     max-width: 80%;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    &:empty {
+      display: none;
+    }
   }
 
   .pgv-step-detail-header__chevron {
@@ -70,6 +75,7 @@
     width: 1rem;
     height: 1rem;
     margin-inline: -0.25rem;
+    flex-shrink: 0;
   }
 
   & > svg:first-of-type {

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.scss
@@ -88,6 +88,7 @@
       svg {
         width: 1.125rem;
         height: 1.125rem;
+        flex-shrink: 0;
 
         * {
           stroke-width: 36px;


### PR DESCRIPTION
Discovered on https://ci.jenkins.io/job/Plugins/job/git-plugin/job/master/1496/pipeline-console/?selected-node=121

<img width="669" alt="image" src="https://github.com/user-attachments/assets/9ad853ca-f5aa-46cd-8e7e-a249da0bcd3c" />

<img width="81" alt="image" src="https://github.com/user-attachments/assets/b01bd3d1-011b-43e8-b4d3-6e3613782dac" />

<img width="553" alt="image" src="https://github.com/user-attachments/assets/a8f26299-a14a-4d06-a7b7-a2f9730e02f2" />

When text is too long it causes the icons to shrink unintentionally. There's also an issue where a steps title is empty, causing a large gap when there shouldn't be one.

### Testing done

* Icons no longer shrink
* Gaps are fixed

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
