### PR TITLE
Set loading to complete when data is received without a previous build

### DIFF
--- a/src/main/frontend/common/tree-api.ts
+++ b/src/main/frontend/common/tree-api.ts
@@ -43,7 +43,10 @@ export default function useRunPoller({
         }
       };
     } else {
-      onPipelineDataReceived = (data: RunStatus) => setRun(data);
+      onPipelineDataReceived = (data: RunStatus) => {
+        setLoading(false);
+        setRun(data);
+      }
     }
     startPollingPipelineStatus(
       onPipelineDataReceived,


### PR DESCRIPTION
Fixes #712 

Set the loading property to true when data is retrieved without a previous run

### Testing done

Used the example pipeline in #712

![image](https://github.com/user-attachments/assets/8eb2718e-b73f-42d4-b75f-2e85d607b429)


### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
