### PR TITLE
refactor: extract user permissions to provider

### DIFF
--- a/src/main/frontend/common/user/user-permission-provider.tsx
+++ b/src/main/frontend/common/user/user-permission-provider.tsx
@@ -1,0 +1,59 @@
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+interface UserPermissions {
+  canConfigure: boolean;
+}
+
+type UserPermissionsProviderProps = {
+  children: ReactNode;
+  proxy?: ProxyProps;
+};
+
+type ProxyProps = {
+  configureProxy?: string;
+};
+
+const UserPermissionsContext = createContext<UserPermissions>({
+  canConfigure: false,
+});
+
+type StaplerResponse = {
+  responseJSON?: boolean;
+};
+
+export const UserPermissionsProvider = ({
+  children,
+  proxy,
+}: UserPermissionsProviderProps) => {
+  const [canConfigure, setCanConfigure] = useState(false);
+
+  proxy = proxy ?? {};
+
+  if (proxy.configureProxy) {
+    // The compiler complains if we don't capture to a local variable,
+    // it cannot guarantee that `proxy.configureProxy` won't change to undefined
+    const { configureProxy } = proxy;
+    useEffect(() => {
+      (window as any)[configureProxy]?.hasConfigurePermission(
+        (response: StaplerResponse) => {
+          setCanConfigure(response?.responseJSON || false);
+        },
+      );
+    }, []);
+  }
+
+  return (
+    <UserPermissionsContext value={{ canConfigure }}>
+      {children}
+    </UserPermissionsContext>
+  );
+};
+
+export const useUserPermissions = (): UserPermissions =>
+  useContext(UserPermissionsContext);

--- a/src/main/frontend/pipeline-console-view/app.tsx
+++ b/src/main/frontend/pipeline-console-view/app.tsx
@@ -5,6 +5,7 @@ import {
   LocaleProvider,
   ResourceBundleName,
 } from "../common/i18n/index.ts";
+import { UserPermissionsProvider } from "../common/user/user-permission-provider.tsx";
 import { FilterProvider } from "./pipeline-console/main/providers/filter-provider.tsx";
 import { LayoutPreferencesProvider } from "./pipeline-console/main/providers/user-preference-provider.tsx";
 
@@ -15,15 +16,20 @@ const PipelineConsole = lazy(
 export default function App() {
   const locale = document.getElementById("console-pipeline-root")!.dataset
     .userLocale!;
+  const configureProxy = document.getElementById(
+    "console-pipeline-overflow-root",
+  )?.dataset.proxyName;
   return (
-    <LocaleProvider locale={locale}>
-      <I18NProvider bundles={[ResourceBundleName.messages]}>
-        <FilterProvider>
-          <LayoutPreferencesProvider>
-            <PipelineConsole />
-          </LayoutPreferencesProvider>
-        </FilterProvider>
-      </I18NProvider>
-    </LocaleProvider>
+    <UserPermissionsProvider proxy={{ configureProxy }}>
+      <LocaleProvider locale={locale}>
+        <I18NProvider bundles={[ResourceBundleName.messages]}>
+          <FilterProvider>
+            <LayoutPreferencesProvider>
+              <PipelineConsole />
+            </LayoutPreferencesProvider>
+          </FilterProvider>
+        </I18NProvider>
+      </LocaleProvider>
+    </UserPermissionsProvider>
   );
 }

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -2,10 +2,9 @@ import "./pipeline-console.scss";
 import "../../../pipeline-graph-view/app.scss";
 import "../../../pipeline-graph-view/pipeline-graph/styles/main.scss";
 
-import { useEffect, useState } from "react";
-
 import Dropdown from "../../../common/components/dropdown.tsx";
 import DropdownPortal from "../../../common/components/dropdown-portal.tsx";
+import { useUserPermissions } from "../../../common/user/user-permission-provider.tsx";
 import Skeleton from "./components/skeleton.tsx";
 import Stages from "./components/stages.tsx";
 import StagesCustomization from "./components/stages-customization.tsx";
@@ -23,21 +22,6 @@ export default function PipelineConsole() {
   const currentRunPath = rootElement?.dataset.currentRunPath!;
   const previousRunPath = rootElement?.dataset.previousRunPath;
 
-  const [configurePermission, setConfigurePermission] = useState(false);
-
-  useEffect(() => {
-    const configureDataProxyName = document.getElementById(
-      "console-pipeline-overflow-root",
-    )?.dataset.proxyName;
-    if (configureDataProxyName) {
-      (window as any)[configureDataProxyName]?.hasConfigurePermission(function (
-        enabled: any,
-      ) {
-        setConfigurePermission(enabled?.responseJSON);
-      });
-    }
-  }, [configurePermission]);
-
   const { stageViewPosition, mainViewVisibility } = useLayoutPreferences();
   const {
     openStage,
@@ -54,6 +38,8 @@ export default function PipelineConsole() {
   const showSplitView = loading || (!loading && stages.length > 0);
 
   const isOnlyPlaceholderNode = stages.length === 1 && stages[0].placeholder;
+
+  const { canConfigure } = useUserPermissions();
 
   return (
     <>
@@ -75,7 +61,7 @@ export default function PipelineConsole() {
               icon: CONSOLE,
               href: `../console`,
             },
-            configurePermission ? (
+            canConfigure ? (
               {
                 text: "Configure",
                 icon: SETTINGS,


### PR DESCRIPTION
Extract the configure permission logic to a provider for wider reuse throughout other pages and components.

### Testing done

The configure button still appears as expected on the pipeline console page

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
