### PR TITLE
Improve accessibility for opening logs in plain text

### DIFF
--- a/src/main/frontend/common/i18n/i18n-provider.tsx
+++ b/src/main/frontend/common/i18n/i18n-provider.tsx
@@ -45,3 +45,7 @@ export const I18NProvider: FunctionComponent<I18NProviderProps> = ({
     <I18NContext.Provider value={messages}>{children}</I18NContext.Provider>
   );
 };
+
+export function useMessages() {
+  return useContext(I18NContext);
+}

--- a/src/main/frontend/common/i18n/messages.ts
+++ b/src/main/frontend/common/i18n/messages.ts
@@ -81,6 +81,7 @@ export enum LocalizedMessageKey {
   start = "node.start",
   end = "node.end",
   changesSummary = "changes.summary",
+  consoleNewTab = "console.newTab",
 }
 
 const DEFAULT_MESSAGES: ResourceBundle = {
@@ -96,6 +97,7 @@ const DEFAULT_MESSAGES: ResourceBundle = {
   [LocalizedMessageKey.start]: "Start",
   [LocalizedMessageKey.end]: "End",
   [LocalizedMessageKey.changesSummary]: "{0} {0,choice,1#change|1<changes}",
+  [LocalizedMessageKey.consoleNewTab]: "View step as plain text",
 };
 
 export function defaultMessages(locale: string): Messages {

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
@@ -9,6 +9,7 @@ import {
 
 import StatusIcon from "../../../common/components/status-icon.tsx";
 import Tooltip from "../../../common/components/tooltip.tsx";
+import { LocalizedMessageKey, useMessages } from "../../../common/i18n";
 import { classNames } from "../../../common/utils/classnames.ts";
 import { Total } from "../../../common/utils/timings.tsx";
 import {
@@ -72,6 +73,8 @@ export default function ConsoleLogCard(props: ConsoleLogCardProps) {
     return `${(size / gib).toFixed(2)}GiB`;
   };
 
+  const messages = useMessages();
+
   return (
     <div className={"pgv-step-detail-group"} key={`step-card-${props.step.id}`}>
       <div
@@ -124,12 +127,13 @@ export default function ConsoleLogCard(props: ConsoleLogCardProps) {
           </div>
         </a>
 
-        <Tooltip content={"View step as plain text"}>
+        <Tooltip content={messages.format(LocalizedMessageKey.consoleNewTab)}>
           <a
             href={`log?nodeId=${props.step.id}`}
             className={"jenkins-button jenkins-button--tertiary"}
             target="_blank"
             rel="noreferrer"
+            aria-label={messages.format(LocalizedMessageKey.consoleNewTab)}
           >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
               <path

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
@@ -33,3 +33,5 @@ FlowNodeWrapper.noStage=System Generated
 
 run.alreadyCancelled=Run was already cancelled
 run.isFinished=Run is already finished
+
+console.newTab=View step as plain text

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/playwright/PipelineConsole.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/playwright/PipelineConsole.java
@@ -70,8 +70,9 @@ class PipelineConsole {
         Locator stepLogs = stepContainer.getByRole(AriaRole.LOG);
         assertThat(stepLogs).containsText(textToFind);
 
-        try (Page plainText = page.waitForPopup(stepContainer.locator("a[href*='log?nodeId=']")::click)) {
-            plainText.waitForLoadState();
+        Locator plainTextLogsLink = stepContainer.getByRole(
+                AriaRole.LINK, new Locator.GetByRoleOptions().setName("View step as plain text"));
+        try (Page plainText = page.context().waitForPage(plainTextLogsLink::click)) {
             assertThat(plainText.locator("body")).containsText(textToFind);
         }
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Driven by #820. Introduce an aria label to describe the open plain text logs link to make it easier for screen readers and not rely on css selectors in the tests.

### Testing done

Updated test code still passes existing tests.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
