### PR TITLE
Add choices to rebuild button

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
+      <artifactId>rebuild</artifactId>
+      <version>338.va_0a_b_50e29397</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>ionicons-api</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,12 +55,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
-      <artifactId>rebuild</artifactId>
-      <version>338.va_0a_b_50e29397</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>ionicons-api</artifactId>
     </dependency>

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -8,6 +8,7 @@ import hudson.Plugin;
 import hudson.model.Action;
 import hudson.model.BallColor;
 import hudson.model.Item;
+import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Queue;
 import hudson.security.Permission;
 import hudson.util.HttpResponses;
@@ -55,10 +56,11 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
         return run.getDisplayName();
     }
 
-    public boolean isRebuildPluginAvailable() {
+    public boolean isRebuildAvailable() {
         Plugin rebuildPlugin = Jenkins.get().getPlugin("rebuild");
-        if (rebuildPlugin != null) {
-            return rebuildPlugin.getWrapper().isEnabled();
+        if (rebuildPlugin != null && rebuildPlugin.getWrapper().isEnabled()) {
+            // limit rebuild to parameterized jobs otherwise it duplicates rerun's behaviour
+            return run.getParent().getProperty(ParametersDefinitionProperty.class) != null;
         }
         return false;
     }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -4,6 +4,7 @@ import static io.jenkins.plugins.pipelinegraphview.consoleview.PipelineConsoleVi
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import hudson.Plugin;
 import hudson.model.Action;
 import hudson.model.BallColor;
 import hudson.model.Item;
@@ -15,6 +16,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkins.ui.icon.IconSpec;
 import org.jenkinsci.plugins.workflow.cps.replay.ReplayAction;
@@ -51,6 +53,14 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
 
     public String getBuildDisplayName() {
         return run.getDisplayName();
+    }
+
+    public boolean isRebuildPluginAvailable() {
+        Plugin rebuildPlugin = Jenkins.get().getPlugin("rebuild");
+        if (rebuildPlugin != null) {
+            return rebuildPlugin.getWrapper().isEnabled();
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/AbstractPipelineViewAction.java
@@ -64,11 +64,11 @@ public abstract class AbstractPipelineViewAction implements Action, IconSpec {
     }
 
     /**
-     * Handles the rebuild request using ReplayAction feature
+     * Handles the rerun request using ReplayAction feature
      */
     @RequirePOST
     @JavaScriptMethod
-    public boolean doRebuild() throws IOException, ExecutionException {
+    public boolean doRerun() throws IOException, ExecutionException {
         if (run != null) {
             run.checkAnyPermission(Item.BUILD);
             ReplayAction replayAction = run.getAction(ReplayAction.class);

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -25,22 +25,10 @@
                                 icon="symbol-chevron-down"
                                 tooltip="${null}"
                                 clazz="jenkins-button jenkins-!-build-color">
-                                <dd:custom>
-                                    <button id="pgv-replay" class="jenkins-dropdown__item">
-                                        <div class="jenkins-dropdown__item__icon">
-                                            <l:icon src="symbol-arrow-redo-outline plugin-ionicons-api" />
-                                        </div>
-                                        ${%Replay}
-                                    </button>
-                                    <j:if test="${it.rebuildPluginAvailable}">
-                                        <button id="pgv-rebuild" class="jenkins-dropdown__item">
-                                            <div class="jenkins-dropdown__item__icon">
-                                                <l:icon src="symbol-play-outline plugin-ionicons-api"/>
-                                            </div>
-                                            ${%Rebuild}
-                                        </button>
-                                    </j:if>
-                                </dd:custom>
+                                <dd:item icon="symbol-arrow-redo-outline plugin-ionicons-api" id="pgv-replay" text="${%Replay}" href="../replay" />
+                                <j:if test="${it.rebuildAvailable}">
+                                    <dd:item icon="symbol-play-outline plugin-ionicons-api" id="pgv-rebuild" text="${%Rebuild}" href="../rebuild/parameterized" />
+                                </j:if>
                             </l:overflowButton>
                         </div>
                     </l:hasPermission>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:dd="/lib/layout/dropdowns">
     <l:layout title="${it.buildDisplayName} - ${it.fullProjectDisplayName}">
         <l:main-panel>
             <link rel="stylesheet" href="${resURL}/plugin/pipeline-graph-view/js/style.css" type="text/css" />
@@ -12,12 +12,37 @@
                     <l:hasPermission permission="${it.permission}">
                         <j:set var="proxyId" value="${h.generateId()}" />
                         <st:bind value="${it}" var="rebuildAction${proxyId}"/>
-                        <button id="pgv-rebuild" data-success-message="${%Build scheduled}"
-                                data-proxy-name="rebuildAction${proxyId}"
-                                class="jenkins-button jenkins-!-build-color">
-                            <l:icon src="symbol-play-outline plugin-ionicons-api"/>
-                            ${%Rebuild}
-                        </button>
+                        <div class="jenkins-split-button">
+                            <button id="pgv-replay-now" data-success-message="${%Build scheduled}"
+                                    data-proxy-name="rebuildAction${proxyId}"
+                                    class="jenkins-button jenkins-!-build-color">
+                                <div class="jenkins-dropdown__item__icon">
+                                    <l:icon src="symbol-refresh-outline plugin-ionicons-api"/>
+                                </div>
+                                ${%Replay Now}
+                            </button>
+                            <l:overflowButton id="button-install-after-restart"
+                                icon="symbol-chevron-down"
+                                tooltip="${null}"
+                                clazz="jenkins-button jenkins-!-build-color">
+                                <dd:custom>
+                                    <button id="pgv-replay" class="jenkins-dropdown__item">
+                                        <div class="jenkins-dropdown__item__icon">
+                                            <l:icon src="symbol-arrow-redo-outline plugin-ionicons-api" />
+                                        </div>
+                                        ${%Replay}
+                                    </button>
+                                    <j:if test="${it.rebuildPluginAvailable}">
+                                        <button id="pgv-rebuild" class="jenkins-dropdown__item">
+                                            <div class="jenkins-dropdown__item__icon">
+                                                <l:icon src="symbol-play-outline plugin-ionicons-api"/>
+                                            </div>
+                                            ${%Rebuild}
+                                        </button>
+                                    </j:if>
+                                </dd:custom>
+                            </l:overflowButton>
+                        </div>
                     </l:hasPermission>
                 </j:if>
                 <l:hasPermission permission="${it.configurePermission}">

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -21,7 +21,7 @@
                                 </div>
                                 ${%Rerun}
                             </button>
-                            <l:overflowButton id="button-install-after-restart"
+                            <l:overflowButton id="pgv-rerun-overflow"
                                 icon="symbol-chevron-down"
                                 tooltip="${null}"
                                 clazz="jenkins-button jenkins-!-build-color">

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -11,15 +11,15 @@
                 <j:if test="${it.buildable}">
                     <l:hasPermission permission="${it.permission}">
                         <j:set var="proxyId" value="${h.generateId()}" />
-                        <st:bind value="${it}" var="rebuildAction${proxyId}"/>
+                        <st:bind value="${it}" var="rerunAction${proxyId}"/>
                         <div class="jenkins-split-button">
-                            <button id="pgv-replay-now" data-success-message="${%Build scheduled}"
-                                    data-proxy-name="rebuildAction${proxyId}"
+                            <button id="pgv-rerun" data-success-message="${%Build scheduled}"
+                                    data-proxy-name="rerunAction${proxyId}"
                                     class="jenkins-button jenkins-!-build-color">
                                 <div class="jenkins-dropdown__item__icon">
                                     <l:icon src="symbol-refresh-outline plugin-ionicons-api"/>
                                 </div>
-                                ${%Replay Now}
+                                ${%Rerun}
                             </button>
                             <l:overflowButton id="button-install-after-restart"
                                 icon="symbol-chevron-down"

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.properties
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.properties
@@ -1,0 +1,3 @@
+Rerun=Re-run
+Replay=Replay
+Rebuild=Rebuild

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -1,13 +1,13 @@
-const rebuildButton = document.getElementById('pgv-rebuild');
+const rerunButton = document.getElementById('pgv-rerun');
 
-if (rebuildButton) {
-  rebuildButton.addEventListener('click', event => {
+if (rerunButton) {
+  rerunButton.addEventListener('click', event => {
     event.preventDefault();
-    const rebuildAction = window[`${rebuildButton.dataset.proxyName}`];
-    rebuildAction.doRebuild(function (success) {
+    const rerunAction = window[`${rerunButton.dataset.proxyName}`];
+    rerunAction.doRerun(function (success) {
       const result = success.responseJSON;
       if (result) {
-        window.hoverNotification(rebuildButton.dataset.successMessage, rebuildButton);
+        window.hoverNotification(rerunButton.dataset.successMessage, rerunButton);
       }
     });
   })

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewRebuildTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewRebuildTest.java
@@ -48,7 +48,7 @@ class PipelineGraphViewRebuildTest {
             Response navigate = page.navigate(j.getURL() + run.getUrl() + urlName);
             String currentUrl = navigate.url();
 
-            page.click("#pgv-rebuild");
+            page.click("#pgv-rerun");
             String newUrl = page.url();
 
             assertEquals(currentUrl, newUrl);


### PR DESCRIPTION
Fixes #756 , #618.

Replaced the rebuild button with a split-button offering:

- Re-run (current behavior) 
- Replay (pipeline replay task to edit and then run) 
- Rebuild (depends on the rebuilder plugin being available, edit parents and then run) 


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
