### PR TITLE
Flatten skipped stage connections when collapsed (and redisplay timings)

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.ts
@@ -140,7 +140,7 @@ export function layoutGraph(
   const timings = createTimings(allNodeColumns, collapsed, showDurations);
   const smallLabels = createSmallLabels(allNodeColumns, collapsed);
   const branchLabels = createBranchLabels(allNodeColumns, collapsed);
-  const connections = createConnections(allNodeColumns);
+  const connections = createConnections(allNodeColumns, collapsed);
 
   // Calculate the size of the graph
   let measuredWidth = 0;
@@ -401,10 +401,6 @@ function createTimings(
     }
     const stage = column.topStage;
 
-    if (stage?.state === Result.skipped) {
-      continue;
-    }
-
     const text = stage?.totalDurationMillis + "";
     if (!text) {
       // shouldn't happen
@@ -501,6 +497,7 @@ function createBranchLabels(
  */
 function createConnections(
   columns: Array<NodeColumn>,
+  collapsed: boolean,
 ): Array<CompositeConnection> {
   const connections: Array<CompositeConnection> = [];
 
@@ -508,7 +505,7 @@ function createConnections(
   let skippedNodes: Array<NodeInfo> = [];
 
   for (const column of columns) {
-    if (column.topStage && column.topStage.state === "skipped") {
+    if (!collapsed && column.topStage?.state === Result.skipped) {
       skippedNodes.push(column.rows[0][0]);
       continue;
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Closes #845

Flattens the connections for a skipped stage when the graph is in "collapsed" mode

This also reverts the changes for #843 (but that can be kept and altered further if we want)

### Testing done

Manual

![image](https://github.com/user-attachments/assets/8a188c3d-3f71-4990-be2d-fdcf5838d8cc)


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
