### PR TITLE
Don't select first unsuccessful step when the pipeline is running

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.ts
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.ts
@@ -108,8 +108,9 @@ export function useStepsPoller(props: RunPollerProps) {
         case Result.unstable:
         case Result.failure:
         case Result.aborted:
-          if (selectedStepResult && stepResult < selectedStepResult) {
-            // Return first unstable/failed/aborted step which has a state worse than the selectedStep.
+          if (run?.complete && selectedStepResult && stepResult < selectedStepResult) {
+            // If the run is complete return first unstable/failed/aborted step which has a state worse 
+            // than the selectedStep.
             // E.g. if the first step state is failure we want to return that over a later unstable step.
             return step;
           }

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.ts
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.ts
@@ -108,8 +108,12 @@ export function useStepsPoller(props: RunPollerProps) {
         case Result.unstable:
         case Result.failure:
         case Result.aborted:
-          if (run?.complete && selectedStepResult && stepResult < selectedStepResult) {
-            // If the run is complete return first unstable/failed/aborted step which has a state worse 
+          if (
+            run?.complete &&
+            selectedStepResult &&
+            stepResult < selectedStepResult
+          ) {
+            // If the run is complete return first unstable/failed/aborted step which has a state worse
             // than the selectedStep.
             // E.g. if the first step state is failure we want to return that over a later unstable step.
             return step;

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewTest.java
@@ -7,7 +7,6 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.pipelinegraphview.playwright.PipelineJobPage;
-import io.jenkins.plugins.pipelinegraphview.playwright.PipelineOverviewPage;
 import io.jenkins.plugins.pipelinegraphview.playwright.PlaywrightConfig;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineState;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
@@ -71,14 +70,17 @@ class PipelineGraphViewTest {
                 .waitForStart();
         SemaphoreStep.waitForStart("wait/1", run);
 
-        PipelineOverviewPage op = new PipelineJobPage(p, run.getParent())
+        new PipelineJobPage(p, run.getParent())
                 .goTo()
                 .hasBuilds(1)
                 .nthBuild(0)
                 .goToBuild()
-                .goToPipelineOverview();
+                .goToPipelineOverview()
+                .hasStagesInGraph(2, "Caught1", "Runs1")
+                .stageIsVisibleInTree("Parallel1")
+                .stageIsVisibleInTree("Runs1")
+                .stageIsSelected("Runs1");
 
-        op.stageIsSelected("Runs1");
         SemaphoreStep.success("wait/1", run);
         j.assertBuildStatus(Result.SUCCESS, j.waitForCompletion(run));
     }
@@ -95,6 +97,10 @@ class PipelineGraphViewTest {
                 .nthBuild(0)
                 .goToBuild()
                 .goToPipelineOverview()
+                .hasStagesInGraph(2, "Caught1", "Runs1")
+                .stageIsVisibleInTree("Parallel1")
+                .stageIsVisibleInTree("Caught1")
+                .stageIsVisibleInTree("Runs1")
                 .stageIsSelected("Caught1");
     }
 }

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh797_errorAndContinue.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh797_errorAndContinue.jenkinsfile
@@ -1,0 +1,22 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Parallel1') {
+            parallel {
+                stage('Caught1') {
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            error 'Oops'
+                        }
+                    }
+                }
+            }
+       }
+       stage('Runs1') {
+            steps {
+                echo 'success'
+            }
+        }
+    }
+}

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh797_errorAndContinueWithWait.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh797_errorAndContinueWithWait.jenkinsfile
@@ -1,0 +1,22 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Parallel1') {
+            parallel {
+                stage('Caught1') {
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            error 'Oops'
+                        }
+                    }
+                }
+            }
+       }
+       stage('Runs1') {
+            steps {
+                semaphore 'wait'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #797.

Added a check if the run was complete when default selecting the first unsuccessful step in a pipeline.

### Testing done

~~`TODO` - I need to figure out how use playwright to assert that the correct pipeline graph node is selected. Either one has some kind of `-active` class added to its `div` / `a` tag so maybe looking for that on the element with the expected `id` is the best approach.~~

NVM - all of the above already exists in the test util class [PipelineOverviewPage](https://github.com/jenkinsci/pipeline-graph-view-plugin/blob/main/src/test/java/io/jenkins/plugins/pipelinegraphview/playwright/PipelineOverviewPage.java).

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
