### PR TITLE
Consider findWorstWarningBetween for branches of running builds

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/analysis/StatusAndTiming.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/analysis/StatusAndTiming.java
@@ -282,7 +282,12 @@ public class StatusAndTiming {
                         && lastNode instanceof BlockEndNode) { // Check to see if all the action is on other branches
                     BlockStartNode start = ((BlockEndNode) lastNode).getStartNode();
                     if (start.getAction(ThreadNameAction.class) != null) {
-                        return (lastNode.getError() == null) ? GenericStatus.SUCCESS : GenericStatus.FAILURE;
+                        GenericStatus status = GenericStatus.SUCCESS;
+                        WarningAction warningAction = findWorstWarningBetween(start, lastNode);
+                        if (warningAction != null) {
+                            status = GenericStatus.fromResult(warningAction.getResult());
+                        }
+                        return (lastNode.getError() != null) ? GenericStatus.FAILURE : status;
                     }
                 }
 

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/analysis/StatusAndTimingTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/analysis/StatusAndTimingTest.java
@@ -389,7 +389,7 @@ class StatusAndTimingTest {
                          }
                          stage('Passes') {
                            steps {
-                             sleep 1
+                             sleep 2
                              semaphore 'wait'
                            }
                          }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixes #794.

Use [`StatusAndTiming#findWorstWarningBetween`](https://github.com/jenkinsci/pipeline-graph-view-plugin/blob/bceef947ba4369c6580eee4408cc6b1ef140afbe/src/main/java/io/jenkins/plugins/pipelinegraphview/analysis/StatusAndTiming.java#L344-L358) to inform the status of branches while a build is still running.

Detection of [`WarningAction`](https://github.com/jenkinsci/workflow-api-plugin/blob/master/src/main/java/org/jenkinsci/plugins/workflow/actions/WarningAction.java)s in enclosed nodes is the most reliable way to determine a status for `stage` or `parallel` branches. Previously [`StatusAndTiming#findWorstWarningBetween`](https://github.com/jenkinsci/pipeline-graph-view-plugin/blob/bceef947ba4369c6580eee4408cc6b1ef140afbe/src/main/java/io/jenkins/plugins/pipelinegraphview/analysis/StatusAndTiming.java#L344-L358) was only considered for completed pipelines.

### Testing done

`TODO:` I will need to implement a test utility to gather the status of stages and parallel branches for a running pipeline. Currently this is only supported in [`StagesAndParallelBranchesVisitor`](https://github.com/jenkinsci/pipeline-graph-view-plugin/blob/bceef947ba4369c6580eee4408cc6b1ef140afbe/src/test/java/io/jenkins/plugins/pipelinegraphview/analysis/StatusAndTimingTest.java#L1026-L1038) for completed pipelines.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
