### PR TITLE
Remove property for tooltip to follow cursor

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/convertLabelToTooltip.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/convertLabelToTooltip.tsx
@@ -59,7 +59,7 @@ export function TooltipLabel(props: TooltipLabelProps) {
 
   return (
     <>
-      <Tooltip content={table} interactive={true} followCursor={true}>
+      <Tooltip content={table} interactive={true}>
         {props.children}
       </Tooltip>
     </>


### PR DESCRIPTION
Without [loading](https://github.com/atomiks/tippyjs-react?tab=readme-ov-file#plugins) the followCursor plugin the corresponding does nothing but generate a warning in the console. Therefore as it wasn't doing anything before and is unwanted, let's remove it.

### Testing done

Tooltip still renders as intended

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
