### PR TITLE
Rename Rebuild button to Replay Now

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -54,11 +54,11 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
     }
 
     /**
-     * Handles the rebuild request using ReplayAction feature
+     * Handles the replay request using ReplayAction feature
      */
     @RequirePOST
     @JavaScriptMethod
-    public boolean doRebuild() throws IOException, ExecutionException {
+    public boolean doReplay() throws IOException, ExecutionException {
         if (run != null) {
             run.checkAnyPermission(Item.BUILD);
             ReplayAction replayAction = run.getAction(ReplayAction.class);

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -15,7 +15,7 @@
                         <button id="pgv-replay" data-success-message="${%Build scheduled}"
                                 data-proxy-name="replayAction${proxyId}"
                                 class="jenkins-button jenkins-!-build-color">
-                            <l:icon src="symbol-reload-outline plugin-ionicons-api"/>
+                            <l:icon src="symbol-arrow-redo-outline plugin-ionicons-api"/>
                             ${%Replay}
                         </button>
                     </l:hasPermission>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -11,12 +11,12 @@
                 <j:if test="${it.buildable}">
                     <l:hasPermission permission="${it.permission}">
                         <j:set var="proxyId" value="${h.generateId()}" />
-                        <st:bind value="${it}" var="rebuildAction${proxyId}"/>
-                        <button id="pgv-rebuild" data-success-message="${%Build scheduled}"
-                                data-proxy-name="rebuildAction${proxyId}"
+                        <st:bind value="${it}" var="replayAction${proxyId}"/>
+                        <button id="pgv-replay" data-success-message="${%Build scheduled}"
+                                data-proxy-name="replayAction${proxyId}"
                                 class="jenkins-button jenkins-!-build-color">
                             <l:icon src="symbol-play-outline plugin-ionicons-api"/>
-                            ${%Rebuild}
+                            ${%Replay}
                         </button>
                     </l:hasPermission>
                 </j:if>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -15,7 +15,7 @@
                         <button id="pgv-replay" data-success-message="${%Build scheduled}"
                                 data-proxy-name="replayAction${proxyId}"
                                 class="jenkins-button jenkins-!-build-color">
-                            <l:icon src="symbol-play-outline plugin-ionicons-api"/>
+                            <l:icon src="symbol-reload-outline plugin-ionicons-api"/>
                             ${%Replay}
                         </button>
                     </l:hasPermission>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -16,7 +16,7 @@
                                 data-proxy-name="replayAction${proxyId}"
                                 class="jenkins-button jenkins-!-build-color">
                             <l:icon src="symbol-arrow-redo-outline plugin-ionicons-api"/>
-                            ${%Replay}
+                            ${%Replay Now}
                         </button>
                     </l:hasPermission>
                 </j:if>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction/index.jelly
@@ -8,9 +8,9 @@
         <j:if test="${it.buildable}">
           <l:hasPermission permission="${it.permission}">
             <j:set var="proxyId" value="${h.generateId()}" />
-            <st:bind value="${it}" var="rebuildAction${proxyId}"/>
-            <button id="pgv-rebuild" data-success-message="${%Build scheduled}"
-                    data-proxy-name="rebuildAction${proxyId}"
+            <st:bind value="${it}" var="replayAction${proxyId}"/>
+            <button id="pgv-replay" data-success-message="${%Build scheduled}"
+                    data-proxy-name="replayAction${proxyId}"
                     class="jenkins-button jenkins-!-build-color">
               <l:icon src="symbol-play-outline plugin-ionicons-api"/>
               ${%Build}

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -1,13 +1,13 @@
-const rebuildButton = document.getElementById('pgv-rebuild');
+const replayButton = document.getElementById('pgv-replay');
 
-if (rebuildButton) {
-  rebuildButton.addEventListener('click', event => {
+if (replayButton) {
+  replayButton.addEventListener('click', event => {
     event.preventDefault();
-    const rebuildAction = window[`${rebuildButton.dataset.proxyName}`];
-    rebuildAction.doRebuild(function (success) {
+    const replayAction = window[`${replayButton.dataset.proxyName}`];
+    replayAction.doReplay(function (success) {
       const result = success.responseJSON;
       if (result) {
-        window.hoverNotification(rebuildButton.dataset.successMessage, rebuildButton);
+        window.hoverNotification(replayButton.dataset.successMessage, replayButton);
       }
     });
   })

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewRebuildTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewRebuildTest.java
@@ -20,11 +20,11 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
-class PipelineGraphViewRebuildTest {
+class PipelineGraphViewReplayTest {
 
     @Issue("GH#330")
     @Test
-    void rebuildButtonStartsNewBuild(JenkinsRule j) throws Exception {
+    void replayButtonStartsNewBuild(JenkinsRule j) throws Exception {
         WorkflowRun run =
                 TestUtils.createAndRunJob(j, "hello_world", "helloWorldScriptedPipeline.jenkinsfile", Result.SUCCESS);
 
@@ -33,7 +33,7 @@ class PipelineGraphViewRebuildTest {
 
     @Issue("GH#330")
     @Test
-    void rebuildButtonRedirectsForParameterizedJob(JenkinsRule j) throws Exception {
+    void replayButtonRedirectsForParameterizedJob(JenkinsRule j) throws Exception {
         WorkflowRun run = TestUtils.createAndRunJob(
                 j, "echo_parameterized", "gh330_parameterizedBuild.jenkinsfile", Result.SUCCESS);
 
@@ -48,7 +48,7 @@ class PipelineGraphViewRebuildTest {
             Response navigate = page.navigate(j.getURL() + run.getUrl() + urlName);
             String currentUrl = navigate.url();
 
-            page.click("#pgv-rebuild");
+            page.click("#pgv-replay");
             String newUrl = page.url();
 
             assertEquals(currentUrl, newUrl);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

May _close #618. Also related to #756.

I think the name Rebuild for this button was a poor chose.

That's because Rebuild is an existing concept of Jenkins, through the [Rebuilder Plugin](https://plugins.jenkins.io/rebuild/), and that's not at all what this button does.

Replay is another concept, and the regular build page already has a Replay button.

I think we should name this button as Replay to clearly reflect what it does and avoid any confusion/assumption.

**Before:**
![image](https://github.com/user-attachments/assets/da7ffa0c-2653-4105-8357-8044816cb350)


**After:**
![image](https://github.com/user-attachments/assets/e27ed726-dd9c-409f-ba0f-b6e8452e729f)


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

There's no much to test, it's working.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
