### PR TITLE
Fix scroll up/down controls overlaying full screen graph

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.scss
@@ -32,6 +32,7 @@
     border-radius: 0;
     border: none;
     height: unset;
+    max-height: unset;
 
     .pgv-stages-graph__controls {
       margin: 1rem;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.scss
@@ -54,8 +54,14 @@
   }
 }
 
+// Hacky method of getting the full screen graph to
+// overlay the header and scroll up/down controls
 #page-body:has(.pgv-stages-graph--dialog) {
   z-index: 1001;
+
+  .pgv-split-view__container {
+    z-index: 1001;
+  }
 }
 
 .pgv-stages-graph__controls {


### PR DESCRIPTION
Slight bug where the scroll up/down would overlay the full screen graph - this PR fixes that and attaches a note that the fix isn't the cleanest :')

**Before**
<img width="267" alt="image" src="https://github.com/user-attachments/assets/92e3dc2d-ed88-4978-90ad-30429dc058a1" />

**After**
<img width="314" alt="image" src="https://github.com/user-attachments/assets/aaa11514-2b39-4d0b-879a-e9bde45cf650" />

### Testing done

* Controls no longer overlay full screen graph

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
