### PR TITLE
Add cancel button to pipeline overview

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,8 @@
     <node.version>22.15.0</node.version>
     <npm.version>11.3.0</npm.version>
     <spotless.check.skip>false</spotless.check.skip>
+    <!-- for WithConsoleUrl -->
+    <useBeta>true</useBeta>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>4.3.0</version>
@@ -131,11 +136,6 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
       <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.configuration-as-code</groupId>
-      <artifactId>test-harness</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,11 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,6 @@
     <node.version>22.15.0</node.version>
     <npm.version>11.3.0</npm.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <!-- for WithConsoleUrl -->
-    <useBeta>true</useBeta>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import jenkins.console.WithConsoleUrl;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -35,7 +36,7 @@ import org.kohsuke.stapler.verb.GET;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
+public class PipelineConsoleViewAction extends AbstractPipelineViewAction implements WithConsoleUrl {
     public static final long LOG_THRESHOLD = 150 * 1024; // 150KB
     public static final String URL_NAME = "pipeline-overview";
 
@@ -311,5 +312,10 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
 
     public boolean isShowGraphOnBuildPage() {
         return PipelineGraphViewConfiguration.get().isShowGraphOnBuildPage();
+    }
+
+    @Override
+    public String getConsoleUrl() {
+        return getUrl() + getUrlName();
     }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import jenkins.console.WithConsoleUrl;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -36,7 +35,7 @@ import org.kohsuke.stapler.verb.GET;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PipelineConsoleViewAction extends AbstractPipelineViewAction implements WithConsoleUrl {
+public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
     public static final long LOG_THRESHOLD = 150 * 1024; // 150KB
     public static final String URL_NAME = "pipeline-overview";
 
@@ -312,10 +311,5 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction implem
 
     public boolean isShowGraphOnBuildPage() {
         return PipelineGraphViewConfiguration.get().isShowGraphOnBuildPage();
-    }
-
-    @Override
-    public String getConsoleUrl() {
-        return getUrl() + getUrlName();
     }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -8,8 +8,10 @@ import hudson.model.Action;
 import hudson.model.BallColor;
 import hudson.model.Item;
 import hudson.model.Queue;
+import hudson.model.Result;
 import hudson.security.Permission;
 import hudson.util.HttpResponses;
+import io.jenkins.plugins.pipelinegraphview.Messages;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -88,7 +90,15 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
     @JavaScriptMethod
     public HttpResponse doCancel() throws IOException, ExecutionException {
         if (run != null) {
-            return run.doStop();
+            if (run.isBuilding()) {
+                run.doTerm();
+                return HttpResponses.okJSON();
+            } else {
+                String message = Result.ABORTED.equals(run.getResult())
+                        ? Messages.run_alreadyCancelled()
+                        : Messages.run_isFinished();
+                return HttpResponses.errorJSON(message);
+            }
         }
         return HttpResponses.errorJSON("No run to cancel");
     }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -90,8 +90,9 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
     @JavaScriptMethod
     public HttpResponse doCancel() throws IOException, ExecutionException {
         if (run != null) {
+            run.checkPermission(getCancelPermission());
             if (run.isBuilding()) {
-                run.doTerm();
+                run.doStop();
                 return HttpResponses.okJSON();
             } else {
                 String message = Result.ABORTED.equals(run.getResult())

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -63,6 +63,10 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
         return run.getDisplayName();
     }
 
+    public String getBuildFullDisplayName() {
+        return run.getFullDisplayName();
+    }
+
     /**
      * Handles the rebuild request using ReplayAction feature
      */

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -52,7 +52,7 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
     }
 
     public Permission getCancelPermission() {
-        return run.getParent().CANCEL;
+        return Item.CANCEL;
     }
 
     public Permission getConfigurePermission() {

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -43,7 +43,7 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
         return run.getParent().isBuildable();
     }
 
-    public boolean isBuilding() {
+    public boolean isBuildInProgress() {
         return run.isBuilding();
     }
 

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -41,7 +41,7 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
         return run.getParent().isBuildable();
     }
 
-   public boolean isBuilding() {
+    public boolean isBuilding() {
         return run.isBuilding();
     }
 
@@ -49,7 +49,7 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
         return run.getParent().BUILD;
     }
 
-	public Permission getCancelPermission() {
+    public Permission getCancelPermission() {
         return run.getParent().CANCEL;
     }
 

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -41,8 +41,16 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
         return run.getParent().isBuildable();
     }
 
+   public boolean isBuilding() {
+        return run.isBuilding();
+    }
+
     public Permission getPermission() {
         return run.getParent().BUILD;
+    }
+
+	public Permission getCancelPermission() {
+        return run.getParent().CANCEL;
     }
 
     public Permission getConfigurePermission() {
@@ -71,6 +79,18 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Handles the cancel request.
+     */
+    @RequirePOST
+    @JavaScriptMethod
+    public HttpResponse doCancel() throws IOException, ExecutionException {
+        if (run != null) {
+            return run.doStop();
+        }
+        return HttpResponses.errorJSON("No run to cancel");
     }
 
     public String getFullBuildDisplayName() {

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
@@ -28,3 +28,6 @@ cause.user=Manually run by {0}
 
 FlowNodeWrapper.parallel=Parallel
 FlowNodeWrapper.noStage=System Generated
+
+run.alreadyCancelled=Run was already cancelled
+run.isFinished=Run is already finished

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -8,7 +8,7 @@
             <j:out value="${h.generateConsoleAnnotationScriptAndStylesheet()}"/>
 
             <j:set var="controls">
-                <j:if test="${it.building}">
+                <j:if test="${it.buildInProgress}">
                     <l:hasPermission permission="${it.cancelPermission}">
                         <j:set var="proxyId" value="${h.generateId()}" />
                         <st:bind value="${it}" var="cancelAction${proxyId}"/>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -8,6 +8,18 @@
             <j:out value="${h.generateConsoleAnnotationScriptAndStylesheet()}"/>
 
             <j:set var="controls">
+                <j:if test="${it.building}">
+                    <l:hasPermission permission="${it.cancelPermission}">
+                        <j:set var="proxyId" value="${h.generateId()}" />
+                        <st:bind value="${it}" var="cancelAction${proxyId}"/>
+                        <button id="pgv-cancel" data-success-message="${%Build cancelled}"
+                                data-proxy-name="cancelAction${proxyId}"
+                                class="jenkins-button jenkins-!-error-color">
+                            <l:icon src="symbol-stop-circle-outline plugin-ionicons-api"/>
+                            ${%Cancel}
+                        </button>
+                    </l:hasPermission>
+                </j:if>
                 <j:if test="${it.buildable}">
                     <l:hasPermission permission="${it.permission}">
                         <j:set var="proxyId" value="${h.generateId()}" />

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -12,7 +12,7 @@
                     <l:hasPermission permission="${it.cancelPermission}">
                         <j:set var="proxyId" value="${h.generateId()}" />
                         <st:bind value="${it}" var="cancelAction${proxyId}"/>
-                        <button id="pgv-cancel" data-success-message="${%Build cancelled}"
+                        <button id="pgv-cancel" data-confirm="${%Confirm(it.buildFullDisplayName)}"
                                 data-proxy-name="cancelAction${proxyId}"
                                 class="jenkins-button jenkins-!-error-color">
                             <l:icon src="symbol-stop-circle-outline plugin-ionicons-api"/>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.properties
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.properties
@@ -1,0 +1,1 @@
+Cancel=Cancel

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.properties
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.properties
@@ -1,1 +1,2 @@
 Cancel=Cancel
+Confirm=Are you sure you want to abort {0}?

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -35,13 +35,17 @@ if (cancelButton) {
       const url = buildCaption.dataset.statusUrl;
       fetch(url).then((rsp) => {
         if (rsp.ok) {
-          let isBuilding = rsp.headers.get("X-Building");
+          const isBuilding = rsp.headers.get("X-Building");
           if (isBuilding === "true") {
             setTimeout(updateCancelButton, 5000);
           } else {
             cancelButton.style.display = "none";
           }
         }
+        return null;
+      })
+      .catch((error) => {
+        console.error("Error fetching build caption statsus:", error);
       })
     }
     setTimeout(updateCancelButton, 5000);

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -25,11 +25,12 @@ if (cancelButton) {
     };
 
     if (question != null) {
-      dialog.confirm(question).then(
-        () => {
-          execute();
-        }
-      );
+      dialog.confirm(question).then(() => {
+        execute();
+        return null;
+      }).catch((error) => {
+        console.error("Error in cancel confirm dialog:", error);
+      })
     } else {
       execute();
     }

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -12,3 +12,17 @@ if (rebuildButton) {
     });
   })
 }
+
+const cancelButton = document.getElementById('pgv-cancel');
+
+if (cancelButton) {
+  cancelButton.addEventListener('click', event => {
+    event.preventDefault();
+    const cancelAction = window[`${cancelButton.dataset.proxyName}`];
+    cancelAction.doCancel(function (success) {
+      if (success.status == 200) {
+        window.hoverNotification(cancelButton.dataset.successMessage, cancelButton);
+      }
+    });
+  })
+}

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -22,12 +22,28 @@ if (cancelButton) {
     cancelAction.doCancel(function (success) {
       const result = success.responseJSON;
       if (result) {
-        if (result.status == "ok") {
+        if (result.status === "ok") {
           window.hoverNotification(cancelButton.dataset.successMessage, cancelButton);
         } else {
           window.hoverNotification(result.message, cancelButton);
         }
       }
     });
+
+    function updateCancelButton() {
+      const buildCaption = document.querySelector(".jenkins-build-caption");
+      const url = buildCaption.dataset.statusUrl;
+      fetch(url).then((rsp) => {
+        if (rsp.ok) {
+          let isBuilding = rsp.headers.get("X-Building");
+          if (isBuilding === "true") {
+            setTimeout(updateCancelButton, 5000);
+          } else {
+            cancelButton.style.display = "none";
+          }
+        }
+      })
+    }
+    setTimeout(updateCancelButton, 5000);
   })
 }

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -25,6 +25,7 @@ if (cancelButton) {
     };
 
     if (question != null) {
+      /*eslint-disable no-undef*/
       dialog.confirm(question).then(() => {
         execute();
         return null;

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -18,17 +18,21 @@ const cancelButton = document.getElementById('pgv-cancel');
 if (cancelButton) {
   cancelButton.addEventListener('click', event => {
     event.preventDefault();
-    const cancelAction = window[`${cancelButton.dataset.proxyName}`];
-    cancelAction.doCancel(function (success) {
-      const result = success.responseJSON;
-      if (result) {
-        if (result.status === "ok") {
-          window.hoverNotification(cancelButton.dataset.successMessage, cancelButton);
-        } else {
-          window.hoverNotification(result.message, cancelButton);
+    const question = cancelButton.getAttribute("data-confirm");
+    const execute = function () {
+      const cancelAction = window[`${cancelButton.dataset.proxyName}`];
+      cancelAction.doCancel();
+    };
+
+    if (question != null) {
+      dialog.confirm(question).then(
+        () => {
+          execute();
         }
-      }
-    });
+      );
+    } else {
+      execute();
+    }
 
     function updateCancelButton() {
       const buildCaption = document.querySelector(".jenkins-build-caption");

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -20,8 +20,13 @@ if (cancelButton) {
     event.preventDefault();
     const cancelAction = window[`${cancelButton.dataset.proxyName}`];
     cancelAction.doCancel(function (success) {
-      if (success.status == 200) {
-        window.hoverNotification(cancelButton.dataset.successMessage, cancelButton);
+      const result = success.responseJSON;
+      if (result) {
+        if (result.status == "ok") {
+          window.hoverNotification(cancelButton.dataset.successMessage, cancelButton);
+        } else {
+          window.hoverNotification(result.message, cancelButton);
+        }
       }
     });
   })

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
@@ -20,8 +20,7 @@ class PipelineGraphViewCancelTest {
 
     @Test
     void cancelButtonCancelsBuild(JenkinsRule j) throws Exception {
-        WorkflowRun run =
-                TestUtils.createAndRunJob(j, "indefiniteWait", "indefiniteWait.jenkinsfile", Result.SUCCESS);
+        WorkflowRun run = TestUtils.createAndRunJob(j, "indefiniteWait", "indefiniteWait.jenkinsfile", Result.SUCCESS);
 
         try (Playwright playwright = Playwright.create();
                 Browser browser = playwright.chromium().launch()) {
@@ -39,5 +38,4 @@ class PipelineGraphViewCancelTest {
             j.assertBuildStatus(Result.ABORTED, run);
         }
     }
-
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.pipelinegraphview;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.AriaRole;
 import hudson.model.Result;
 import hudson.model.queue.QueueTaskFuture;
 import io.jenkins.plugins.pipelinegraphview.consoleview.PipelineConsoleViewAction;
@@ -34,6 +35,8 @@ class PipelineGraphViewCancelTest {
             String urlName = new PipelineConsoleViewAction(run).getUrlName();
             page.navigate(j.getURL() + run.getUrl() + urlName);
             page.click("#pgv-cancel");
+            page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Yes"))
+                    .click();
         }
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
@@ -3,14 +3,10 @@ package io.jenkins.plugins.pipelinegraphview;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
-import com.microsoft.playwright.Response;
 import hudson.model.Result;
 import hudson.model.queue.QueueTaskFuture;
 import io.jenkins.plugins.pipelinegraphview.consoleview.PipelineConsoleViewAction;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
-
-import static org.junit.Assert.assertTrue;
-
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.jupiter.api.Test;
@@ -22,7 +18,8 @@ class PipelineGraphViewCancelTest {
 
     @Test
     void cancelButtonCancelsBuild(JenkinsRule j) throws Exception {
-        QueueTaskFuture<WorkflowRun> futureRun = TestUtils.createAndRunJobNoWait(j, "indefiniteWait", "indefiniteWait.jenkinsfile");
+        QueueTaskFuture<WorkflowRun> futureRun =
+                TestUtils.createAndRunJobNoWait(j, "indefiniteWait", "indefiniteWait.jenkinsfile");
         WorkflowRun run = futureRun.waitForStart();
         SemaphoreStep.waitForStart("wait/1", run);
         cancelRun(j, run);

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
@@ -3,32 +3,25 @@ package io.jenkins.plugins.pipelinegraphview;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.junit.UsePlaywright;
 import hudson.model.Result;
-import io.jenkins.plugins.pipelinegraphview.playwright.ManageAppearancePage;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.pipelinegraphview.playwright.PipelineJobPage;
 import io.jenkins.plugins.pipelinegraphview.playwright.PlaywrightConfig;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.jupiter.api.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.function.ThrowingSupplier;
 
-@WithJenkins
+@WithJenkinsConfiguredWithCode
 @UsePlaywright(PlaywrightConfig.class)
 class PipelineGraphViewCancelTest {
 
-    private static final Logger log = LoggerFactory.getLogger(PipelineGraphViewCancelTest.class);
-
     @Test
-    void cancelButtonCancelsBuild(Page p, JenkinsRule j) throws Exception {
-        WorkflowRun run = setupJenkins(p, j.jenkins.getRootUrl(), (ThrowingSupplier<WorkflowRun>)
-                () -> TestUtils.createAndRunJobNoWait(j, "indefiniteWait", "indefiniteWait.jenkinsfile")
-                        .waitForStart());
+    @ConfiguredWithCode("configure-appearance.yml")
+    void cancelButtonCancelsBuild(Page p, JenkinsConfiguredWithCodeRule j) throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJobNoWait(j, "indefiniteWait", "indefiniteWait.jenkinsfile")
+                        .waitForStart();
         SemaphoreStep.waitForStart("wait/1", run);
         new PipelineJobPage(p, run.getParent())
                 .goTo()
@@ -39,23 +32,5 @@ class PipelineGraphViewCancelTest {
                 .cancel();
         SemaphoreStep.success("wait/1", null);
         j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run));
-    }
-
-    private WorkflowRun setupJenkins(Page p, String rootUrl, Supplier<WorkflowRun> setupRun) {
-        CompletableFuture<WorkflowRun> run = CompletableFuture.supplyAsync(setupRun);
-        CompletableFuture<Void> jenkinsSetup = CompletableFuture.runAsync(() -> {
-            log.info("Setting up Jenkins to have the Pipeline Graph View on all pages");
-            new ManageAppearancePage(p, rootUrl)
-                    .goTo()
-                    .displayPipelineOnJobPage()
-                    .displayPipelineOnBuildPage()
-                    .setPipelineGraphAsConsoleProvider()
-                    .save();
-            log.info("Jenkins setup complete");
-        });
-
-        CompletableFuture.allOf(run, jenkinsSetup).join();
-
-        return run.join();
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
@@ -21,7 +21,7 @@ class PipelineGraphViewCancelTest {
     @ConfiguredWithCode("configure-appearance.yml")
     void cancelButtonCancelsBuild(Page p, JenkinsConfiguredWithCodeRule j) throws Exception {
         WorkflowRun run = TestUtils.createAndRunJobNoWait(j, "indefiniteWait", "indefiniteWait.jenkinsfile")
-                        .waitForStart();
+                .waitForStart();
         SemaphoreStep.waitForStart("wait/1", run);
         new PipelineJobPage(p, run.getParent())
                 .goTo()

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
@@ -1,0 +1,48 @@
+package io.jenkins.plugins.pipelinegraphview;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.Response;
+import hudson.model.Result;
+import io.jenkins.plugins.pipelinegraphview.consoleview.PipelineConsoleViewAction;
+import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
+import jenkins.test.RunMatchers;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class PipelineGraphViewCancelTest {
+
+    @Test
+    void cancelButtonCancelsBuild(JenkinsRule j) throws Exception {
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "indefiniteWait", "indefiniteWait.jenkinsfile", Result.SUCCESS);
+
+        try (Playwright playwright = Playwright.create();
+                Browser browser = playwright.chromium().launch()) {
+            Page page = browser.newPage();
+            String urlName = new PipelineConsoleViewAction(run).getUrlName();
+            page.navigate(j.getURL() + run.getUrl() + urlName);
+
+            page.click("#pgv-cancel");
+
+            SemaphoreStep.waitForStart("wait/1", run);
+            await().until(() -> run.isBuilding(), is(false));
+
+            SemaphoreStep.success("wait/1", null);
+
+            j.assertBuildStatus(Result.ABORTED, run);
+        }
+    }
+
+}

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
@@ -1,14 +1,16 @@
 package io.jenkins.plugins.pipelinegraphview;
 
-import static org.awaitility.Awaitility.await;
-import static org.hamcrest.CoreMatchers.is;
-
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.Response;
 import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
 import io.jenkins.plugins.pipelinegraphview.consoleview.PipelineConsoleViewAction;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
+
+import static org.junit.Assert.assertTrue;
+
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.jupiter.api.Test;
@@ -20,22 +22,21 @@ class PipelineGraphViewCancelTest {
 
     @Test
     void cancelButtonCancelsBuild(JenkinsRule j) throws Exception {
-        WorkflowRun run = TestUtils.createAndRunJob(j, "indefiniteWait", "indefiniteWait.jenkinsfile", Result.SUCCESS);
+        QueueTaskFuture<WorkflowRun> futureRun = TestUtils.createAndRunJobNoWait(j, "indefiniteWait", "indefiniteWait.jenkinsfile");
+        WorkflowRun run = futureRun.waitForStart();
+        SemaphoreStep.waitForStart("wait/1", run);
+        cancelRun(j, run);
+        SemaphoreStep.success("wait/1", null);
+        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run));
+    }
 
+    private static void cancelRun(JenkinsRule j, WorkflowRun run) throws Exception {
         try (Playwright playwright = Playwright.create();
                 Browser browser = playwright.chromium().launch()) {
             Page page = browser.newPage();
             String urlName = new PipelineConsoleViewAction(run).getUrlName();
             page.navigate(j.getURL() + run.getUrl() + urlName);
-
             page.click("#pgv-cancel");
-
-            SemaphoreStep.waitForStart("wait/1", run);
-            await().until(() -> run.isBuilding(), is(false));
-
-            SemaphoreStep.success("wait/1", null);
-
-            j.assertBuildStatus(Result.ABORTED, run);
         }
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
@@ -2,21 +2,16 @@ package io.jenkins.plugins.pipelinegraphview;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
-import com.microsoft.playwright.Response;
 import hudson.model.Result;
 import io.jenkins.plugins.pipelinegraphview.consoleview.PipelineConsoleViewAction;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
-import jenkins.test.RunMatchers;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.jupiter.api.Test;
-import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
@@ -1,42 +1,61 @@
 package io.jenkins.plugins.pipelinegraphview;
 
-import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.Page;
-import com.microsoft.playwright.Playwright;
-import com.microsoft.playwright.options.AriaRole;
+import com.microsoft.playwright.junit.UsePlaywright;
 import hudson.model.Result;
-import hudson.model.queue.QueueTaskFuture;
-import io.jenkins.plugins.pipelinegraphview.consoleview.PipelineConsoleViewAction;
+import io.jenkins.plugins.pipelinegraphview.playwright.ManageAppearancePage;
+import io.jenkins.plugins.pipelinegraphview.playwright.PipelineJobPage;
+import io.jenkins.plugins.pipelinegraphview.playwright.PlaywrightConfig;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.function.ThrowingSupplier;
 
 @WithJenkins
+@UsePlaywright(PlaywrightConfig.class)
 class PipelineGraphViewCancelTest {
 
+    private static final Logger log = LoggerFactory.getLogger(PipelineGraphViewCancelTest.class);
+
     @Test
-    void cancelButtonCancelsBuild(JenkinsRule j) throws Exception {
-        QueueTaskFuture<WorkflowRun> futureRun =
-                TestUtils.createAndRunJobNoWait(j, "indefiniteWait", "indefiniteWait.jenkinsfile");
-        WorkflowRun run = futureRun.waitForStart();
+    void cancelButtonCancelsBuild(Page p, JenkinsRule j) throws Exception {
+        WorkflowRun run = setupJenkins(p, j.jenkins.getRootUrl(), (ThrowingSupplier<WorkflowRun>)
+                () -> TestUtils.createAndRunJobNoWait(j, "indefiniteWait", "indefiniteWait.jenkinsfile")
+                        .waitForStart());
         SemaphoreStep.waitForStart("wait/1", run);
-        cancelRun(j, run);
+        new PipelineJobPage(p, run.getParent())
+                .goTo()
+                .hasBuilds(1)
+                .nthBuild(0)
+                .goToBuild()
+                .goToPipelineOverview()
+                .cancel();
         SemaphoreStep.success("wait/1", null);
         j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run));
     }
 
-    private static void cancelRun(JenkinsRule j, WorkflowRun run) throws Exception {
-        try (Playwright playwright = Playwright.create();
-                Browser browser = playwright.chromium().launch()) {
-            Page page = browser.newPage();
-            String urlName = new PipelineConsoleViewAction(run).getUrlName();
-            page.navigate(j.getURL() + run.getUrl() + urlName);
-            page.click("#pgv-cancel");
-            page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Yes"))
-                    .click();
-        }
+    private WorkflowRun setupJenkins(Page p, String rootUrl, Supplier<WorkflowRun> setupRun) {
+        CompletableFuture<WorkflowRun> run = CompletableFuture.supplyAsync(setupRun);
+        CompletableFuture<Void> jenkinsSetup = CompletableFuture.runAsync(() -> {
+            log.info("Setting up Jenkins to have the Pipeline Graph View on all pages");
+            new ManageAppearancePage(p, rootUrl)
+                    .goTo()
+                    .displayPipelineOnJobPage()
+                    .displayPipelineOnBuildPage()
+                    .setPipelineGraphAsConsoleProvider()
+                    .save();
+            log.info("Jenkins setup complete");
+        });
+
+        CompletableFuture.allOf(run, jenkinsSetup).join();
+
+        return run.join();
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/playwright/PipelineOverviewPage.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/playwright/PipelineOverviewPage.java
@@ -132,4 +132,11 @@ public class PipelineOverviewPage extends JenkinsPage<PipelineOverviewPage> {
         tree.stageIsVisible(stage);
         return this;
     }
+
+    public PipelineOverviewPage cancel() {
+        page.click("#pgv-cancel");
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Yes"))
+                .click();
+        return this;
+    }
 }

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/configure-appearance.yml
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/configure-appearance.yml
@@ -1,0 +1,7 @@
+appearance:
+  consoleUrlProvider:
+    providers:
+      - "pipelineGraphView"
+  pipelineGraphView:
+    showGraphOnBuildPage: true
+    showGraphOnJobPage: true

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/indefiniteWait.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/indefiniteWait.jenkinsfile
@@ -1,0 +1,10 @@
+pipeline {
+    agent any
+    stages {
+        stage('Wait') {
+            steps {
+                semaphore 'wait'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #478. Adds a `Cancel` button to the pipeline overview when a build is running.

### Testing done

Created a new test using playwright to simulate clicking the cancel button on the pipeline overview page of a running build.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
