### PR TITLE
Add tests from MR 798 as a sanity check

### DIFF
--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewTest.java
@@ -3,22 +3,21 @@ package io.jenkins.plugins.pipelinegraphview;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.junit.UsePlaywright;
 import hudson.model.Result;
-import io.jenkins.plugins.pipelinegraphview.playwright.ManageAppearancePage;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.pipelinegraphview.playwright.PipelineJobPage;
 import io.jenkins.plugins.pipelinegraphview.playwright.PlaywrightConfig;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineState;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.jupiter.api.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.jvnet.hudson.test.Issue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.util.function.ThrowingSupplier;
 
-@WithJenkins
+@WithJenkinsConfiguredWithCode
 @UsePlaywright(PlaywrightConfig.class)
 class PipelineGraphViewTest {
     private static final Logger log = LoggerFactory.getLogger(PipelineGraphViewTest.class);
@@ -28,10 +27,10 @@ class PipelineGraphViewTest {
     // http://localhost:8080/jenkins
 
     @Test
-    void smokeTest(Page p, JenkinsRule j) {
+    @ConfiguredWithCode("configure-appearance.yml")
+    void smokeTest(Page p, JenkinsConfiguredWithCodeRule j) throws Exception {
         String name = "Integration Tests";
-        WorkflowRun run = setupJenkins(p, j.jenkins.getRootUrl(), (ThrowingSupplier<WorkflowRun>)
-                () -> TestUtils.createAndRunJob(j, name, "smokeTest.jenkinsfile", Result.FAILURE));
+        WorkflowRun run = TestUtils.createAndRunJob(j, name, "smokeTest.jenkinsfile", Result.FAILURE);
 
         new PipelineJobPage(p, run.getParent())
                 .goTo()
@@ -62,21 +61,46 @@ class PipelineGraphViewTest {
                 .stageIsVisibleInTree("B2");
     }
 
-    private static WorkflowRun setupJenkins(Page p, String rootUrl, Supplier<WorkflowRun> setupRun) {
-        CompletableFuture<WorkflowRun> run = CompletableFuture.supplyAsync(setupRun);
-        CompletableFuture<Void> jenkinsSetup = CompletableFuture.runAsync(() -> {
-            log.info("Setting up Jenkins to have the Pipeline Graph View on all pages");
-            new ManageAppearancePage(p, rootUrl)
-                    .goTo()
-                    .displayPipelineOnJobPage()
-                    .displayPipelineOnBuildPage()
-                    .setPipelineGraphAsConsoleProvider()
-                    .save();
-            log.info("Jenkins setup complete");
-        });
+    @Issue("GH#797")
+    @Test
+    @ConfiguredWithCode("configure-appearance.yml")
+    void runningStageSelected(Page p, JenkinsConfiguredWithCodeRule j) throws Exception {
+        String name = "gh797";
+        WorkflowRun run = TestUtils.createAndRunJobNoWait(j, name, "gh797_errorAndContinueWithWait.jenkinsfile")
+                .waitForStart();
+        SemaphoreStep.waitForStart("wait/1", run);
 
-        CompletableFuture.allOf(run, jenkinsSetup).join();
+        new PipelineJobPage(p, run.getParent())
+                .goTo()
+                .hasBuilds(1)
+                .nthBuild(0)
+                .goToBuild()
+                .goToPipelineOverview()
+                .hasStagesInGraph(2, "Caught1", "Runs1")
+                .stageIsVisibleInTree("Parallel1")
+                .stageIsVisibleInTree("Runs1")
+                .stageIsSelected("Runs1");
 
-        return run.join();
+        SemaphoreStep.success("wait/1", run);
+        j.assertBuildStatus(Result.SUCCESS, j.waitForCompletion(run));
+    }
+
+    @Test
+    @ConfiguredWithCode("configure-appearance.yml")
+    void failedStageSelected(Page p, JenkinsConfiguredWithCodeRule j) throws Exception {
+        String name = "Pipeline Success Error Caught";
+        WorkflowRun run = TestUtils.createAndRunJob(j, name, "gh797_errorAndContinue.jenkinsfile", Result.SUCCESS);
+
+        new PipelineJobPage(p, run.getParent())
+                .goTo()
+                .hasBuilds(1)
+                .nthBuild(0)
+                .goToBuild()
+                .goToPipelineOverview()
+                .hasStagesInGraph(2, "Caught1", "Runs1")
+                .stageIsVisibleInTree("Parallel1")
+                .stageIsVisibleInTree("Caught1")
+                .stageIsVisibleInTree("Runs1")
+                .stageIsSelected("Caught1");
     }
 }

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh797_errorAndContinue.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh797_errorAndContinue.jenkinsfile
@@ -1,0 +1,22 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Parallel1') {
+            parallel {
+                stage('Caught1') {
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            error 'Oops'
+                        }
+                    }
+                }
+            }
+       }
+       stage('Runs1') {
+            steps {
+                echo 'success'
+            }
+        }
+    }
+}

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh797_errorAndContinueWithWait.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh797_errorAndContinueWithWait.jenkinsfile
@@ -1,0 +1,22 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Parallel1') {
+            parallel {
+                stage('Caught1') {
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            error 'Oops'
+                        }
+                    }
+                }
+            }
+       }
+       stage('Runs1') {
+            steps {
+                semaphore 'wait'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Sanity check to ensure that the tests added in !798 are actually failing on `main` without the associated fixes.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
