### PR TITLE
Optimize interface for mobile

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -39,7 +39,6 @@ export default function PipelineConsole() {
         <Dropdown
           items={[
             <StagesCustomization key="visibility-select" />,
-            "separator",
             {
               text: "View as plain text",
               icon: DOCUMENT,

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/StageNodeLink.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/StageNodeLink.tsx
@@ -14,7 +14,7 @@ export default function StageNodeLink({ agent }: StageNodeLinkProps) {
   }
 
   return (
-    <li>
+    <li className={"jenkins-mobile-hide"}>
       <a
         href={href}
         className={"jenkins-button jenkins-button--tertiary"}

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages-customization.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages-customization.tsx
@@ -14,7 +14,12 @@ export default function StagesCustomization() {
     setMainViewVisibility,
     stageViewPosition,
     setStageViewPosition,
+    isMobile,
   } = useLayoutPreferences();
+
+  if (isMobile) {
+    return null;
+  }
 
   const handleViewChange = (e: ChangeEvent<HTMLSelectElement>) => {
     setMainViewVisibility(e.target.value as MainViewVisibility);
@@ -121,6 +126,7 @@ export default function StagesCustomization() {
           <option value={StageViewPosition.LEFT}>Left</option>
         </select>
       </label>
+      <div className="jenkins-dropdown__separator"></div>
     </>
   );
 }

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages-customization.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages-customization.tsx
@@ -126,7 +126,7 @@ export default function StagesCustomization() {
           <option value={StageViewPosition.LEFT}>Left</option>
         </select>
       </label>
-      <div className="jenkins-dropdown__separator"></div>
+      <div className="jenkins-dropdown__separator" />
     </>
   );
 }

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/providers/user-preference-provider.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/providers/user-preference-provider.tsx
@@ -70,7 +70,6 @@ const loadFromLocalStorage = <T,>(key: string, fallback: T): T => {
   return fallback;
 };
 
-// PROVIDER
 const MOBILE_BREAKPOINT = 700;
 
 // PROVIDER

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/providers/user-preference-provider.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/providers/user-preference-provider.tsx
@@ -30,6 +30,10 @@ interface LayoutPreferences {
   setTreeViewWidth: (width: number) => void;
   setStageViewWidth: (width: number) => void;
   setStageViewHeight: (height: number) => void;
+  /**
+   * Returns true if the current window width is less than the mobile breakpoint.
+   * Used for disabling customization options in favor of a mobile-friendly layout.
+   */
   isMobile: boolean;
 }
 
@@ -67,7 +71,6 @@ const loadFromLocalStorage = <T,>(key: string, fallback: T): T => {
 };
 
 // PROVIDER
-// Add near the top
 const MOBILE_BREAKPOINT = 700;
 
 // PROVIDER

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/split-view.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/split-view.scss
@@ -3,6 +3,7 @@
   display: grid;
   gap: var(--section-padding);
   animation: fade-in 0.1s ease-in-out both;
+  align-items: start;
 }
 
 @keyframes fade-in {
@@ -12,7 +13,7 @@
 }
 
 .pgv-split-view__side-panel {
-  position: relative;
+  display: contents;
 }
 
 .pgv-split-view__divider {

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.tsx
@@ -80,7 +80,7 @@ export default function StageDetails({ stage }: StageDetailsProps) {
           </Tooltip>
         </li>
         {stage.pauseDurationMillis !== 0 && (
-          <li>
+          <li className={"jenkins-mobile-hide"}>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
               <path
                 d="M145.61 464h220.78c19.8 0 35.55-16.29 33.42-35.06C386.06 308 304 310 304 256s83.11-51 95.8-172.94c2-18.78-13.61-35.06-33.41-35.06H145.61c-19.8 0-35.37 16.28-33.41 35.06C124.89 205 208 201 208 256s-82.06 52-95.8 172.94c-2.14 18.77 13.61 35.06 33.41 35.06z"


### PR DESCRIPTION
Overrides UI preferences when the viewport width is small (< 700px). Feel the graph is better for mobile users (e.g. larger hitboxes, gesture based, smaller).

**Before**
<img width="568" alt="image" src="https://github.com/user-attachments/assets/0168cf13-8337-4808-8f6d-77c44650ceb0" />

**After**
<img width="564" alt="image" src="https://github.com/user-attachments/assets/3550a897-afde-4f3b-8fc8-ecf2b057dd76" />

Should fix https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/698

### Testing done

* Resize window and notice UI preferences are overriden
* In mobile you can no longer show/hide graph/stages

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
