### PR TITLE
Fix order of names in steps

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
@@ -84,18 +84,10 @@ export default function ConsoleLogCard(props: ConsoleLogCardProps) {
               status={props.step.state}
               percentage={props.step.completePercent}
             />
-            <span style={{ fontWeight: "450" }}>{props.step.title || props.step.name}</span>
 
-            {props.step.title !== '' && (
-              <span
-                style={{
-                  color: "var(--text-color-secondary)",
-                  fontFamily: "var(--font-family-mono)",
-                }}
-              >
-              {props.step.name}
-            </span>
-            )}
+            {props.step.title !== "" && <span>{props.step.title}</span>}
+
+            {props.step.name !== "" && <span>{props.step.name}</span>}
 
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
@@ -84,15 +84,18 @@ export default function ConsoleLogCard(props: ConsoleLogCardProps) {
               status={props.step.state}
               percentage={props.step.completePercent}
             />
-            <span style={{ fontWeight: "450" }}>{props.step.name}</span>
-            <span
-              style={{
-                color: "var(--text-color-secondary)",
-                fontFamily: "var(--font-family-mono)",
-              }}
-            >
-              {props.step.title}
+            <span style={{ fontWeight: "450" }}>{props.step.title || props.step.name}</span>
+
+            {props.step.title !== '' && (
+              <span
+                style={{
+                  color: "var(--text-color-secondary)",
+                  fontFamily: "var(--font-family-mono)",
+                }}
+              >
+              {props.step.name}
             </span>
+            )}
 
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/console-log-card.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/console-log-card.scss
@@ -64,9 +64,13 @@
     max-width: 80%;
     overflow: hidden;
     text-overflow: ellipsis;
+    color: var(--text-color-secondary);
+    font-family: var(--font-family-mono);
 
-    &:empty {
-      display: none;
+    &:first-of-type {
+      color: var(--text-color);
+      font-weight: var(--font-bold-weight);
+      font-family: var(--font-family-sans);
     }
   }
 

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
@@ -45,13 +45,17 @@ public class PipelineStepApi {
                     displayName = cleanTextContent(displayName);
                     logger.debug("DisplayName After: '" + displayName + "'.");
 
+                    // Ignore certain titles
+                    if (title.equals("Shell Script") || title.equals("Print Message")) {
+                        title = "";
+                    }
+
                     return new PipelineStep(
                             flowNodeWrapper.getId(),
                             displayName,
                             PipelineState.of(flowNodeWrapper.getStatus()),
                             flowNodeWrapper.getType().name(),
-                            title, // TODO blue ocean uses timing information: "Passed in
-                            // 0s"
+                            title,
                             stageId,
                             flowNodeWrapper.getTiming());
                 })

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
@@ -46,8 +46,10 @@ public class PipelineStepApi {
                     logger.debug("DisplayName After: '" + displayName + "'.");
 
                     // Ignore certain titles
-                    if (title.equals("Shell Script") || title.equals("Print Message")) {
-                        title = "";
+                    if (!displayName.isBlank()) {
+                        if (title.equals("Shell Script") || title.equals("Print Message")) {
+                            title = "";
+                        }
                     }
 
                     return new PipelineStep(

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiLegacyTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiLegacyTest.java
@@ -32,16 +32,16 @@ class PipelineStepApiLegacyTest {
         List<PipelineStep> steps = api.getLegacySteps(unstableOneId).getSteps();
         assertThat(steps, hasSize(3));
         assertThat(steps.get(0).getName(), is("foo"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("oops-one"));
         assertThat(steps.get(1).getTitle(), is("Set stage result to unstable"));
         assertThat(steps.get(2).getName(), is("bar"));
-        assertThat(steps.get(2).getTitle(), is("Print Message"));
+        assertThat(steps.get(2).getTitle(), is(""));
 
         steps = api.getSteps(successId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("baz"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         steps = api.getSteps(unstableTwoId).getSteps();
         assertThat(steps, hasSize(2));
@@ -87,7 +87,7 @@ class PipelineStepApiLegacyTest {
         List<PipelineStep> steps = api.getLegacySteps(nonParallelId).getSteps();
         assertThat(steps, hasSize(2));
         assertThat(steps.get(0).getName(), is("This stage will be executed first."));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("Print Message"));
         assertThat(steps.get(1).getTitle(), is(""));
 
@@ -95,17 +95,17 @@ class PipelineStepApiLegacyTest {
         steps = api.getSteps(branchAId).getSteps();
         assertThat(steps, hasSize(2));
         assertThat(steps.get(0).getName(), is("On Branch A - 1"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("On Branch A - 2"));
-        assertThat(steps.get(1).getTitle(), is("Print Message"));
+        assertThat(steps.get(1).getTitle(), is(""));
 
         // Check 'Branch B'
         steps = api.getSteps(branchBId).getSteps();
         assertThat(steps, hasSize(2));
         assertThat(steps.get(0).getName(), is("On Branch B - 1"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("On Branch B - 2"));
-        assertThat(steps.get(1).getTitle(), is("Print Message"));
+        assertThat(steps.get(1).getTitle(), is(""));
 
         // Check 'Branch C'
         steps = api.getSteps(branchCId).getSteps();
@@ -115,17 +115,17 @@ class PipelineStepApiLegacyTest {
         steps = api.getSteps(branchNested1Id).getSteps();
         assertThat(steps, hasSize(2));
         assertThat(steps.get(0).getName(), is("In stage Nested 1 - 1 within Branch C"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("In stage Nested 1 - 2 within Branch C"));
-        assertThat(steps.get(1).getTitle(), is("Print Message"));
+        assertThat(steps.get(1).getTitle(), is(""));
 
         // Check 'Nested 2'
         steps = api.getSteps(branchNested2Id).getSteps();
         assertThat(steps, hasSize(2));
         assertThat(steps.get(0).getName(), is("In stage Nested 2 - 1 within Branch C"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("In stage Nested 2 - 2 within Branch C"));
-        assertThat(steps.get(1).getTitle(), is("Print Message"));
+        assertThat(steps.get(1).getTitle(), is(""));
     }
 
     @Test
@@ -152,7 +152,7 @@ class PipelineStepApiLegacyTest {
         List<PipelineStep> steps = api.getSteps(childAId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("In child A"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         // Check 'Child A'
         steps = api.getSteps(childBId).getSteps();
@@ -162,7 +162,7 @@ class PipelineStepApiLegacyTest {
         steps = api.getSteps(grandchildBId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("In grandchild B"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         // Check 'Child C'
         steps = api.getSteps(childCId).getSteps();
@@ -176,7 +176,7 @@ class PipelineStepApiLegacyTest {
         steps = api.getSteps(greatGrandchildCId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("In great-grandchild C"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
     }
 
     @Test
@@ -193,26 +193,26 @@ class PipelineStepApiLegacyTest {
         List<PipelineStep> steps = api.getAllSteps().getSteps();
         assertThat(steps, hasSize(11));
         assertThat(steps.get(0).getName(), is("This stage will be executed first."));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("Print Message"));
         assertThat(steps.get(1).getTitle(), is(""));
         assertThat(steps.get(2).getName(), is("On Branch A - 1"));
-        assertThat(steps.get(2).getTitle(), is("Print Message"));
+        assertThat(steps.get(2).getTitle(), is(""));
         assertThat(steps.get(3).getName(), is("On Branch A - 2"));
-        assertThat(steps.get(3).getTitle(), is("Print Message"));
+        assertThat(steps.get(3).getTitle(), is(""));
         assertThat(steps.get(4).getName(), is("On Branch B - 1"));
-        assertThat(steps.get(4).getTitle(), is("Print Message"));
+        assertThat(steps.get(4).getTitle(), is(""));
         assertThat(steps.get(5).getName(), is("On Branch B - 2"));
-        assertThat(steps.get(5).getTitle(), is("Print Message"));
+        assertThat(steps.get(5).getTitle(), is(""));
 
         assertThat(steps.get(6).getName(), is("In stage Nested 1 - 1 within Branch C"));
-        assertThat(steps.get(6).getTitle(), is("Print Message"));
+        assertThat(steps.get(6).getTitle(), is(""));
         assertThat(steps.get(7).getName(), is("In stage Nested 1 - 2 within Branch C"));
-        assertThat(steps.get(7).getTitle(), is("Print Message"));
+        assertThat(steps.get(7).getTitle(), is(""));
         assertThat(steps.get(8).getName(), is("In stage Nested 2 - 1 within Branch C"));
-        assertThat(steps.get(8).getTitle(), is("Print Message"));
+        assertThat(steps.get(8).getTitle(), is(""));
         assertThat(steps.get(9).getName(), is("In stage Nested 2 - 2 within Branch C"));
-        assertThat(steps.get(9).getTitle(), is("Print Message"));
+        assertThat(steps.get(9).getTitle(), is(""));
         assertThat(steps.get(10).getName(), is("Get contextual object from internal APIs"));
         assertThat(steps.get(10).getTitle(), is(""));
     }
@@ -229,11 +229,11 @@ class PipelineStepApiLegacyTest {
         List<PipelineStep> steps = api.getAllSteps().getSteps();
         assertThat(steps, hasSize(3));
         assertThat(steps.get(0).getName(), is("In child A"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("In grandchild B"));
-        assertThat(steps.get(1).getTitle(), is("Print Message"));
+        assertThat(steps.get(1).getTitle(), is(""));
         assertThat(steps.get(2).getName(), is("In great-grandchild C"));
-        assertThat(steps.get(2).getTitle(), is("Print Message"));
+        assertThat(steps.get(2).getTitle(), is(""));
     }
 
     @Issue("GH#92")
@@ -271,37 +271,37 @@ class PipelineStepApiLegacyTest {
         List<PipelineStep> steps = api.getLegacySteps(linux8CheckoutId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("Checking out linux-8"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         steps = api.getSteps(linux8BuildId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("Building linux-8"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         steps = api.getSteps(linux8ArchiveId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("Archiving linux-8"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         steps = api.getSteps(linux11CheckoutId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("Checking out linux-11"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         steps = api.getSteps(linux11BuildId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("Building linux-11"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         steps = api.getSteps(linux11ArchiveId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("Archiving linux-11"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         steps = api.getSteps(deployStageId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("Deploying..."));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
     }
 
     @Issue("GH#213")

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
@@ -72,16 +72,16 @@ class PipelineStepApiTest {
         List<PipelineStep> steps = api.getSteps(unstableOneId).getSteps();
         assertThat(steps, hasSize(3));
         assertThat(steps.get(0).getName(), is("foo"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("oops-one"));
         assertThat(steps.get(1).getTitle(), is("Set stage result to unstable"));
         assertThat(steps.get(2).getName(), is("bar"));
-        assertThat(steps.get(2).getTitle(), is("Print Message"));
+        assertThat(steps.get(2).getTitle(), is(""));
 
         steps = api.getSteps(successId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("baz"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         steps = api.getSteps(unstableTwoId).getSteps();
         assertThat(steps, hasSize(2));
@@ -127,7 +127,7 @@ class PipelineStepApiTest {
         List<PipelineStep> steps = api.getSteps(nonParallelId).getSteps();
         assertThat(steps, hasSize(2));
         assertThat(steps.get(0).getName(), is("This stage will be executed first."));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("Print Message"));
         assertThat(steps.get(1).getTitle(), is(""));
 
@@ -135,17 +135,17 @@ class PipelineStepApiTest {
         steps = api.getSteps(branchAId).getSteps();
         assertThat(steps, hasSize(2));
         assertThat(steps.get(0).getName(), is("On Branch A - 1"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("On Branch A - 2"));
-        assertThat(steps.get(1).getTitle(), is("Print Message"));
+        assertThat(steps.get(1).getTitle(), is(""));
 
         // Check 'Branch B'
         steps = api.getSteps(branchBId).getSteps();
         assertThat(steps, hasSize(2));
         assertThat(steps.get(0).getName(), is("On Branch B - 1"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("On Branch B - 2"));
-        assertThat(steps.get(1).getTitle(), is("Print Message"));
+        assertThat(steps.get(1).getTitle(), is(""));
 
         // Check 'Branch C'
         steps = api.getSteps(branchCId).getSteps();
@@ -155,17 +155,17 @@ class PipelineStepApiTest {
         steps = api.getSteps(branchNested1Id).getSteps();
         assertThat(steps, hasSize(2));
         assertThat(steps.get(0).getName(), is("In stage Nested 1 - 1 within Branch C"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("In stage Nested 1 - 2 within Branch C"));
-        assertThat(steps.get(1).getTitle(), is("Print Message"));
+        assertThat(steps.get(1).getTitle(), is(""));
 
         // Check 'Nested 2'
         steps = api.getSteps(branchNested2Id).getSteps();
         assertThat(steps, hasSize(2));
         assertThat(steps.get(0).getName(), is("In stage Nested 2 - 1 within Branch C"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("In stage Nested 2 - 2 within Branch C"));
-        assertThat(steps.get(1).getTitle(), is("Print Message"));
+        assertThat(steps.get(1).getTitle(), is(""));
     }
 
     @Test
@@ -192,7 +192,7 @@ class PipelineStepApiTest {
         List<PipelineStep> steps = api.getSteps(childAId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("In child A"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         // Check 'Child A'
         steps = api.getSteps(childBId).getSteps();
@@ -202,7 +202,7 @@ class PipelineStepApiTest {
         steps = api.getSteps(grandchildBId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("In grandchild B"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         // Check 'Child C'
         steps = api.getSteps(childCId).getSteps();
@@ -216,7 +216,7 @@ class PipelineStepApiTest {
         steps = api.getSteps(greatGrandchildCId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("In great-grandchild C"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
     }
 
     @Test
@@ -233,26 +233,26 @@ class PipelineStepApiTest {
         List<PipelineStep> steps = api.getAllSteps().getSteps();
         assertThat(steps, hasSize(11));
         assertThat(steps.get(0).getName(), is("This stage will be executed first."));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("Print Message"));
         assertThat(steps.get(1).getTitle(), is(""));
         assertThat(steps.get(2).getName(), is("On Branch A - 1"));
-        assertThat(steps.get(2).getTitle(), is("Print Message"));
+        assertThat(steps.get(2).getTitle(), is(""));
         assertThat(steps.get(3).getName(), is("On Branch A - 2"));
-        assertThat(steps.get(3).getTitle(), is("Print Message"));
+        assertThat(steps.get(3).getTitle(), is(""));
         assertThat(steps.get(4).getName(), is("On Branch B - 1"));
-        assertThat(steps.get(4).getTitle(), is("Print Message"));
+        assertThat(steps.get(4).getTitle(), is(""));
         assertThat(steps.get(5).getName(), is("On Branch B - 2"));
-        assertThat(steps.get(5).getTitle(), is("Print Message"));
+        assertThat(steps.get(5).getTitle(), is(""));
 
         assertThat(steps.get(6).getName(), is("In stage Nested 1 - 1 within Branch C"));
-        assertThat(steps.get(6).getTitle(), is("Print Message"));
+        assertThat(steps.get(6).getTitle(), is(""));
         assertThat(steps.get(7).getName(), is("In stage Nested 1 - 2 within Branch C"));
-        assertThat(steps.get(7).getTitle(), is("Print Message"));
+        assertThat(steps.get(7).getTitle(), is(""));
         assertThat(steps.get(8).getName(), is("In stage Nested 2 - 1 within Branch C"));
-        assertThat(steps.get(8).getTitle(), is("Print Message"));
+        assertThat(steps.get(8).getTitle(), is(""));
         assertThat(steps.get(9).getName(), is("In stage Nested 2 - 2 within Branch C"));
-        assertThat(steps.get(9).getTitle(), is("Print Message"));
+        assertThat(steps.get(9).getTitle(), is(""));
         assertThat(steps.get(10).getName(), is("Get contextual object from internal APIs"));
         assertThat(steps.get(10).getTitle(), is(""));
     }
@@ -269,11 +269,11 @@ class PipelineStepApiTest {
         List<PipelineStep> steps = api.getAllSteps().getSteps();
         assertThat(steps, hasSize(3));
         assertThat(steps.get(0).getName(), is("In child A"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
         assertThat(steps.get(1).getName(), is("In grandchild B"));
-        assertThat(steps.get(1).getTitle(), is("Print Message"));
+        assertThat(steps.get(1).getTitle(), is(""));
         assertThat(steps.get(2).getName(), is("In great-grandchild C"));
-        assertThat(steps.get(2).getTitle(), is("Print Message"));
+        assertThat(steps.get(2).getTitle(), is(""));
     }
 
     @Issue("GH#92")
@@ -311,37 +311,37 @@ class PipelineStepApiTest {
         List<PipelineStep> steps = api.getSteps(linux8CheckoutId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("Checking out linux-8"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         steps = api.getSteps(linux8BuildId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("Building linux-8"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         steps = api.getSteps(linux8ArchiveId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("Archiving linux-8"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         steps = api.getSteps(linux11CheckoutId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("Checking out linux-11"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         steps = api.getSteps(linux11BuildId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("Building linux-11"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         steps = api.getSteps(linux11ArchiveId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("Archiving linux-11"));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
 
         steps = api.getSteps(deployStageId).getSteps();
         assertThat(steps, hasSize(1));
         assertThat(steps.get(0).getName(), is("Deploying..."));
-        assertThat(steps.get(0).getTitle(), is("Print Message"));
+        assertThat(steps.get(0).getTitle(), is(""));
     }
 
     @Issue("GH#213")


### PR DESCRIPTION
Small PR to correct the order of names in steps in the console view. Hides 'Print Message' and 'Shell Script' from being visible.

**Before**
![image](https://github.com/user-attachments/assets/4807b182-a845-4d20-a961-429d69b972e9)

**After**
![image](https://github.com/user-attachments/assets/77e88523-89b4-40cc-a22f-bed0b18f5db5)

### Testing done

* Works as expected

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
