### PR TITLE
Improve stability of cancel tests

### DIFF
--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
@@ -1,14 +1,11 @@
 package io.jenkins.plugins.pipelinegraphview;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.microsoft.playwright.Locator;
-import com.microsoft.playwright.Locator.WaitForOptions;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.junit.UsePlaywright;
 import com.microsoft.playwright.options.AriaRole;
-import com.microsoft.playwright.options.WaitForSelectorState;
 import hudson.model.Result;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewCancelTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.pipelinegraphview;
 
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.microsoft.playwright.Locator;
@@ -37,17 +38,15 @@ class PipelineGraphViewCancelTest {
                 .goToBuild()
                 .goToPipelineOverview();
 
-        assertTrue(p.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel"))
-                .isVisible());
+        Locator cancelLocator = p.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel"));
+        assertThat(cancelLocator).isVisible();
 
         op.cancel();
 
         SemaphoreStep.success("wait/1", null);
         j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run));
 
-        Locator cancelLocator = p.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel"));
-        cancelLocator.waitFor(new WaitForOptions().setState(WaitForSelectorState.HIDDEN));
-        assertTrue(cancelLocator.isHidden());
+        assertThat(cancelLocator).isHidden();
     }
 
     @Test
@@ -63,14 +62,12 @@ class PipelineGraphViewCancelTest {
                 .goToBuild()
                 .goToPipelineOverview();
 
-        assertTrue(p.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel"))
-                .isVisible());
+        Locator cancelLocator = p.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel"));
+        assertThat(cancelLocator).isVisible();
 
         SemaphoreStep.success("wait/1", null);
         j.assertBuildStatus(Result.SUCCESS, j.waitForCompletion(run));
 
-        Locator cancelLocator = p.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel"));
-        cancelLocator.waitFor(new WaitForOptions().setState(WaitForSelectorState.HIDDEN));
-        assertTrue(cancelLocator.isHidden());
+        assertThat(cancelLocator).isHidden();
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/playwright/PipelineOverviewPage.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/playwright/PipelineOverviewPage.java
@@ -154,9 +154,10 @@ public class PipelineOverviewPage extends JenkinsPage<PipelineOverviewPage> {
     }
 
     public PipelineOverviewPage cancel() {
-        page.click("#pgv-cancel");
-        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Yes"))
-                .click();
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel")).click();
+        Locator dialog = page.getByRole(AriaRole.DIALOG);
+        dialog.getByText("Yes").click();
+        assertThat(dialog).isHidden();
         return this;
     }
 

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/playwright/PipelineOverviewPage.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/playwright/PipelineOverviewPage.java
@@ -154,7 +154,8 @@ public class PipelineOverviewPage extends JenkinsPage<PipelineOverviewPage> {
     }
 
     public PipelineOverviewPage cancel() {
-        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel")).click();
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel"))
+                .click();
         Locator dialog = page.getByRole(AriaRole.DIALOG);
         dialog.getByText("Yes").click();
         assertThat(dialog).isHidden();


### PR DESCRIPTION
An attempt to fix https://github.com/jenkinsci/bom/issues/5276. I wasn't able to recreate the issue locally but looking at the output of the [ci test results](https://ci.jenkins.io/job/Tools/job/bom/job/PR-5295/1/testReport/junit/io.jenkins.plugins.pipelinegraphview/PipelineGraphViewCancelTest/pct_pipeline_graph_view_plugin_weekly___cancelButtonCancelsBuild_Page__JenkinsConfiguredWithCodeRule_/) it appears that the code to wait until the cancel button is hidden is executing before the dialog is closed and as such finds two instances of a cancel button on the page (the button in the dialog and the button to show the dialog).

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
