### PR TITLE
Wrap on console text overflow

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/console-log-card.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/console-log-card.scss
@@ -112,6 +112,7 @@
 .console-text div {
   text-indent: 0;
   display: inline-block;
+  overflow-wrap: anywhere;
 }
 
 pre.console-output-line {


### PR DESCRIPTION
Add a property to wrap text that overflows. I've used the [anywhere](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap#anywhere) option as otherwise the example pipeline wouldn't wrap as it contains nowhere natural for a break to occur.

Fixes #713 

### Testing done

Used test pipeline provided in #713 

Before

![image](https://github.com/user-attachments/assets/59fe8527-025f-4599-a322-2ef531bb4bea)

After

![image](https://github.com/user-attachments/assets/445fbb44-6e74-4ab4-95f7-64b67c9e16fd)


### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
