### PR TITLE
Set content type for plain text stage logs

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -129,7 +129,7 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
     public void getConsoleText(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
         String nodeId = req.getParameter("nodeId");
 
-        rsp.setContentType("text/plain");
+        rsp.setContentType("text/plain;charset=UTF-8");
 
         if (nodeId == null) {
             logger.error("'consoleText' was not passed 'nodeId'.");

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewTest.java
@@ -113,4 +113,23 @@ class PipelineGraphViewTest {
 
         new PipelineJobPage(p, run.getParent()).goTo().hasBuilds(1).nthBuild(0).hasStages(2, "Parent", "Child");
     }
+
+    @Issue("GH#817")
+    @Test
+    @ConfiguredWithCode("configure-appearance.yml")
+    void unicodePlainTextLogs(Page p, JenkinsConfiguredWithCodeRule j) throws Exception {
+        String name = "Stage with Emoji";
+        WorkflowRun run = TestUtils.createAndRunJob(j, name, "gh817_unicodePlainTextLogs.jenkinsfile", Result.SUCCESS);
+
+        new PipelineJobPage(p, run.getParent())
+                .goTo()
+                .hasBuilds(1)
+                .nthBuild(0)
+                .goToBuild()
+                .goToPipelineOverview()
+                .hasStagesInGraph(1, "echo")
+                .selectStageInGraph("echo")
+                .stageHasSteps("\uD83D\uDE00")
+                .stepContainsText("\uD83D\uDE00", "\uD83D\uDE00");
+    }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/playwright/PipelineConsole.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/playwright/PipelineConsole.java
@@ -69,6 +69,11 @@ class PipelineConsole {
         }
         Locator stepLogs = stepContainer.getByRole(AriaRole.LOG);
         assertThat(stepLogs).containsText(textToFind);
+
+        try (Page plainText = page.waitForPopup(stepContainer.locator("a[href*='log?nodeId=']")::click)) {
+            plainText.waitForLoadState();
+            assertThat(plainText.locator("body")).containsText(textToFind);
+        }
     }
 
     public void stageHasSteps(String step, String... additional) {

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh817_unicodePlainTextLogs.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh817_unicodePlainTextLogs.jenkinsfile
@@ -1,0 +1,10 @@
+pipeline {
+    agent any
+    stages {
+        stage('echo') {
+            steps {
+                echo "😀"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #817

### Testing done

Before the changes to `src/main`, the new automated test fails with:

```
[ERROR] io.jenkins.plugins.pipelinegraphview.PipelineGraphViewTest.unicodePlainTextLogs(Page, JenkinsConfiguredWithCodeRule) -- Time elapsed: 7.152 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 
Locator expected to contain text: 😀
Received: ðŸ˜€
```

After the changes to `src/main`, the new automated test passes.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
