### PR TITLE
Reduce number of calls to FlowNode#getEnclosingId

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationshipFinder.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationshipFinder.java
@@ -96,18 +96,19 @@ public class NodeRelationshipFinder {
     }
 
     private void addSeenNodes(FlowNode node) {
-        if (!seenChildNodes.containsKey(node.getEnclosingId())) {
-            seenChildNodes.put(node.getEnclosingId(), new ArrayDeque<>());
+        String enclosingId = node.getEnclosingId();
+        if (!seenChildNodes.containsKey(enclosingId)) {
+            seenChildNodes.put(enclosingId, new ArrayDeque<>());
         }
         if (isDebugEnabled) {
-            logger.debug("Adding {} to seenChildNodes {}", node.getId(), node.getEnclosingId());
+            logger.debug("Adding {} to seenChildNodes {}", node.getId(), enclosingId);
         }
-        seenChildNodes.get(node.getEnclosingId()).push(node);
+        seenChildNodes.get(enclosingId).push(node);
     }
 
     @CheckForNull
     private FlowNode getAfterNode(FlowNode node) {
-        FlowNode after = null;
+        FlowNode after;
         // The after node is the last child of the enclosing node, except for the last node in
         // a block, then it's the last node in the enclosing nodes list (likely, this blocks end node).
         FlowNode parentStartNode = getFirstEnclosingNode(node);


### PR DESCRIPTION
`FlowNode#getEnclosingId` was being called multiple times in `NodeRelationshipFinder#addSeenNodes`. Whilst the majority of the calculations were cached on the initial call, subsequent looks would still have to acquire locks and checks as it performs the non cached operations. Therefore reduce it to just once.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
