### PR TITLE
Fetch more logs before showing there's more to see

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsoleModel.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsoleModel.tsx
@@ -6,5 +6,5 @@ export type {
 } from "../../../pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx";
 export { Result } from "../../../pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx";
 
-export const LOG_FETCH_SIZE = 150 * 1024;
+export const LOG_FETCH_SIZE = 5 * 1024 * 1024;
 export const POLL_INTERVAL = 1000;

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
-    public static final long LOG_THRESHOLD = 150 * 1024; // 150KB
+    public static final long LOG_THRESHOLD = 5 * 1024 * 1024; // 10MB
     public static final String URL_NAME = "pipeline-overview";
 
     private static final Logger logger = LoggerFactory.getLogger(PipelineConsoleViewAction.class);
@@ -195,7 +195,7 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
         // This will be a step, so return it's log output.
         // startByte to start getting data from. If negative will startByte from end of string with
         // LOG_THRESHOLD.
-        Long startByte = parseIntWithDefault(req.getParameter("startByte"), -LOG_THRESHOLD);
+        Long startByte = parseIntWithDefault(req.getParameter("startByte"), - LOG_THRESHOLD);
         JSONObject data = getConsoleOutputJson(nodeId, startByte);
         if (data == null) {
             return HttpResponses.errorJSON("Something went wrong - check Jenkins logs.");

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -195,7 +195,7 @@ public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
         // This will be a step, so return it's log output.
         // startByte to start getting data from. If negative will startByte from end of string with
         // LOG_THRESHOLD.
-        Long startByte = parseIntWithDefault(req.getParameter("startByte"), - LOG_THRESHOLD);
+        Long startByte = parseIntWithDefault(req.getParameter("startByte"), -LOG_THRESHOLD);
         JSONObject data = getConsoleOutputJson(nodeId, startByte);
         if (data == null) {
             return HttpResponses.errorJSON("Something went wrong - check Jenkins logs.");

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PipelineConsoleViewAction extends AbstractPipelineViewAction {
-    public static final long LOG_THRESHOLD = 5 * 1024 * 1024; // 10MB
+    public static final long LOG_THRESHOLD = 5 * 1024 * 1024; // 5MB
     public static final String URL_NAME = "pipeline-overview";
 
     private static final Logger logger = LoggerFactory.getLogger(PipelineConsoleViewAction.class);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

I'm a bit worried about watching builds as they run and larger builds as its now transferring a lot more data. Ideally each call should be offsetting so only new data is requested but thats a bigger change.

Will help with things like:
- https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/830
- https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/490

Thoughts?

### Testing done

Tested with some maven builds that had a lot hidden before and now its easier to use.


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
