### PR TITLE
fix: log anchoring with small stage logs

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogStream.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogStream.tsx
@@ -73,6 +73,21 @@ export default function ConsoleLogStream(props: ConsoleLogStreamProps) {
     return props.step.state === Result.running || props.logBuffer.startByte < 0;
   };
 
+  useEffect(() => {
+    const hash = window.location.hash;
+    if (!hash.startsWith("#log-")) {
+      return;
+    }
+    const lineNumber = parseInt(hash.substring(5));
+    if (!(!isNaN(lineNumber) && virtuosoRef.current)) {
+      return;
+    }
+    virtuosoRef.current.scrollToIndex({
+      index: lineNumber,
+      align: "center",
+    });
+  }, []);
+
   return (
     <Virtuoso
       useWindowScroll


### PR DESCRIPTION
A start at fixing log anchoring.

When you select a log index it adds the anchor `#log-XXX` to url. This is intended to allow you to go directly to that log but that doesn't work at the moment.
This change adds an effect to tell the Virtuos list to scroll to a given index in the event that this anchor is in the url.

This does not fix the issue described in #629 were the log is outside of the initial buffer.

<!-- Please describe your pull request here. -->

### Testing done

Manual testing against a job which builds the [design library](https://github.com/jenkinsci/design-library-plugin)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
