### PR TITLE
Add changes link

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItem.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItem.java
@@ -1,0 +1,22 @@
+package io.jenkins.plugins.pipelinegraphview.cards.items;
+
+import io.jenkins.plugins.pipelinegraphview.Messages;
+import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem;
+import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem.Icon.Ionicon;
+import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem.ItemContent;
+import java.util.Optional;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+
+public class ChangesRunDetailsItem {
+
+    public static Optional<RunDetailsItem> get(WorkflowRun run) {
+        boolean hasChanges = !run.getChangeSets().isEmpty();
+
+        if (!hasChanges) {
+            return Optional.empty();
+        }
+        RunDetailsItem changes = new RunDetailsItem.RunDetail(
+                new Ionicon("code-slash-outline"), ItemContent.of("../changes", Messages.changes()));
+        return Optional.of(changes);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItem.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItem.java
@@ -1,22 +1,51 @@
 package io.jenkins.plugins.pipelinegraphview.cards.items;
 
+import hudson.scm.ChangeLogSet;
 import io.jenkins.plugins.pipelinegraphview.Messages;
 import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem;
 import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem.Icon.Ionicon;
 import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem.ItemContent;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 public class ChangesRunDetailsItem {
 
     public static Optional<RunDetailsItem> get(WorkflowRun run) {
-        boolean hasChanges = !run.getChangeSets().isEmpty();
+        Optional<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSet =
+                run.getChangeSets().stream().filter(cs -> !cs.isEmptySet()).findFirst();
 
-        if (!hasChanges) {
+        if (changeSet.isEmpty()) {
             return Optional.empty();
         }
+
+        List<ChangeLogSet.Entry> changeEntries = Arrays.stream(changeSet.get().getItems())
+                .map(ChangeLogSet.Entry.class::cast)
+                .collect(Collectors.toList());
+
+        ChangeLogSet.Entry changeEntry = changeEntries.get(0);
+
+        StringBuilder toolTipBuilder = new StringBuilder();
+        String commitId = changeEntry.getCommitId();
+        if (commitId != null) {
+            String author = changeEntry.getAuthor().getDisplayName();
+            toolTipBuilder.append("%s by %s".formatted(commitId, author));
+            toolTipBuilder.append(System.lineSeparator());
+        }
+        toolTipBuilder.append(changeEntry.getMsgEscaped());
+
+        int numEntries = changeEntries.size();
+        if (numEntries > 1) {
+            toolTipBuilder.append(System.lineSeparator()).append(System.lineSeparator());
+            toolTipBuilder.append(Messages.changes_other(numEntries - 1));
+        }
+
         RunDetailsItem changes = new RunDetailsItem.RunDetail(
-                new Ionicon("code-slash-outline"), ItemContent.of("../changes", Messages.changes()));
+                new Ionicon("code-slash-outline"),
+                ItemContent.of("../changes", Messages.changes()),
+                toolTipBuilder.toString());
         return Optional.of(changes);
     }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -8,6 +8,7 @@ import io.jenkins.plugins.pipelinegraphview.PipelineGraphViewConfiguration;
 import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsCard;
 import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem;
 import io.jenkins.plugins.pipelinegraphview.cards.items.ArtifactRunDetailsItem;
+import io.jenkins.plugins.pipelinegraphview.cards.items.ChangesRunDetailsItem;
 import io.jenkins.plugins.pipelinegraphview.cards.items.SCMRunDetailsItems;
 import io.jenkins.plugins.pipelinegraphview.cards.items.TestResultRunDetailsItem;
 import io.jenkins.plugins.pipelinegraphview.cards.items.TimingRunDetailsItems;
@@ -290,6 +291,7 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
 
         runDetailsItems.addAll(TimingRunDetailsItems.get(run));
 
+        ChangesRunDetailsItem.get(run).ifPresent(runDetailsItems::add);
         TestResultRunDetailsItem.get(run).ifPresent(runDetailsItems::add);
         ArtifactRunDetailsItem.get(run).ifPresent(runDetailsItems::add);
 

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
@@ -21,6 +21,7 @@ testResults.skipped=Skipped {0}
 testResults.total= Total {0}
 artifacts=Artifacts
 changes=Changes
+changes.other={0} other changes
 
 cause.upstream=Started by upstream pipeline {0}
 cause.user=Manually run by {0}

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
@@ -20,6 +20,7 @@ testResults.failed=Failed {0}
 testResults.skipped=Skipped {0}
 testResults.total= Total {0}
 artifacts=Artifacts
+changes=Changes
 
 cause.upstream=Started by upstream pipeline {0}
 cause.user=Manually run by {0}

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItemTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItemTest.java
@@ -8,7 +8,6 @@ import io.jenkins.plugins.pipelinegraphview.Messages;
 import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
 import java.util.Optional;
-
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.jupiter.api.Test;
@@ -21,8 +20,8 @@ class ChangesRunDetailsItemTest {
     @Test
     void get_noChanges(JenkinsRule j) throws Exception {
         // build once, there should be no change set
-        WorkflowRun run = TestUtils.createAndRunJob(j, "simpleWithSCM", "singleStagePipelineWithSCM.jenkinsfile",
-                Result.SUCCESS);
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "simpleWithSCM", "singleStagePipelineWithSCM.jenkinsfile", Result.SUCCESS);
         Optional<RunDetailsItem> detailsItem = ChangesRunDetailsItem.get(run);
         assertTrue(detailsItem.isEmpty());
     }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItemTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItemTest.java
@@ -1,0 +1,50 @@
+package io.jenkins.plugins.pipelinegraphview.cards.items;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.model.Result;
+import io.jenkins.plugins.pipelinegraphview.Messages;
+import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem;
+import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
+import java.util.Optional;
+
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class ChangesRunDetailsItemTest {
+
+    @Test
+    void get_noChanges(JenkinsRule j) throws Exception {
+        // build once, there should be no change set
+        WorkflowRun run = TestUtils.createAndRunJob(j, "simpleWithSCM", "singleStagePipelineWithSCM.jenkinsfile",
+                Result.SUCCESS);
+        Optional<RunDetailsItem> detailsItem = ChangesRunDetailsItem.get(run);
+        assertTrue(detailsItem.isEmpty());
+    }
+
+    @Test
+    void get_changes(JenkinsRule j) throws Exception {
+        WorkflowJob job = TestUtils.createJob(j, "simpleWithSCM", "singleStagePipelineWithSCM.jenkinsfile", true);
+        // build twice to establish a change set
+        j.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
+        j.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
+
+        WorkflowRun run = job.getLastBuild();
+
+        Optional<RunDetailsItem> detailsItem = ChangesRunDetailsItem.get(run);
+
+        assertTrue(detailsItem.isPresent());
+
+        RunDetailsItem.RunDetail changesDetails = (RunDetailsItem.RunDetail) detailsItem.get();
+
+        assertEquals(
+                new RunDetailsItem.ItemContent.LinkContent(j.getURL() + run.getUrl(), Messages.changes()),
+                changesDetails.content());
+        assertEquals("symbol-code-slash-outline plugin-ionicons-api", changesDetails.icon());
+    }
+}

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItemTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItemTest.java
@@ -42,7 +42,7 @@ class ChangesRunDetailsItemTest {
         RunDetailsItem.RunDetail changesDetails = (RunDetailsItem.RunDetail) detailsItem.get();
 
         assertEquals(
-                new RunDetailsItem.ItemContent.LinkContent(j.getURL() + run.getUrl(), Messages.changes()),
+                new RunDetailsItem.ItemContent.LinkContent("../changes", Messages.changes()),
                 changesDetails.content());
         assertEquals("symbol-code-slash-outline plugin-ionicons-api", changesDetails.icon());
     }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItemTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItemTest.java
@@ -42,8 +42,7 @@ class ChangesRunDetailsItemTest {
         RunDetailsItem.RunDetail changesDetails = (RunDetailsItem.RunDetail) detailsItem.get();
 
         assertEquals(
-                new RunDetailsItem.ItemContent.LinkContent("../changes", Messages.changes()),
-                changesDetails.content());
+                new RunDetailsItem.ItemContent.LinkContent("../changes", Messages.changes()), changesDetails.content());
         assertEquals("symbol-code-slash-outline plugin-ionicons-api", changesDetails.icon());
     }
 }

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/singleStagePipelineWithSCM.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/singleStagePipelineWithSCM.jenkinsfile
@@ -1,0 +1,8 @@
+node {
+    def checkoutUrl = 'https://github.com/jenkinsci/pipeline-graph-view-plugin.git'
+    def number = currentBuild.getNumber()
+    def checkoutName = number == 1 ? 'b6dc82faf9248fece30bc704c09edbb4708c9756' : (number == 2 ? '1dc41d9c9758a111baebebe5f6bcd39c66040941' : 'main')
+    stage('Checkout') {
+        checkout scmGit(branches: [[name: checkoutName]], extensions: [], userRemoteConfigs: [[url: checkoutUrl]])
+    }
+}


### PR DESCRIPTION
Added a new `RunDetailsItem` for SCM changes to expose a link to `../changes` for the current run.

### Testing done

With changes
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/b0fbae89-8bbb-4c09-ab1d-6dfbe7a56b6d" />

Without
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/e556fb61-b9bb-4766-afee-688df30d0b1d" />


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
