### PR TITLE
Move entry title to checkbox

### DIFF
--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewConfiguration/config.jelly
@@ -3,11 +3,11 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:section title="${%Pipeline graph view}">
-    <f:entry title="${%Show pipeline graph on job page}">
-      <f:checkbox field="showGraphOnJobPage"/>
+    <f:entry>
+      <f:checkbox field="showGraphOnJobPage" title="${%Show pipeline graph on job page}" />
     </f:entry>
-    <f:entry title="${%Show pipeline graph on build page}">
-      <f:checkbox field="showGraphOnBuildPage"/>
+    <f:entry>
+      <f:checkbox field="showGraphOnBuildPage" title="${%Show pipeline graph on build page}" />
     </f:entry>
   </f:section>
 </j:jelly>


### PR DESCRIPTION
We have some special JS logic in Jenkins that moves entry titles to their child checkboxes - this can be a little janky and should really be avoided. This PR updates this plugin to move the title from entry to its child checkbox.

### Testing done

* Checkbox works as expected
* No more content shift on page load

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
