### PR TITLE
Make overflow on sidebar hidden

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -66,6 +66,7 @@
 .pgv-sticky-sidebar {
   position: sticky;
   top: calc(var(--header-height) + var(--section-padding));
+  overflow: hidden;
 }
 
 .pgv-skeleton-column {


### PR DESCRIPTION
When the sidebar has text that is wider than it's width, it currently overflows onto the content in the right side. This makes the overflow hidden to avoid this.

<!-- Please describe your pull request here. -->

### Testing done

Added the style locally and verified that the text does not overflow onto the right side content.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

