### PR TITLE
Fix step header and stage tree not sticking

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.scss
@@ -14,14 +14,14 @@
   &--left {
     --additional-height: 0px;
     position: sticky;
-    top: calc(var(--header-height) + var(--section-padding));
+    top: calc(var(--pgv-header-height) + var(--section-padding));
     height: calc(
       (100vh + var(--additional-height)) -
-        (var(--header-height) + 100px + var(--section-padding))
+        (var(--pgv-header-height) + 100px + var(--section-padding))
     );
     max-height: calc(
       100vh -
-        (var(--header-height) + var(--section-padding) + var(--section-padding))
+        (var(--pgv-header-height) + var(--section-padding) + var(--section-padding))
     );
   }
 

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.scss
@@ -14,7 +14,7 @@
   &--left {
     --additional-height: 0px;
     position: sticky;
-    top: var(--pgv-header-height);
+    top: calc(var(--pgv-header-height) + var(--section-padding));
     height: calc(
       (100vh + var(--additional-height)) -
         (var(--pgv-header-height) + 100px + var(--section-padding))

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.scss
@@ -14,7 +14,7 @@
   &--left {
     --additional-height: 0px;
     position: sticky;
-    top: calc(var(--pgv-header-height) + var(--section-padding));
+    top: var(--pgv-header-height);
     height: calc(
       (100vh + var(--additional-height)) -
         (var(--pgv-header-height) + 100px + var(--section-padding))

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.scss
@@ -21,7 +21,10 @@
     );
     max-height: calc(
       100vh -
-        (var(--pgv-header-height) + var(--section-padding) + var(--section-padding))
+        (
+          var(--pgv-header-height) + var(--section-padding) +
+            var(--section-padding)
+        )
     );
   }
 

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/console-log-card.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/console-log-card.scss
@@ -9,7 +9,7 @@
 
 .pgv-step-detail-header {
   position: sticky;
-  top: calc(var(--pgv-header-height) + var(--section-padding));
+  top: calc(var(--pgv-header-height) + 0.375rem);
   z-index: 1;
   display: grid;
   grid-template-columns: 1fr auto;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/console-log-card.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/console-log-card.scss
@@ -9,7 +9,7 @@
 
 .pgv-step-detail-header {
   position: sticky;
-  top: calc(var(--header-height) + 0.375rem);
+  top: var(--pgv-header-height);
   z-index: 1;
   display: grid;
   grid-template-columns: 1fr auto;
@@ -101,7 +101,7 @@
 
 .pgv-show-more-logs {
   position: sticky;
-  top: calc(var(--header-height) + 0.375rem + 0.375rem + 2.375rem);
+  top: calc(var(--pgv-header-height) + 0.375rem + 0.375rem + 2.375rem);
   background: var(--card-background);
   box-shadow: 0 0 0.375rem var(--card-background);
   z-index: 10;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/console-log-card.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/console-log-card.scss
@@ -9,7 +9,7 @@
 
 .pgv-step-detail-header {
   position: sticky;
-  top: var(--pgv-header-height);
+  top: calc(var(--pgv-header-height) + var(--section-padding));
   z-index: 1;
   display: grid;
   grid-template-columns: 1fr auto;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -1,3 +1,8 @@
+:root {
+  // can be removed and `--header-height` used directly when jenkins baseline is 2.507
+  --pgv-header-height: var(--header-height, 4.125rem)
+}
+
 .ansi-fg-0 {
   color: var(--black, #333);
 }
@@ -65,7 +70,7 @@
 
 .pgv-sticky-sidebar {
   position: sticky;
-  top: calc(var(--header-height) + var(--section-padding));
+  top: var(--pgv-header-height);
 }
 
 .pgv-skeleton-column {

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -1,6 +1,6 @@
 :root {
   // can be removed and `--header-height` used directly when jenkins baseline is 2.507
-  --pgv-header-height: var(--header-height, 45.5938px)
+  --pgv-header-height: var(--header-height, 45.5938px);
 }
 
 .ansi-fg-0 {

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -1,6 +1,6 @@
 :root {
   // can be removed and `--header-height` used directly when jenkins baseline is 2.507
-  --pgv-header-height: var(--header-height, 4.125rem)
+  --pgv-header-height: var(--header-height, 45.5938px)
 }
 
 .ansi-fg-0 {
@@ -70,7 +70,7 @@
 
 .pgv-sticky-sidebar {
   position: sticky;
-  top: var(--pgv-header-height);
+  top: calc(var(--pgv-header-height) + var(--section-padding));
 }
 
 .pgv-skeleton-column {


### PR DESCRIPTION
The [`--header-height`](https://github.com/jenkinsci/jenkins/blob/817ba7282424274be567eda21f8b8dcde3913914/src/main/scss/abstracts/_theme.scss#L77
) variable doesn't exist in jenkins-core until the baseline targets [`2.507`](https://www.jenkins.io/changelog/#v2.507).

As such an appropriate value based on the height off the breadcrumbs bar has been used as a fallback

Fixes #739

### Testing done

Visual checks manually.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
