### PR TITLE
Use the result of a WarningAction set on a branch node instead of the calculated status

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/ParallelBlockRelationship.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/ParallelBlockRelationship.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
+import org.jenkinsci.plugins.workflow.actions.WarningAction;
 import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -162,6 +163,12 @@ public class ParallelBlockRelationship extends NodeRelationship {
                     this.branchStatuses.get(getBranchName(branchStartNode)));
         }
         boolean skippedStage = PipelineNodeUtil.isSkippedStage(branchStartNode);
+
+        WarningAction warningAction = branchStartNode.getPersistentAction(WarningAction.class);
+        if (warningAction != null) {
+            return new NodeRunStatus(GenericStatus.fromResult(warningAction.getResult()), skippedStage);
+        }
+
         return new NodeRunStatus(this.branchStatuses.get(getBranchName(branchStartNode)), skippedStage);
     }
 

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
@@ -499,4 +499,26 @@ class PipelineGraphApiTest {
                         "{failure-stage,failure-stage,STAGE,failure},",
                         "{unstable-stage,unstable-stage,STAGE,unstable}")));
     }
+
+    @Issue("GH#764")
+    @Test
+    void createTree_branchResult() throws Exception {
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "branchResult", "gh764_branchResult.jenkinsfile", Result.UNSTABLE, false);
+        PipelineGraphApi api = new PipelineGraphApi(run);
+        PipelineGraph graph = api.createTree();
+
+        List<PipelineStage> stages = graph.getStages();
+
+        String stagesString = TestUtils.collectStagesAsString(stages, TestUtils::nodeNameAndStatus);
+        assertThat(
+                stagesString,
+                equalTo(String.join(
+                        "",
+                        "Parallel{unstable}[",
+                        "success-branch{success},",
+                        "failure-branch{failure},",
+                        "unstable-branch{unstable}",
+                        "]")));
+    }
 }

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh764_branchResult.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh764_branchResult.jenkinsfile
@@ -1,0 +1,26 @@
+import hudson.model.Result
+import io.jenkins.plugins.pipelinegraphview.utils.PipelineNodeUtil
+import org.jenkinsci.plugins.workflow.actions.WarningAction
+import org.jenkinsci.plugins.workflow.graph.FlowNode
+
+void setBranchResult(Result result) {
+    FlowNode branchNode = getContext(FlowNode.class).getEnclosingBlocks().find { PipelineNodeUtil.isParallelBranch(it) }
+    if (branchNode) {
+        branchNode.addOrReplaceAction(new WarningAction(result));
+    }
+}
+
+parallel([
+    "success-branch": {
+         unstable("unstable-step")
+         setBranchResult(Result.SUCCESS)
+    },
+    "failure-branch": {
+        echo("foo")
+        setBranchResult(Result.FAILURE)
+    },
+    "unstable-branch": {
+        echo("foo")
+        setBranchResult(Result.UNSTABLE)
+    }
+])


### PR DESCRIPTION
Fix #764. Add logic to use the result of a `WarningAction` set on a branch node instead of the calculated status.

### Testing done

Added new tests to validate that the branch node status reflects the result of any `WarningAction` set on the node.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
