### PR TITLE
Do not reset expanded steps while polling, only extend them

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.spec.ts
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.spec.ts
@@ -141,7 +141,7 @@ it("expanded steps remain expanded", async () => {
     { id: "step-1", title: "Step 1", stageId: "stage-1", state: "running" },
     { id: "step-2", title: "Step 2", stageId: "stage-1", state: "queued" },
   ];
-  (model.getRunSteps as Mock).mockResolvedValue(currentSteps);
+  (model.getRunSteps as Mock).mockResolvedValue({ steps: currentSteps });
 
   const props = { currentRunPath: "/run/1" };
   const { result, unmount, rerender } = renderHook(() => useStepsPoller(props));
@@ -157,7 +157,7 @@ it("expanded steps remain expanded", async () => {
     { id: "step-1", title: "Step 1", stageId: "stage-1", state: "success" },
     { id: "step-2", title: "Step 2", stageId: "stage-1", state: "running" },
   ];
-  (model.getRunSteps as Mock).mockResolvedValue(currentSteps);
+  (model.getRunSteps as Mock).mockResolvedValue({ steps: currentSteps });
 
   // trigger rerun of ?selected-node logic
   (treeApi.default as Mock).mockReturnValue({

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.spec.ts
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.spec.ts
@@ -3,6 +3,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { Mock, vi } from "vitest";
 
+import * as treeApi from "../../../../common/tree-api.ts";
 import * as model from "../PipelineConsoleModel.tsx";
 import { useStepsPoller } from "./use-steps-poller.ts";
 
@@ -122,6 +123,52 @@ it("expands and collapses step when toggled", async () => {
   expect(result.current.expandedSteps).not.toContain("step-2");
 
   act(() => result.current.onStepToggle("step-2"));
+  expect(result.current.expandedSteps).toContain("step-2");
+
+  unmount();
+});
+
+it("expanded steps remain expanded", async () => {
+  window.history.pushState({}, "", "/?selected-node=step-1&start-byte=0");
+
+  (treeApi.default as Mock).mockReturnValue({
+    run: {
+      stages: mockStages,
+      complete: true, // avoid "steps" poller
+    },
+  });
+  let currentSteps = [
+    { id: "step-1", title: "Step 1", stageId: "stage-1", state: "running" },
+    { id: "step-2", title: "Step 2", stageId: "stage-1", state: "queued" },
+  ];
+  (model.getRunSteps as Mock).mockResolvedValue(currentSteps);
+
+  const props = { currentRunPath: "/run/1" };
+  const { result, unmount, rerender } = renderHook(() => useStepsPoller(props));
+  await waitFor(() => expect(result.current.expandedSteps).toContain("step-1"));
+
+  expect(result.current.expandedSteps).toContain("step-1");
+  act(() => result.current.onStepToggle("step-2"));
+  expect(result.current.expandedSteps).toContain("step-1");
+  expect(result.current.expandedSteps).toContain("step-2");
+
+  // Simulate step-1 finishing and step-2 becoming active
+  currentSteps = [
+    { id: "step-1", title: "Step 1", stageId: "stage-1", state: "success" },
+    { id: "step-2", title: "Step 2", stageId: "stage-1", state: "running" },
+  ];
+  (model.getRunSteps as Mock).mockResolvedValue(currentSteps);
+
+  // trigger rerun of ?selected-node logic
+  (treeApi.default as Mock).mockReturnValue({
+    run: { stages: mockStages.slice(0), complete: true },
+  });
+  rerender(props); // happens implicitly from polling.
+
+  await waitFor(() =>
+    expect(result.current.openStageSteps).to.deep.equal(currentSteps),
+  );
+  expect(result.current.expandedSteps).toContain("step-1");
   expect(result.current.expandedSteps).toContain("step-2");
 
   unmount();

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.ts
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.ts
@@ -67,11 +67,12 @@ export function useStepsPoller(props: RunPollerProps) {
       setUserManuallySetNode(true);
 
       const step = steps.find((s) => s.id === selected);
-      const expanded: string[] = [];
-
       if (step) {
         selected = step.stageId;
-        expanded.push(step.id);
+        setExpandedSteps((prev) => {
+          if (prev.includes(step.id)) return prev;
+          return [...prev, step.id];
+        });
 
         updateStepConsoleOffset(
           step.id,
@@ -81,7 +82,6 @@ export function useStepsPoller(props: RunPollerProps) {
       }
 
       setOpenStage(selected);
-      setExpandedSteps(expanded);
       return true;
     },
     [updateStepConsoleOffset],


### PR DESCRIPTION
Closes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/905

Hint: Collapsing a step also marks it as "?selected-node".

Previously, any following polling responses would action on the "?selected-node" again and expand the step that was just collapsed. Also, any other steps that were opened in addition to the last "?selected-node" would be collapsed again. When switching stages, all steps would be collapsed again.
Now, steps do not get collapsed eagerly.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```goovy
pipeline {
    agent any

    stages {
        stage('Hello') {
            steps {
                script {
                    for(int i=1; i<=10; i++) {
                        stage("Stage - ${i}") {
                            sh 'for i in 1 2 3; do sleep 1; echo "Slept ${i} times"; done'
                            sh 'for i in 4 5 6; do sleep 1; echo "Slept ${i} times"; done'
                        }
                    }
                }
            }
        }
    }
}
``` 
- Select the first stage
- Expand all the steps
- Navigate to the second stage
- Navigate back to the first stage
- See all steps open

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
