### PR TITLE
Don't escape commit messages in changes card tooltip

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItem.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItem.java
@@ -29,7 +29,7 @@ public class ChangesRunDetailsItem {
             toolTipBuilder.append("%s by %s".formatted(commitId, author));
             toolTipBuilder.append(System.lineSeparator());
         }
-        toolTipBuilder.append(changeEntry.getMsgEscaped());
+        toolTipBuilder.append(changeEntry.getMsg());
 
         int numEntries = changeEntries.size();
         if (numEntries > 1) {


### PR DESCRIPTION
Fixes #801.

Replaced `changeEntry.getMsgEscaped()` with `changeEntry.getMsg()`.

The tooltip doesn't support html and so characters do not need to be escaped.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
