### PR TITLE
Do not create skeleton when the run is complete

### DIFF
--- a/src/main/frontend/common/tree-api.ts
+++ b/src/main/frontend/common/tree-api.ts
@@ -1,8 +1,12 @@
 import { useEffect, useState } from "react";
-import { getRunStatusFromPath } from "./RestClient";
-import { StageInfo } from "../pipeline-graph-view/pipeline-graph/main";
+import { getRunStatusFromPath, RunStatus } from "./RestClient";
 import startPollingPipelineStatus from "../pipeline-graph-view/pipeline-graph/main/support/startPollingPipelineStatus";
 import { mergeStageInfos } from "./utils/stage-merge";
+
+const onPipelineComplete = () => undefined;
+
+const onPollingError = (err: Error) =>
+  console.log("There was an error when polling the pipeline status", err);
 
 /**
  * Polls a run, stopping once the run has completed
@@ -12,72 +16,45 @@ export default function useRunPoller({
   currentRunPath,
   previousRunPath,
 }: RunPollerProps) {
-  const [run, setRun] = useState<Run>();
+  const [run, setRun] = useState<RunStatus>();
 
   useEffect(() => {
-    const onPipelineComplete = () => undefined;
-
+    let onPipelineDataReceived: (data: RunStatus) => void;
     if (previousRunPath) {
-      getRunStatusFromPath(previousRunPath).then((r) => {
-        // This should be a Result - not 'complete'
-        const onPipelineDataReceived = (data: {
-          stages: StageInfo[];
-          complete: boolean;
-        }) => {
-          setRun({
-            stages: data.complete
-              ? data.stages
-              : mergeStageInfos(r!.stages, data.stages),
-            complete: data.complete,
-          });
-        };
-
-        const onPollingError = (err: Error) => {
-          console.log(
-            "There was an error when polling the pipeline status",
-            err,
-          );
-        };
-
-        startPollingPipelineStatus(
-          onPipelineDataReceived,
-          onPollingError,
-          onPipelineComplete,
-          currentRunPath,
-        );
-      });
+      let previousRun: RunStatus | null = null;
+      onPipelineDataReceived = async (current: RunStatus) => {
+        if (current.complete) {
+          setRun(current);
+        } else {
+          if (previousRun == null) {
+            // only set the previous run if it is not yet set
+            previousRun = await getRunStatusFromPath(previousRunPath);
+          }
+          // error getting previous run
+          if (previousRun == null) {
+            setRun(current);
+          } else {
+            setRun({
+              stages: mergeStageInfos(previousRun!.stages, current.stages),
+              complete: false,
+            });
+          }
+        }
+      };
     } else {
-      const onPipelineDataReceived = (data: {
-        stages: StageInfo[];
-        complete: boolean;
-      }) => {
-        setRun({
-          stages: data.stages,
-          complete: data.complete,
-        });
-      };
-
-      const onPollingError = (err: Error) => {
-        console.log("There was an error when polling the pipeline status", err);
-      };
-
-      startPollingPipelineStatus(
-        onPipelineDataReceived,
-        onPollingError,
-        onPipelineComplete,
-        currentRunPath,
-      );
+      onPipelineDataReceived = (data: RunStatus) => setRun(data);
     }
+    startPollingPipelineStatus(
+      onPipelineDataReceived,
+      onPollingError,
+      onPipelineComplete,
+      currentRunPath,
+    );
   }, []);
 
   return {
     run,
   };
-}
-
-interface Run {
-  stages: StageInfo[];
-  complete: boolean;
 }
 
 interface RunPollerProps {

--- a/src/main/frontend/common/tree-api.ts
+++ b/src/main/frontend/common/tree-api.ts
@@ -25,7 +25,9 @@ export default function useRunPoller({
           complete: boolean;
         }) => {
           setRun({
-            stages: mergeStageInfos(r!.stages, data.stages),
+            stages: data.complete
+              ? data.stages
+              : mergeStageInfos(r!.stages, data.stages),
             complete: data.complete,
           });
         };

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/startPollingPipelineStatus.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/startPollingPipelineStatus.ts
@@ -1,17 +1,10 @@
-import { StageInfo } from "../PipelineGraphModel";
-import { getRunStatusFromPath } from "../../../../common/RestClient";
-
-interface ApiResult {
-  complete: boolean;
-  stages: Array<StageInfo>;
-}
-
+import { getRunStatusFromPath, RunStatus } from "../../../../common/RestClient";
 /**
  * Starts polling the server to retrieve pipeline status.
  * Will only stop once the run is finished.
  */
-export default function startPollingPipelineStatus(
-  onFetchSuccess: (data: ApiResult) => void,
+export default async function startPollingPipelineStatus(
+  onFetchSuccess: (data: RunStatus) => void,
   onFetchError: (err: Error) => void,
   onPipelineComplete: () => void,
   path: string,


### PR DESCRIPTION
Fixes #655. Ensures that skeletons are not created if the current run is complete.

Before

![image](https://github.com/user-attachments/assets/c3e3502b-d981-4e56-8ccf-d0082c57a1f5)

After

![image](https://github.com/user-attachments/assets/152cb35c-a4b4-4ee7-911c-f3c932759040)


### Testing done

Manual testing of the given scenario in the issue.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
