### PR TITLE
Fix NPE when no cause can be identified

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/UpstreamCauseRunDetailsItem.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/UpstreamCauseRunDetailsItem.java
@@ -16,6 +16,9 @@ public class UpstreamCauseRunDetailsItem {
 
     public static Optional<RunDetailsItem> get(WorkflowRun run) {
         CauseAction causeAction = run.getAction(CauseAction.class);
+        if (causeAction == null) {
+            return Optional.empty();
+        }
         List<Cause> causes = causeAction.getCauses();
         return causes.stream()
                 .filter(cause -> cause instanceof Cause.UpstreamCause)

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/UserIdCauseRunDetailsItem.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/UserIdCauseRunDetailsItem.java
@@ -17,6 +17,9 @@ public class UserIdCauseRunDetailsItem {
 
     public static Optional<RunDetailsItem> get(WorkflowRun run) {
         CauseAction causeAction = run.getAction(CauseAction.class);
+        if (causeAction == null) {
+            return Optional.empty();
+        }
         List<Cause> causes = causeAction.getCauses();
         return causes.stream()
                 .filter(cause -> cause instanceof Cause.UserIdCause)

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/UpstreamCauseRunDetailsItemTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/UpstreamCauseRunDetailsItemTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Result;
+import io.jenkins.plugins.pipelinegraphview.Messages;
 import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
 import java.util.Optional;
@@ -60,7 +61,7 @@ class UpstreamCauseRunDetailsItemTest {
         RunDetailsItem.RunDetail userDetails = (RunDetailsItem.RunDetail) detailsItem.get();
 
         assertEquals(
-                new RunDetailsItem.ItemContent.LinkContent(baseUrl + run.getUrl(), "Started by upstream pipeline #1"),
+                new RunDetailsItem.ItemContent.LinkContent(baseUrl + run.getUrl(), Messages.cause_upstream("#1")),
                 userDetails.content());
         assertEquals("symbol-play-circle-outline plugin-ionicons-api", userDetails.icon());
     }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/UpstreamCauseRunDetailsItemTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/UpstreamCauseRunDetailsItemTest.java
@@ -1,0 +1,67 @@
+package io.jenkins.plugins.pipelinegraphview.cards.items;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.Result;
+import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem;
+import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
+import java.util.Optional;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class UpstreamCauseRunDetailsItemTest {
+
+    private static WorkflowRun run;
+    private static String baseUrl;
+
+    @BeforeAll
+    static void beforeAll(JenkinsRule j) throws Exception {
+        run = TestUtils.createAndRunJob(j, "simple", "singleStagePipeline.jenkinsfile", Result.SUCCESS);
+        baseUrl = j.getURL().toString();
+    }
+
+    @BeforeEach
+    void setUp() {
+        run.removeActions(CauseAction.class);
+    }
+
+    @Test
+    void get_noActionsOfType() {
+        Optional<RunDetailsItem> detailsItem = UpstreamCauseRunDetailsItem.get(run);
+
+        assertTrue(detailsItem.isEmpty());
+    }
+
+    @Test
+    void get_noUpstreamCause() {
+        run.addAction(new CauseAction(new Cause.UserIdCause("User Id")));
+
+        Optional<RunDetailsItem> detailsItem = UpstreamCauseRunDetailsItem.get(run);
+
+        assertTrue(detailsItem.isEmpty());
+    }
+
+    @Test
+    void get() {
+        run.addAction(new CauseAction(new Cause.UpstreamCause(run)));
+
+        Optional<RunDetailsItem> detailsItem = UpstreamCauseRunDetailsItem.get(run);
+
+        assertTrue(detailsItem.isPresent());
+
+        RunDetailsItem.RunDetail userDetails = (RunDetailsItem.RunDetail) detailsItem.get();
+
+        assertEquals(
+                new RunDetailsItem.ItemContent.LinkContent(baseUrl + run.getUrl(), "Started by upstream pipeline #1"),
+                userDetails.content());
+        assertEquals("symbol-play-circle-outline plugin-ionicons-api", userDetails.icon());
+    }
+}

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/UserIdCauseRunDetailsItemTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/UserIdCauseRunDetailsItemTest.java
@@ -7,6 +7,7 @@ import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Result;
 import hudson.model.User;
+import io.jenkins.plugins.pipelinegraphview.Messages;
 import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
 import java.io.IOException;
@@ -77,7 +78,8 @@ class UserIdCauseRunDetailsItemTest {
 
         RunDetailsItem.RunDetail userDetails = (RunDetailsItem.RunDetail) detailsItem.get();
 
-        assertEquals(new RunDetailsItem.ItemContent.PlainContent("Manually run by User Id"), userDetails.content());
+        assertEquals(
+                new RunDetailsItem.ItemContent.PlainContent(Messages.cause_user("User Id")), userDetails.content());
         assertEquals("symbol-person-outline plugin-ionicons-api", userDetails.icon());
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/UserIdCauseRunDetailsItemTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/UserIdCauseRunDetailsItemTest.java
@@ -1,0 +1,83 @@
+package io.jenkins.plugins.pipelinegraphview.cards.items;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.Result;
+import hudson.model.User;
+import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem;
+import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Optional;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class UserIdCauseRunDetailsItemTest {
+
+    private static WorkflowRun run;
+
+    @BeforeAll
+    static void beforeAll(JenkinsRule j) throws Exception {
+        run = TestUtils.createAndRunJob(j, "simple", "singleStagePipeline.jenkinsfile", Result.SUCCESS);
+    }
+
+    @BeforeEach
+    void setUp() {
+        run.removeActions(CauseAction.class);
+        User.getAll().forEach(user -> {
+            try {
+                user.delete();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    void get_noActionsOfType() {
+        Optional<RunDetailsItem> detailsItem = UserIdCauseRunDetailsItem.get(run);
+
+        assertTrue(detailsItem.isEmpty());
+    }
+
+    @Test
+    void get_noUserIdCause() {
+        run.addAction(new CauseAction(new Cause.UpstreamCause(run)));
+
+        Optional<RunDetailsItem> detailsItem = UserIdCauseRunDetailsItem.get(run);
+
+        assertTrue(detailsItem.isEmpty());
+    }
+
+    @Test
+    void get_userNotFound() {
+        run.addAction(new CauseAction(new Cause.UserIdCause("User Id")));
+
+        Optional<RunDetailsItem> detailsItem = UserIdCauseRunDetailsItem.get(run);
+
+        assertTrue(detailsItem.isEmpty());
+    }
+
+    @Test
+    void get() {
+        run.addAction(new CauseAction(new Cause.UserIdCause("User Id")));
+        User.get("User Id", true, new HashMap<>());
+
+        Optional<RunDetailsItem> detailsItem = UserIdCauseRunDetailsItem.get(run);
+
+        assertTrue(detailsItem.isPresent());
+
+        RunDetailsItem.RunDetail userDetails = (RunDetailsItem.RunDetail) detailsItem.get();
+
+        assertEquals(new RunDetailsItem.ItemContent.PlainContent("Manually run by User Id"), userDetails.content());
+        assertEquals("symbol-person-outline plugin-ionicons-api", userDetails.icon());
+    }
+}


### PR DESCRIPTION
Whilst playing around with playwright on #731 I noticed an NPE exception in the logs when it got the console page due to there being no cause action registered with the run.

I don't know if this is just a quirk of the test Jenkins setup or if this is actually possible in the real world but I've added a guard against it. If it is an issue with how our tests run jobs then I can investigate making a change there instead.

### Testing done

Unit tests added

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
