### PR TITLE
Add i18n support for run detail cards

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/TestResultRunDetailsItem.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/TestResultRunDetailsItem.java
@@ -17,21 +17,21 @@ public class TestResultRunDetailsItem {
 
         AbstractTestResultAction<?> action = run.getAction(AbstractTestResultAction.class);
 
-        if (action != null) {
-            RunDetailsItem testResult = new RunDetailsItem.Builder()
-                    .ionicon("clipboard-outline")
-                    .text(Messages.testResults())
-                    .href("../%s".formatted(action.getUrlName()))
-                    .tooltip("Passed: %s%nFailed: %s%nSkipped: %s%nTotal: %s"
-                            .formatted(
-                                    action.getTotalCount() - action.getFailCount() - action.getSkipCount(),
-                                    action.getFailCount(),
-                                    action.getSkipCount(),
-                                    action.getTotalCount()))
-                    .build();
-            return Optional.of(testResult);
+        if (action == null) {
+            return Optional.empty();
         }
 
-        return Optional.empty();
+        String passed =
+                Messages.testResults_passed(action.getTotalCount() - action.getFailCount() - action.getSkipCount());
+        String failed = Messages.testResults_failed(action.getFailCount());
+        String skipped = Messages.testResults_skipped(action.getSkipCount());
+        String total = Messages.testResults_total(action.getTotalCount());
+        RunDetailsItem testResult = new RunDetailsItem.Builder()
+                .ionicon("clipboard-outline")
+                .text(Messages.testResults())
+                .href("../" + action.getUrlName())
+                .tooltip(passed + "\n" + failed + "\n" + skipped + "\n" + total)
+                .build();
+        return Optional.of(testResult);
     }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/TimingRunDetailsItems.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/TimingRunDetailsItems.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.pipelinegraphview.cards.items;
 
 import hudson.Util;
+import io.jenkins.plugins.pipelinegraphview.Messages;
 import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem;
 import java.util.ArrayList;
 import java.util.Date;
@@ -15,9 +16,8 @@ public class TimingRunDetailsItems {
 
         RunDetailsItem startedItem = new RunDetailsItem.Builder()
                 .ionicon("time-outline")
-                .text("Started "
-                        + Util.getTimeSpanString(Math.abs(run.getTime().getTime() - new Date().getTime()))
-                        + " ago")
+                .text(Messages.startedAgo(
+                        Util.getTimeSpanString(Math.abs(run.getTime().getTime() - new Date().getTime()))))
                 .build();
         runDetailsItems.add(startedItem);
 
@@ -26,7 +26,7 @@ public class TimingRunDetailsItems {
         if (timeInQueueAction != null) {
             RunDetailsItem queuedItem = new RunDetailsItem.Builder()
                     .ionicon("hourglass-outline")
-                    .text("Queued " + Util.getTimeSpanString(timeInQueueAction.getQueuingDurationMillis()))
+                    .text(Messages.queued(Util.getTimeSpanString(timeInQueueAction.getQueuingDurationMillis())))
                     .build();
 
             runDetailsItems.add(queuedItem);
@@ -34,7 +34,7 @@ public class TimingRunDetailsItems {
 
         RunDetailsItem timerItem = new RunDetailsItem.Builder()
                 .ionicon("timer-outline")
-                .text("Took " + run.getDurationString())
+                .text(Messages.took(run.getDurationString()))
                 .build();
 
         runDetailsItems.add(timerItem);

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/UpstreamCauseRunDetailsItem.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/UpstreamCauseRunDetailsItem.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.pipelinegraphview.cards.items;
 
 import hudson.model.Cause;
 import hudson.model.CauseAction;
+import io.jenkins.plugins.pipelinegraphview.Messages;
 import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem;
 import java.util.List;
 import java.util.Objects;
@@ -17,12 +18,11 @@ public class UpstreamCauseRunDetailsItem {
         return causes.stream()
                 .filter(cause -> cause instanceof Cause.UpstreamCause)
                 .map(upstreamCause -> (Cause.UpstreamCause) upstreamCause)
-                .map(upstreamCause -> upstreamCause.getUpstreamRun())
+                .map(Cause.UpstreamCause::getUpstreamRun)
                 .filter(Objects::nonNull)
-                // TODO i18n
                 .map(upstreamRun -> new RunDetailsItem.Builder()
                         .ionicon("play-circle-outline")
-                        .text("Started by upstream pipeline " + upstreamRun.getDisplayName())
+                        .text(Messages.cause_upstream(upstreamRun.getDisplayName()))
                         .href(DisplayURLProvider.get().getRunURL(upstreamRun))
                         .build())
                 .findAny();

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/UserIdCauseRunDetailsItem.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/UserIdCauseRunDetailsItem.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.pipelinegraphview.cards.items;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.User;
+import io.jenkins.plugins.pipelinegraphview.Messages;
 import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem;
 import java.util.HashMap;
 import java.util.List;
@@ -20,11 +21,9 @@ public class UserIdCauseRunDetailsItem {
                 .map(userIdCause -> (Cause.UserIdCause) userIdCause)
                 .map(userIdCause -> User.get(userIdCause.getUserId(), false, new HashMap<>()))
                 .filter(Objects::nonNull)
-                // TODO i18n
-                .map(user -> "Manually run by " + user.getDisplayName())
-                .map(startedAt -> new RunDetailsItem.Builder()
+                .map(user -> new RunDetailsItem.Builder()
                         .ionicon("person-outline")
-                        .text(startedAt)
+                        .text(Messages.cause_user(user.getDisplayName()))
                         .build())
                 .findAny();
     }

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
@@ -1,5 +1,7 @@
 startedAgo=Started {0} ago
 noBuilds=No builds
+queued=Queued {0}
+took=Queued {0}
 
 node.start=Start
 node.end=End
@@ -13,4 +15,11 @@ timings.month ={0} mo
 timings.year  ={0} yr
 
 testResults=Test results
+testResults.passed=Passed {0}
+testResults.failed=Failed {0}
+testResults.skipped=Skipped {0}
+testResults.total= Total {0}
 artifacts=Artifacts
+
+cause.upstream=Started by upstream pipeline {0}
+cause.user=Manually run by {0}

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
@@ -1,7 +1,7 @@
 startedAgo=Started {0} ago
 noBuilds=No builds
 queued=Queued {0}
-took=Queued {0}
+took=Took {0}
 
 node.start=Start
 node.end=End


### PR DESCRIPTION
Continuing on from #728 and #725 this PR adds internationalisation support for other elements of the run details cards.

### Testing done

Manual testing in English and Japanese

Before

![image](https://github.com/user-attachments/assets/904c9fc5-38ec-429c-902e-7820dbac8345)

After

![image](https://github.com/user-attachments/assets/1a53711c-c990-4460-affb-96d4494805a5)


### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
