### PR TITLE
Encapsulate message format to translations

### DIFF
--- a/src/main/frontend/common/RestClient.tsx
+++ b/src/main/frontend/common/RestClient.tsx
@@ -2,7 +2,7 @@ import {
   Result,
   StageInfo,
 } from "../pipeline-graph-view/pipeline-graph/main/index.ts";
-import { ResourceBundle } from "./i18n/translations.ts";
+import { ResourceBundle } from "./i18n/index.ts";
 
 export interface RunStatus {
   stages: StageInfo[];

--- a/src/main/frontend/common/i18n/i18n-provider.tsx
+++ b/src/main/frontend/common/i18n/i18n-provider.tsx
@@ -7,14 +7,14 @@ import React, {
   useState,
 } from "react";
 import {
-  defaultTranslations,
-  getTranslations,
+  defaultMessages,
+  getMessages,
   ResourceBundleName,
-  Translations,
-} from "./translations.ts";
+  Messages,
+} from "./messages.ts";
 
-export const I18NContext: Context<Translations> = createContext(
-  defaultTranslations("en"),
+export const I18NContext: Context<Messages> = createContext(
+  defaultMessages("en"),
 );
 
 interface I18NProviderProps {
@@ -28,19 +28,19 @@ export const I18NProvider: FunctionComponent<I18NProviderProps> = ({
   bundles,
   locale,
 }) => {
-  const [translations, setTranslations] = useState<Translations>(
-    defaultTranslations(locale),
+  const [messages, setMessages] = useState<Messages>(
+    defaultMessages(locale),
   );
 
   useEffect(() => {
-    const fetchTranslations = async () => {
-      const translations = await getTranslations(locale, bundles);
-      setTranslations(translations);
+    const fetchMessages = async () => {
+      const found = await getMessages(locale, bundles);
+      setMessages(found);
     };
-    fetchTranslations();
+    fetchMessages();
   }, []);
 
   return (
-    <I18NContext.Provider value={translations}>{children}</I18NContext.Provider>
+    <I18NContext.Provider value={messages}>{children}</I18NContext.Provider>
   );
 };

--- a/src/main/frontend/common/i18n/i18n-provider.tsx
+++ b/src/main/frontend/common/i18n/i18n-provider.tsx
@@ -28,9 +28,7 @@ export const I18NProvider: FunctionComponent<I18NProviderProps> = ({
   bundles,
   locale,
 }) => {
-  const [messages, setMessages] = useState<Messages>(
-    defaultMessages(locale),
-  );
+  const [messages, setMessages] = useState<Messages>(defaultMessages(locale));
 
   useEffect(() => {
     const fetchMessages = async () => {

--- a/src/main/frontend/common/i18n/i18n-provider.tsx
+++ b/src/main/frontend/common/i18n/i18n-provider.tsx
@@ -14,7 +14,7 @@ import {
 } from "./translations.ts";
 
 export const I18NContext: Context<Translations> = createContext(
-  new Translations({}),
+  defaultTranslations("en"),
 );
 
 interface I18NProviderProps {

--- a/src/main/frontend/common/i18n/index.ts
+++ b/src/main/frontend/common/i18n/index.ts
@@ -1,6 +1,3 @@
-export {
-  Translations,
-  ResourceBundleName,
-  ResourceBundle,
-} from "./translations.ts";
+export { Messages, ResourceBundleName } from "./messages.ts";
+export type { ResourceBundle } from "./messages.ts";
 export * from "./i18n-provider.tsx";

--- a/src/main/frontend/common/i18n/index.ts
+++ b/src/main/frontend/common/i18n/index.ts
@@ -1,0 +1,6 @@
+export {
+  Translations,
+  ResourceBundleName,
+  ResourceBundle,
+} from "./translations.ts";
+export * from "./i18n-provider.tsx";

--- a/src/main/frontend/common/i18n/messages.spec.ts
+++ b/src/main/frontend/common/i18n/messages.spec.ts
@@ -1,11 +1,7 @@
 import { Mock, vi } from "vitest";
 
 import { getResourceBundle } from "../RestClient.tsx";
-import {
-  getMessages,
-  ResourceBundleName,
-  Messages,
-} from "./messages.ts";
+import { getMessages, ResourceBundleName, Messages } from "./messages.ts";
 
 vi.mock("../RestClient.tsx", () => ({
   getResourceBundle: vi.fn(),
@@ -40,17 +36,13 @@ describe("Messages", () => {
         "Another.property": "with another value",
         "One.more.property": "with {one} more value",
       });
-      const messages = await getMessages("en", [
-        ResourceBundleName.messages,
-      ]);
+      const messages = await getMessages("en", [ResourceBundleName.messages]);
 
       expect(getResourceBundle).toHaveBeenCalledWith(
         "io.jenkins.plugins.pipelinegraphview.Messages",
       );
       expect(messages.format("A.property")).toEqual("a value");
-      expect(messages.format("Another.property")).toEqual(
-        "with another value",
-      );
+      expect(messages.format("Another.property")).toEqual("with another value");
       expect(messages.format("One.more.property", { one: "some" })).toEqual(
         "with some more value",
       );
@@ -59,9 +51,7 @@ describe("Messages", () => {
     it("should use the default messages if undefined returned", async () => {
       (getResourceBundle as Mock).mockResolvedValue(undefined);
 
-      const messages = await getMessages("en", [
-        ResourceBundleName.messages,
-      ]);
+      const messages = await getMessages("en", [ResourceBundleName.messages]);
 
       expect(messages.format("Util.second", { 0: 5 })).toEqual("5 sec");
       expect(messages.format("Util.day", { 0: 1 })).toEqual("1 day");

--- a/src/main/frontend/common/i18n/messages.spec.ts
+++ b/src/main/frontend/common/i18n/messages.spec.ts
@@ -2,18 +2,18 @@ import { Mock, vi } from "vitest";
 
 import { getResourceBundle } from "../RestClient.tsx";
 import {
-  getTranslations,
+  getMessages,
   ResourceBundleName,
-  Translations,
-} from "./translations.ts";
+  Messages,
+} from "./messages.ts";
 
 vi.mock("../RestClient.tsx", () => ({
   getResourceBundle: vi.fn(),
 }));
 
-describe("Translations", () => {
-  describe("Format translation", () => {
-    const translations = new Translations(
+describe("Messages", () => {
+  describe("Format message", () => {
+    const messages = new Messages(
       {
         "Property.name": "{arg} world",
       },
@@ -21,37 +21,37 @@ describe("Translations", () => {
     );
 
     it("should use known mapped message", () => {
-      expect(translations.format("Property.name", { arg: "hello" })).toEqual(
+      expect(messages.format("Property.name", { arg: "hello" })).toEqual(
         "hello world",
       );
     });
 
     it("should use fallback formatter with unknown property", () => {
       expect(
-        translations.format("Unknown.property.name", { arg: "hello" }),
+        messages.format("Unknown.property.name", { arg: "hello" }),
       ).toEqual("hello");
     });
   });
 
-  describe("Get Translations", () => {
+  describe("Get Messages", () => {
     it("should compile found resource bundle", async () => {
       (getResourceBundle as Mock).mockResolvedValue({
         "A.property": "a value",
         "Another.property": "with another value",
         "One.more.property": "with {one} more value",
       });
-      const translations = await getTranslations("en", [
+      const messages = await getMessages("en", [
         ResourceBundleName.messages,
       ]);
 
       expect(getResourceBundle).toHaveBeenCalledWith(
         "io.jenkins.plugins.pipelinegraphview.Messages",
       );
-      expect(translations.format("A.property")).toEqual("a value");
-      expect(translations.format("Another.property")).toEqual(
+      expect(messages.format("A.property")).toEqual("a value");
+      expect(messages.format("Another.property")).toEqual(
         "with another value",
       );
-      expect(translations.format("One.more.property", { one: "some" })).toEqual(
+      expect(messages.format("One.more.property", { one: "some" })).toEqual(
         "with some more value",
       );
     });
@@ -59,14 +59,14 @@ describe("Translations", () => {
     it("should use the default messages if undefined returned", async () => {
       (getResourceBundle as Mock).mockResolvedValue(undefined);
 
-      const translations = await getTranslations("en", [
+      const messages = await getMessages("en", [
         ResourceBundleName.messages,
       ]);
 
-      expect(translations.format("Util.second", { 0: 5 })).toEqual("5 sec");
-      expect(translations.format("Util.day", { 0: 1 })).toEqual("1 day");
-      expect(translations.format("Util.day", { 0: 2 })).toEqual("2 days");
-      expect(translations.format("A.property")).toEqual("");
+      expect(messages.format("Util.second", { 0: 5 })).toEqual("5 sec");
+      expect(messages.format("Util.day", { 0: 1 })).toEqual("1 day");
+      expect(messages.format("Util.day", { 0: 2 })).toEqual("2 days");
+      expect(messages.format("A.property")).toEqual("");
     });
   });
 });

--- a/src/main/frontend/common/i18n/messages.ts
+++ b/src/main/frontend/common/i18n/messages.ts
@@ -6,7 +6,7 @@ export type ResourceBundle = {
   [key: string]: string;
 };
 
-export class Translations {
+export class Messages {
   private readonly mapping: Record<string, MessageFunction<"string">>;
 
   constructor(messages: ResourceBundle, locale: string) {
@@ -52,10 +52,10 @@ export enum ResourceBundleName {
   messages = "io.jenkins.plugins.pipelinegraphview.Messages",
 }
 
-export async function getTranslations(
+export async function getMessages(
   locale: string,
   bundleNames: ResourceBundleName[],
-): Promise<Translations> {
+): Promise<Messages> {
   const bundles = await Promise.all(
     bundleNames.map((name) => getResourceBundle(name).then((r) => r ?? {})),
   );
@@ -65,7 +65,7 @@ export async function getTranslations(
     DEFAULT_MESSAGES,
   );
 
-  return new Translations(messages, locale);
+  return new Messages(messages, locale);
 }
 
 const DEFAULT_MESSAGES: ResourceBundle = {
@@ -80,6 +80,6 @@ const DEFAULT_MESSAGES: ResourceBundle = {
   noBuilds: "No builds",
 };
 
-export function defaultTranslations(locale: string) {
-  return new Translations(DEFAULT_MESSAGES, locale);
+export function defaultMessages(locale: string): Messages {
+  return new Messages(DEFAULT_MESSAGES, locale);
 }

--- a/src/main/frontend/common/i18n/translations.spec.ts
+++ b/src/main/frontend/common/i18n/translations.spec.ts
@@ -13,7 +13,7 @@ vi.mock("../RestClient.tsx", () => ({
 }));
 
 describe("Translations", () => {
-  describe("Get translation", () => {
+  describe("Format translation", () => {
     const fmt = messageFormat("en");
 
     const translations = new Translations({
@@ -21,14 +21,14 @@ describe("Translations", () => {
     });
 
     it("should use known mapped message", () => {
-      expect(translations.get("Property.name")({ arg: "hello" })).toEqual(
+      expect(translations.format("Property.name", { arg: "hello" })).toEqual(
         "hello world",
       );
     });
 
     it("should use fallback formatter with unknown property", () => {
       expect(
-        translations.get("Unknown.property.name")({ arg: "hello" }),
+        translations.format("Unknown.property.name", { arg: "hello" }),
       ).toEqual("hello");
     });
   });
@@ -47,11 +47,11 @@ describe("Translations", () => {
       expect(getResourceBundle).toHaveBeenCalledWith(
         "io.jenkins.plugins.pipelinegraphview.Messages",
       );
-      expect(translations.get("A.property")()).toEqual("a value");
-      expect(translations.get("Another.property")()).toEqual(
+      expect(translations.format("A.property")).toEqual("a value");
+      expect(translations.format("Another.property")).toEqual(
         "with another value",
       );
-      expect(translations.get("One.more.property")({ one: "some" })).toEqual(
+      expect(translations.format("One.more.property", { one: "some" })).toEqual(
         "with some more value",
       );
     });
@@ -63,10 +63,10 @@ describe("Translations", () => {
         ResourceBundleName.messages,
       ]);
 
-      expect(translations.get("Util.second")({ 0: 5 })).toEqual("5 sec");
-      expect(translations.get("Util.day")({ 0: 1 })).toEqual("1 day");
-      expect(translations.get("Util.day")({ 0: 2 })).toEqual("2 days");
-      expect(translations.get("A.property")()).toEqual("");
+      expect(translations.format("Util.second", { 0: 5 })).toEqual("5 sec");
+      expect(translations.format("Util.day", { 0: 1 })).toEqual("1 day");
+      expect(translations.format("Util.day", { 0: 2 })).toEqual("2 days");
+      expect(translations.format("A.property")).toEqual("");
     });
   });
 });

--- a/src/main/frontend/common/i18n/translations.spec.ts
+++ b/src/main/frontend/common/i18n/translations.spec.ts
@@ -3,7 +3,6 @@ import { Mock, vi } from "vitest";
 import { getResourceBundle } from "../RestClient.tsx";
 import {
   getTranslations,
-  messageFormat,
   ResourceBundleName,
   Translations,
 } from "./translations.ts";
@@ -14,11 +13,12 @@ vi.mock("../RestClient.tsx", () => ({
 
 describe("Translations", () => {
   describe("Format translation", () => {
-    const fmt = messageFormat("en");
-
-    const translations = new Translations({
-      "Property.name": fmt.compile("{arg} world"),
-    });
+    const translations = new Translations(
+      {
+        "Property.name": "{arg} world",
+      },
+      "en",
+    );
 
     it("should use known mapped message", () => {
       expect(translations.format("Property.name", { arg: "hello" })).toEqual(

--- a/src/main/frontend/common/i18n/translations.ts
+++ b/src/main/frontend/common/i18n/translations.ts
@@ -17,7 +17,7 @@ export class Translations {
     this.mapping = mapping;
   }
 
-  get(key: string): MessageFunction<"string"> {
+  private get(key: string): MessageFunction<"string"> {
     const message = this.mapping[key];
     if (message != null) {
       return message;
@@ -28,6 +28,11 @@ export class Translations {
     return (params) => {
       return params === undefined ? "" : Object.values(params as any).join(" ");
     };
+  }
+
+  format(key: string, args: Record<string, any> | null = null): string {
+    const message = this.get(key);
+    return args === null ? message() : message(args);
   }
 }
 

--- a/src/main/frontend/common/utils/timings.spec.tsx
+++ b/src/main/frontend/common/utils/timings.spec.tsx
@@ -4,11 +4,10 @@ import { vi } from "vitest";
 import React from "react";
 import { Paused, Started, Total } from "./timings.tsx";
 import { render } from "@testing-library/react";
-import { I18NContext } from "../i18n/i18n-provider.tsx";
-import { Translations } from "../i18n/translations.ts";
+import { I18NContext, Messages } from "../i18n/index.ts";
 
 describe("Timings", () => {
-  const translations = new Translations(
+  const translations = new Messages(
     {
       "Util.year": "{0} yr",
       "Util.month": "{0} mo",

--- a/src/main/frontend/common/utils/timings.spec.tsx
+++ b/src/main/frontend/common/utils/timings.spec.tsx
@@ -6,27 +6,28 @@ import { Paused, Started, Total } from "./timings.tsx";
 import { render } from "@testing-library/react";
 import { I18NContext } from "../i18n/i18n-provider.tsx";
 import { Translations } from "../i18n/translations.ts";
-import MessageFormat from "@messageformat/core";
 
 describe("Timings", () => {
-  const msg = new MessageFormat("en");
-
-  const translations = new Translations({
-    "Util.year": msg.compile("{0} yr"),
-    "Util.month": msg.compile("{0} mo"),
-    "Util.day": msg.compile("{0} day"),
-    "Util.hour": msg.compile("{0} hr"),
-    "Util.minute": msg.compile("{0} min"),
-    "Util.second": msg.compile("{0} sec"),
-    "Util.millisecond": msg.compile("{0} ms"),
-    startedAgo: msg.compile("Started {0} ago"),
-  });
+  const translations = new Translations(
+    {
+      "Util.year": "{0} yr",
+      "Util.month": "{0} mo",
+      "Util.day": "{0} day",
+      "Util.hour": "{0} hr",
+      "Util.minute": "{0} min",
+      "Util.second": "{0} sec",
+      "Util.millisecond": "{0} ms",
+      startedAgo: "Started {0} ago",
+    },
+    "en",
+  );
 
   function process(child: any) {
     return render(
       <I18NContext.Provider value={translations}>{child}</I18NContext.Provider>,
     );
   }
+
   describe("Total", () => {
     function getTotal(ms: number) {
       return process(<Total ms={ms} />);

--- a/src/main/frontend/common/utils/timings.tsx
+++ b/src/main/frontend/common/utils/timings.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
-import { Translations } from "../i18n/translations.ts";
-import { I18NContext } from "../i18n/i18n-provider.tsx";
+import { Translations, I18NContext } from "../i18n/index.ts";
 
 const ONE_SECOND_MS: number = 1000;
 const ONE_MINUTE_MS: number = 60 * ONE_SECOND_MS;

--- a/src/main/frontend/common/utils/timings.tsx
+++ b/src/main/frontend/common/utils/timings.tsx
@@ -62,48 +62,48 @@ function getTimeSpanString(
   if (years > 0) {
     return makeTimeSpanString(
       years,
-      translations.get(YEAR)({ "0": years }),
+      translations.format(YEAR, { "0": years }),
       months,
-      translations.get(MONTH)({ "0": months }),
+      translations.format(MONTH, { "0": months }),
     );
   } else if (months > 0) {
     return makeTimeSpanString(
       months,
-      translations.get(MONTH)({ "0": months }),
+      translations.format(MONTH, { "0": months }),
       days,
-      translations.get(DAY)({ "0": days }),
+      translations.format(DAY, { "0": days }),
     );
   } else if (days > 0) {
     return makeTimeSpanString(
       days,
-      translations.get(DAY)({ "0": days }),
+      translations.format(DAY, { "0": days }),
       hours,
-      translations.get(HOURS)({ "0": hours }),
+      translations.format(HOURS, { "0": hours }),
     );
   } else if (hours > 0) {
     return makeTimeSpanString(
       hours,
-      translations.get(HOURS)({ "0": hours }),
+      translations.format(HOURS, { "0": hours }),
       minutes,
-      translations.get(MINUTE)({ "0": minutes }),
+      translations.format(MINUTE, { "0": minutes }),
     );
   } else if (minutes > 0) {
     return makeTimeSpanString(
       minutes,
-      translations.get(MINUTE)({ "0": minutes }),
+      translations.format(MINUTE, { "0": minutes }),
       seconds,
-      translations.get(SECOND)({ "0": seconds }),
+      translations.format(SECOND, { "0": seconds }),
     );
   } else if (seconds >= 10) {
-    return translations.get(SECOND)({ "0": seconds });
+    return translations.format(SECOND, { "0": seconds });
   } else if (seconds >= 1) {
-    return translations.get(SECOND)({
+    return translations.format(SECOND, {
       "0": seconds + Math.floor(millis / 100) / 10,
     });
   } else if (millis >= 100) {
-    return translations.get(SECOND)({ "0": Math.floor(millis / 10) / 100 });
+    return translations.format(SECOND, { "0": Math.floor(millis / 10) / 100 });
   } else {
-    return translations.get(MILLIS)({ "0": millis });
+    return translations.format(MILLIS, { "0": millis });
   }
 }
 
@@ -125,7 +125,7 @@ export function Started({ since }: { since: number }) {
 
   return (
     <>
-      {translations.get(STARTED_AGO)({
+      {translations.format(STARTED_AGO, {
         "0": getTimeSpanString(Math.abs(since - Date.now()), translations),
       })}
     </>

--- a/src/main/frontend/common/utils/timings.tsx
+++ b/src/main/frontend/common/utils/timings.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import { Translations, I18NContext } from "../i18n/index.ts";
+import { Messages, I18NContext } from "../i18n/index.ts";
 
 const ONE_SECOND_MS: number = 1000;
 const ONE_MINUTE_MS: number = 60 * ONE_SECOND_MS;
@@ -39,11 +39,11 @@ function makeTimeSpanString(
  * @see https://github.com/jenkinsci/jenkins/blob/f9edeb0c0485fddfc03a7e1710ac5cf2b35ec497/core/src/main/java/hudson/Util.java#L734
  *
  * @param duration number of milliseconds.
- * @param translations the translations to get the labels from.
+ * @param messages the messages to get the labels from.
  */
 function getTimeSpanString(
   duration: number,
-  translations: Translations,
+  messages: Messages,
 ): string {
   const years = Math.floor(duration / ONE_YEAR_MS);
   duration %= ONE_YEAR_MS;
@@ -61,71 +61,71 @@ function getTimeSpanString(
   if (years > 0) {
     return makeTimeSpanString(
       years,
-      translations.format(YEAR, { "0": years }),
+      messages.format(YEAR, { "0": years }),
       months,
-      translations.format(MONTH, { "0": months }),
+      messages.format(MONTH, { "0": months }),
     );
   } else if (months > 0) {
     return makeTimeSpanString(
       months,
-      translations.format(MONTH, { "0": months }),
+      messages.format(MONTH, { "0": months }),
       days,
-      translations.format(DAY, { "0": days }),
+      messages.format(DAY, { "0": days }),
     );
   } else if (days > 0) {
     return makeTimeSpanString(
       days,
-      translations.format(DAY, { "0": days }),
+      messages.format(DAY, { "0": days }),
       hours,
-      translations.format(HOURS, { "0": hours }),
+      messages.format(HOURS, { "0": hours }),
     );
   } else if (hours > 0) {
     return makeTimeSpanString(
       hours,
-      translations.format(HOURS, { "0": hours }),
+      messages.format(HOURS, { "0": hours }),
       minutes,
-      translations.format(MINUTE, { "0": minutes }),
+      messages.format(MINUTE, { "0": minutes }),
     );
   } else if (minutes > 0) {
     return makeTimeSpanString(
       minutes,
-      translations.format(MINUTE, { "0": minutes }),
+      messages.format(MINUTE, { "0": minutes }),
       seconds,
-      translations.format(SECOND, { "0": seconds }),
+      messages.format(SECOND, { "0": seconds }),
     );
   } else if (seconds >= 10) {
-    return translations.format(SECOND, { "0": seconds });
+    return messages.format(SECOND, { "0": seconds });
   } else if (seconds >= 1) {
-    return translations.format(SECOND, {
+    return messages.format(SECOND, {
       "0": seconds + Math.floor(millis / 100) / 10,
     });
   } else if (millis >= 100) {
-    return translations.format(SECOND, { "0": Math.floor(millis / 10) / 100 });
+    return messages.format(SECOND, { "0": Math.floor(millis / 10) / 100 });
   } else {
-    return translations.format(MILLIS, { "0": millis });
+    return messages.format(MILLIS, { "0": millis });
   }
 }
 
 export function Total({ ms }: { ms: number }) {
-  const translations = useContext(I18NContext);
-  return <>{getTimeSpanString(ms, translations)}</>;
+  const messages = useContext(I18NContext);
+  return <>{getTimeSpanString(ms, messages)}</>;
 }
 
 export function Paused({ since }: { since: number }) {
-  const translations = useContext(I18NContext);
-  return <>{`Queued ${getTimeSpanString(since, translations)}`}</>;
+  const messages = useContext(I18NContext);
+  return <>{`Queued ${getTimeSpanString(since, messages)}`}</>;
 }
 
 export function Started({ since }: { since: number }) {
-  const translations = useContext(I18NContext);
+  const messages = useContext(I18NContext);
   if (since === 0) {
     return <></>;
   }
 
   return (
     <>
-      {translations.format(STARTED_AGO, {
-        "0": getTimeSpanString(Math.abs(since - Date.now()), translations),
+      {messages.format(STARTED_AGO, {
+        "0": getTimeSpanString(Math.abs(since - Date.now()), messages),
       })}
     </>
   );

--- a/src/main/frontend/common/utils/timings.tsx
+++ b/src/main/frontend/common/utils/timings.tsx
@@ -41,10 +41,7 @@ function makeTimeSpanString(
  * @param duration number of milliseconds.
  * @param messages the messages to get the labels from.
  */
-function getTimeSpanString(
-  duration: number,
-  messages: Messages,
-): string {
+function getTimeSpanString(duration: number, messages: Messages): string {
   const years = Math.floor(duration / ONE_YEAR_MS);
   duration %= ONE_YEAR_MS;
   const months = Math.floor(duration / ONE_MONTH_MS);

--- a/src/main/frontend/multi-pipeline-graph-view/app.tsx
+++ b/src/main/frontend/multi-pipeline-graph-view/app.tsx
@@ -4,8 +4,7 @@ import { MultiPipelineGraph } from "./multi-pipeline-graph/main/index.ts";
 
 import "./app.scss";
 import "./multi-pipeline-graph/styles/main.scss";
-import { I18NProvider } from "../common/i18n/i18n-provider.tsx";
-import { ResourceBundleName } from "../common/i18n/translations.ts";
+import { I18NProvider, ResourceBundleName } from "../common/i18n/index.ts";
 
 const App: FunctionComponent = () => {
   const locale =

--- a/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/MultiPipelineGraph.tsx
+++ b/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/MultiPipelineGraph.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { RunInfo } from "./MultiPipelineGraphModel.ts";
 import startPollingRunsStatus from "./support/startPollingRunsStatus.ts";
 import SingleRun from "./SingleRun.tsx";
-import { I18NContext } from "../../../common/i18n/i18n-provider.tsx";
+import { I18NContext } from "../../../common/i18n/index.ts";
 
 export const MultiPipelineGraph = () => {
   const [runs, setRuns] = useState<Array<RunInfo>>([]);
@@ -38,14 +38,14 @@ export const MultiPipelineGraph = () => {
     {},
   );
 
-  const translations = useContext(I18NContext);
+  const messages = useContext(I18NContext);
 
   return (
     <>
       {Object.keys(groupedRuns).length === 0 ? (
         <div className="pgv-stages__group">
           <div className="pgv-stages__heading">
-            {translations.format("noBuilds")}
+            {messages.format("noBuilds")}
           </div>
         </div>
       ) : (

--- a/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/MultiPipelineGraph.tsx
+++ b/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/MultiPipelineGraph.tsx
@@ -45,7 +45,7 @@ export const MultiPipelineGraph = () => {
       {Object.keys(groupedRuns).length === 0 ? (
         <div className="pgv-stages__group">
           <div className="pgv-stages__heading">
-            {translations.get("noBuilds")()}
+            {translations.format("noBuilds")}
           </div>
         </div>
       ) : (

--- a/src/main/frontend/pipeline-console-view/app.tsx
+++ b/src/main/frontend/pipeline-console-view/app.tsx
@@ -1,8 +1,7 @@
 import React, { lazy } from "react";
 
-import { I18NProvider } from "../common/i18n/i18n-provider.tsx";
+import { I18NProvider, ResourceBundleName } from "../common/i18n/index.ts";
 import { FilterProvider } from "./pipeline-console/main/providers/filter-provider.tsx";
-import { ResourceBundleName } from "../common/i18n/translations.ts";
 
 const PipelineConsole = lazy(
   () => import("./pipeline-console/main/PipelineConsole.tsx"),


### PR DESCRIPTION
As part of resolving #679 the first stage is to fix the API design to ensure that the messageformat library implementation doesn't leak from the Translations class. Doing this will allow us to change the implementation with little if any change to the usages.

I have also done a bit of renaming from Translations to a more standard and probably expected Messages class.

I have added an index.ts file to try and help denote what is public and what is more "package private", I guess another way of doing this would be to merge files as my understanding of js/ts doesn't have quite the same visibility modifiers as what I'm used to with java

### Testing done

Unit tests should handle any regression but I've also done a manual pass in Japanese.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
