### PR TITLE
Reduce number of calculations when finding a nodes relationships

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationshipFinder.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationshipFinder.java
@@ -51,20 +51,20 @@ public class NodeRelationshipFinder {
     public Map<String, NodeRelationship> getNodeRelationships(@NonNull Collection<FlowNode> nodes) {
         if (isDebugEnabled) {
             logger.atDebug()
-                .addArgument(() -> nodes.stream().map(FlowNode::getId).collect(Collectors.joining(", ")))
-                .log("Original Ids: {}");
+                    .addArgument(() -> nodes.stream().map(FlowNode::getId).collect(Collectors.joining(", ")))
+                    .log("Original Ids: {}");
         }
         // This is important, determining the relationships depends on the order of
         // iteration.
         // If there was a method to tell if a node was a parallel block this might be
         // less of an issue.
         List<FlowNode> sorted = nodes.stream()
-            .sorted(new FlowNodeWrapper.FlowNodeComparator().reversed())
-            .toList();
+                .sorted(new FlowNodeWrapper.FlowNodeComparator().reversed())
+                .toList();
         if (isDebugEnabled) {
             logger.atDebug()
-                .addArgument(() -> sorted.stream().map(FlowNode::getId).collect(Collectors.joining(", ")))
-                .log("Sorted Ids: {}");
+                    .addArgument(() -> sorted.stream().map(FlowNode::getId).collect(Collectors.joining(", ")))
+                    .log("Sorted Ids: {}");
         }
         sorted.forEach(node -> {
             getRelationshipForNode(node);

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeTreeScanner.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeTreeScanner.java
@@ -106,11 +106,11 @@ public class PipelineNodeTreeScanner {
         scanner.setup(heads);
 
         // nodes that we've visited
-        final List<FlowNode> nodeMap = new ArrayList<>();
+        final List<FlowNode> nodes = new ArrayList<>();
         for (FlowNode n : scanner) {
-            nodeMap.add(n);
+            nodes.add(n);
         }
-        return nodeMap;
+        return nodes;
     }
 
     @NonNull
@@ -338,7 +338,9 @@ public class PipelineNodeTreeScanner {
          * Builds a graph from the list of nodes and relationships given to the class.
          */
         private void buildGraph() {
-            List<FlowNode> nodeList = nodes.stream().sorted(new FlowNodeWrapper.FlowNodeComparator()).toList();
+            List<FlowNode> nodeList = nodes.stream()
+                    .sorted(new FlowNodeWrapper.FlowNodeComparator())
+                    .toList();
             // If the Pipeline ended with an unhandled exception, then we want to catch the
             // node which threw it.
             BlockEndNode<?> nodeThatThrewException = null;


### PR DESCRIPTION
Whilst investigating performance issues of #862 it was noticed that `node.getEnclosingBlocks()` was being called twice in `NodeRelationshipFinder#getFirstEnclosingNode`. Whilst some of the computation of this result was cached, not all of it was which means there is extra work being done that isn't required.

I also noticed that some maps were being passed around that might have once been used as a lookup table but now were only being used to access values.

Some other small cleanup has been done where newer java functionality is available or the code could be simplified.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
