### PR TITLE
Hide cancel button when pipeline completes

### DIFF
--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -42,25 +42,25 @@ if (cancelButton) {
     } else {
       execute();
     }
-
-    function updateCancelButton() {
-      const buildCaption = document.querySelector(".jenkins-build-caption");
-      const url = buildCaption.dataset.statusUrl;
-      fetch(url).then((rsp) => {
-        if (rsp.ok) {
-          const isBuilding = rsp.headers.get("X-Building");
-          if (isBuilding === "true") {
-            setTimeout(updateCancelButton, 5000);
-          } else {
-            cancelButton.style.display = "none";
-          }
-        }
-        return null;
-      })
-      .catch((error) => {
-        console.error("Error fetching build caption statsus:", error);
-      })
-    }
-    setTimeout(updateCancelButton, 5000);
   })
+
+  function updateCancelButton() {
+    const buildCaption = document.querySelector(".jenkins-build-caption");
+    const url = buildCaption.dataset.statusUrl;
+    fetch(url).then((rsp) => {
+      if (rsp.ok) {
+        const isBuilding = rsp.headers.get("X-Building");
+        if (isBuilding === "true") {
+          setTimeout(updateCancelButton, 5000);
+        } else {
+          cancelButton.style.display = "none";
+        }
+      }
+      return null;
+    })
+    .catch((error) => {
+      console.error("Error fetching build caption statsus:", error);
+    })
+  }
+  setTimeout(updateCancelButton, 5000);
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
@@ -1,12 +1,19 @@
 package io.jenkins.plugins.pipelinegraphview;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Locator.WaitForOptions;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.junit.UsePlaywright;
+import com.microsoft.playwright.options.AriaRole;
+import com.microsoft.playwright.options.WaitForSelectorState;
 import hudson.model.Result;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.pipelinegraphview.playwright.PipelineJobPage;
+import io.jenkins.plugins.pipelinegraphview.playwright.PipelineOverviewPage;
 import io.jenkins.plugins.pipelinegraphview.playwright.PlaywrightConfig;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -23,14 +30,47 @@ class PipelineGraphViewCancelTest {
         WorkflowRun run = TestUtils.createAndRunJobNoWait(j, "indefiniteWait", "indefiniteWait.jenkinsfile")
                 .waitForStart();
         SemaphoreStep.waitForStart("wait/1", run);
+        PipelineOverviewPage op = new PipelineJobPage(p, run.getParent())
+                .goTo()
+                .hasBuilds(1)
+                .nthBuild(0)
+                .goToBuild()
+                .goToPipelineOverview();
+
+        assertTrue(p.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel"))
+                .isVisible());
+
+        op.cancel();
+
+        SemaphoreStep.success("wait/1", null);
+        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run));
+
+        Locator cancelLocator = p.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel"));
+        cancelLocator.waitFor(new WaitForOptions().setState(WaitForSelectorState.HIDDEN));
+        assertTrue(cancelLocator.isHidden());
+    }
+
+    @Test
+    @ConfiguredWithCode("configure-appearance.yml")
+    void cancelButtonDisappears(Page p, JenkinsConfiguredWithCodeRule j) throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJobNoWait(j, "indefiniteWait", "indefiniteWait.jenkinsfile")
+                .waitForStart();
+        SemaphoreStep.waitForStart("wait/1", run);
         new PipelineJobPage(p, run.getParent())
                 .goTo()
                 .hasBuilds(1)
                 .nthBuild(0)
                 .goToBuild()
-                .goToPipelineOverview()
-                .cancel();
+                .goToPipelineOverview();
+
+        assertTrue(p.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel"))
+                .isVisible());
+
         SemaphoreStep.success("wait/1", null);
-        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run));
+        j.assertBuildStatus(Result.SUCCESS, j.waitForCompletion(run));
+
+        Locator cancelLocator = p.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel"));
+        cancelLocator.waitFor(new WaitForOptions().setState(WaitForSelectorState.HIDDEN));
+        assertTrue(cancelLocator.isHidden());
     }
 }


### PR DESCRIPTION
Fixes #795.

Moved the `updateCancelButton()` function out of the cancel button click event handler. This function will run every 5s while the cancel button is visible so that the button can be hidden when the pipeline completes for any reason.
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
