### PR TITLE
Use user avatars for User causes

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/UserIdCauseRunDetailsItem.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/UserIdCauseRunDetailsItem.java
@@ -3,9 +3,10 @@ package io.jenkins.plugins.pipelinegraphview.cards.items;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.User;
+import hudson.tasks.UserAvatarResolver;
 import io.jenkins.plugins.pipelinegraphview.Messages;
 import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem;
-import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem.Icon.Ionicon;
+import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem.Icon.SimpleIcon;
 import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem.ItemContent;
 import java.util.HashMap;
 import java.util.List;
@@ -26,8 +27,9 @@ public class UserIdCauseRunDetailsItem {
                 .map(userIdCause -> (Cause.UserIdCause) userIdCause)
                 .map(userIdCause -> User.get(userIdCause.getUserId(), false, new HashMap<>()))
                 .filter(Objects::nonNull)
-                .map(user -> ItemContent.of(Messages.cause_user(user.getDisplayName())))
-                .<RunDetailsItem>map(content -> new RunDetailsItem.RunDetail(new Ionicon("person-outline"), content))
+                .<RunDetailsItem>map(user -> new RunDetailsItem.RunDetail(
+                        new SimpleIcon(UserAvatarResolver.resolve(user, "48x48")),
+                        ItemContent.of(Messages.cause_user(user.getDisplayName()))))
                 .findAny();
     }
 }

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/cards/RunDetailsItem/RunDetail/description.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/cards/RunDetailsItem/RunDetail/description.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
     <div>
-        <l:icon src="${it.icon()}"/>
+        <l:icon src="${it.icon()}" class="jenkins-avatar" />
         <span tooltip="${it.tooltip()}">
             <st:include page="description.jelly" it="${it.content()}" />
         </span>

--- a/src/main/webapp/js/style.css
+++ b/src/main/webapp/js/style.css
@@ -43,7 +43,7 @@ h1 {
       color: inherit;
     }
 
-    svg {
+    svg, img {
       width: 1.125rem;
       height: 1.125rem;
     }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/UserIdCauseRunDetailsItemTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/UserIdCauseRunDetailsItemTest.java
@@ -80,6 +80,6 @@ class UserIdCauseRunDetailsItemTest {
 
         assertEquals(
                 new RunDetailsItem.ItemContent.PlainContent(Messages.cause_user("User Id")), userDetails.content());
-        assertEquals("symbol-person-outline plugin-ionicons-api", userDetails.icon());
+        assertEquals("symbol-person-circle", userDetails.icon());
     }
 }


### PR DESCRIPTION
**Before**
<img width="552" alt="image" src="https://github.com/user-attachments/assets/f738b302-588b-494c-94e6-b6002246455b" />

**After**
<img width="687" alt="image" src="https://github.com/user-attachments/assets/bf718eba-2afa-4a68-868b-52eae978c1a2" />

### Testing done

* Avatar shows as expected
* User with no avatar falls back to default core symbol

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
