### PR TITLE
Rework polling of steps

### DIFF
--- a/src/main/frontend/common/RestClient.tsx
+++ b/src/main/frontend/common/RestClient.tsx
@@ -17,6 +17,11 @@ export interface InputStep {
   parameters: boolean;
 }
 
+export interface AllStepsData {
+  steps: StepInfo[];
+  runIsComplete: boolean;
+}
+
 /**
  * StageInfo is the input, in the form of an Array<StageInfo> of the top-level stages of a pipeline
  */
@@ -64,12 +69,12 @@ export async function getRunStatusFromPath(
   }
 }
 
-export async function getRunSteps(): Promise<StepInfo[] | null> {
+export async function getRunSteps(): Promise<AllStepsData | null> {
   try {
     const response = await fetch("allSteps");
     if (!response.ok) throw response.statusText;
     const json = await response.json();
-    return json.data.steps;
+    return json.data;
   } catch (e) {
     console.warn(`Caught error getting steps: '${e}'`);
     return null;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.spec.ts
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.spec.ts
@@ -42,7 +42,7 @@ vi.mock("../PipelineConsoleModel.tsx", async () => ({
 }));
 
 beforeEach(() => {
-  (model.getRunSteps as Mock).mockResolvedValue(mockSteps);
+  (model.getRunSteps as Mock).mockResolvedValue({ steps: mockSteps });
   window.history.pushState({}, "", "/");
 });
 
@@ -88,7 +88,7 @@ it("switches to next stage when current one finishes", async () => {
   ];
 
   (model.getRunSteps as Mock).mockImplementation(() =>
-    Promise.resolve(currentSteps),
+    Promise.resolve({ steps: currentSteps }),
   );
 
   const { result, unmount } = renderHook(() =>
@@ -96,17 +96,17 @@ it("switches to next stage when current one finishes", async () => {
   );
 
   await waitFor(() => expect(result.current.openStage?.id).toBe("stage-1"));
+  expect(result.current.expandedSteps).toContain("s1");
 
   // Simulate stage-1 finishing and stage-2 becoming active
   currentSteps = [
     { id: "s1", title: "Step 1", stageId: "stage-1", state: "success" },
     { id: "s2", title: "Step 2", stageId: "stage-2", state: "running" },
   ];
-  (model.getRunSteps as Mock).mockResolvedValue(currentSteps);
+  (model.getRunSteps as Mock).mockResolvedValue({ steps: currentSteps });
 
-  await waitFor(() => expect(result.current.openStage?.id).toBe("stage-1"));
-
-  expect(result.current.expandedSteps).toContain("s1");
+  await waitFor(() => expect(result.current.openStage?.id).toBe("stage-2"));
+  expect(result.current.expandedSteps).toContain("s2");
 
   unmount();
 });

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.ts
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import useRunPoller from "../../../../common/tree-api.ts";
 import {
@@ -25,8 +25,6 @@ export function useStepsPoller(props: RunPollerProps) {
     new Map<string, StepLogBufferInfo>(),
   );
   const [userManuallySetNode, setUserManuallySetNode] = useState(false);
-
-  const stepsRef = useRef<StepInfo[]>([]);
 
   const updateStepConsoleOffset = useCallback(
     async (stepId: string, forceUpdate: boolean, startByte: number) => {
@@ -130,66 +128,43 @@ export function useStepsPoller(props: RunPollerProps) {
   };
 
   useEffect(() => {
-    getRunSteps()
-      .then((steps) => {
-        steps = steps || [];
-        setSteps(steps);
+    let previousStepsSerialized = "";
+    function updateStepsIfChanged(steps: StepInfo[]) {
+      const nextStepsSerialized = JSON.stringify(steps);
+      if (previousStepsSerialized === nextStepsSerialized) return; // no change
+      previousStepsSerialized = nextStepsSerialized;
 
-        const usedUrl = parseUrlParams(steps);
-        if (!usedUrl) {
-          const defaultStep = getDefaultSelectedStep(steps);
-          if (defaultStep) {
-            setOpenStage(defaultStep.stageId);
+      setSteps(steps);
 
-            if (defaultStep.stageId) {
-              setExpandedSteps((prev) => [...prev, defaultStep.id]);
-              updateStepConsoleOffset(
-                defaultStep.id,
-                false,
-                0 - LOG_FETCH_SIZE,
-              );
-            }
+      const usedUrl = parseUrlParams(steps);
+      if (!usedUrl) {
+        const defaultStep = getDefaultSelectedStep(steps);
+        if (defaultStep) {
+          setOpenStage(defaultStep.stageId);
+
+          if (defaultStep.stageId) {
+            setExpandedSteps((prev) => [...prev, defaultStep.id]);
+            updateStepConsoleOffset(defaultStep.id, false, 0 - LOG_FETCH_SIZE);
           }
         }
+      }
+    }
 
-        if (!run?.complete) {
-          startPollingPipeline({
-            getStateUpdateFn: getRunSteps,
-            onData: (data) => {
-              const hasNewSteps =
-                JSON.stringify(stepsRef.current) !== JSON.stringify(data);
-
-              if (userManuallySetNode) {
-                const defaultStep = getDefaultSelectedStep(steps);
-                if (defaultStep) {
-                  setOpenStage(defaultStep.stageId);
-
-                  if (defaultStep.stageId) {
-                    setExpandedSteps((prev) => [...prev, defaultStep.id]);
-                    updateStepConsoleOffset(
-                      defaultStep.id,
-                      false,
-                      0 - LOG_FETCH_SIZE,
-                    );
-                  }
-                }
-              }
-
-              if (hasNewSteps) {
-                setSteps(data);
-                stepsRef.current = data;
-              }
-            },
-            checkComplete: () => !run?.complete,
-            interval: POLL_INTERVAL,
-          });
-        }
-        return null;
-      })
-      .catch((error) => {
-        console.error("Error in getRunSteps:", error);
-      });
-  }, [run?.stages]);
+    let polling = true;
+    const poll = async () => {
+      while (polling) {
+        const data = await getRunSteps();
+        if (data?.steps) updateStepsIfChanged(data.steps);
+        if (data?.runIsComplete) polling = false;
+        if (!polling) break;
+        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+      }
+    };
+    poll();
+    return () => {
+      polling = false;
+    };
+  }, []);
 
   const handleStageSelect = useCallback(
     (nodeId: string) => {
@@ -268,43 +243,6 @@ export function useStepsPoller(props: RunPollerProps) {
     loading,
   };
 }
-
-/**
- * Starts polling a function until a complete condition is met.
- */
-const startPollingPipeline = ({
-  getStateUpdateFn,
-  onData,
-  checkComplete,
-  interval = 1000,
-}: {
-  getStateUpdateFn: () => Promise<StepInfo[] | null>;
-  onData: (data: StepInfo[]) => void;
-  checkComplete: (data: StepInfo[]) => boolean;
-  interval?: number;
-}): (() => void) => {
-  let polling = true;
-
-  const poll = async () => {
-    while (polling) {
-      const data = (await getStateUpdateFn()) || [];
-      onData(data);
-
-      if (checkComplete(data)) {
-        polling = false;
-        break;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, interval));
-    }
-  };
-
-  setTimeout(poll, interval);
-
-  return () => {
-    polling = false;
-  };
-};
 
 interface RunPollerProps {
   currentRunPath: string;

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -117,8 +117,12 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
     public void getAllSteps(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
         run.checkPermission(Item.READ);
 
+        // Look up completed state before computing steps.
+        boolean runIsComplete = !PipelineState.of(run).isInProgress();
+
         PipelineStepList steps = stepApi.getAllSteps();
         JSONObject json = JSONObject.fromObject(steps, jsonConfig);
+        json.element("runIsComplete", runIsComplete, jsonConfig);
         logger.debug("Steps: '{}'.", json);
         HttpResponse response = HttpResponses.okJSON(json);
 

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -26,7 +26,6 @@ import io.jenkins.plugins.pipelinegraphview.cards.items.UserIdCauseRunDetailsIte
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineGraph;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineGraphApi;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineNodeUtil;
-import io.jenkins.plugins.pipelinegraphview.utils.PipelineState;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineStep;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineStepApi;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineStepList;
@@ -122,14 +121,13 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
         logger.debug("Steps: '{}'.", json);
         HttpResponse response = HttpResponses.okJSON(json);
 
-        setCache(rsp);
-
         rsp.setStatus(200);
+        setCache(rsp, steps.runIsComplete);
         response.generateResponse(req, rsp, null);
     }
 
-    private void setCache(StaplerResponse2 rsp) {
-        if (!PipelineState.of(run).isInProgress()) {
+    private void setCache(StaplerResponse2 rsp, boolean complete) {
+        if (complete) {
             rsp.setHeader("Cache-Control", "private, immutable, max-age=" + CACHE_AGE);
         } else {
             rsp.setHeader("Cache-Control", "private, no-store");
@@ -499,7 +497,7 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
         HttpResponse response = HttpResponses.okJSON(JSONObject.fromObject(tree, jsonConfig));
 
         rsp.setStatus(200);
-        setCache(rsp);
+        setCache(rsp, tree.complete);
         response.generateResponse(req, rsp, null);
     }
 

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -117,12 +117,8 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
     public void getAllSteps(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
         run.checkPermission(Item.READ);
 
-        // Look up completed state before computing steps.
-        boolean runIsComplete = !PipelineState.of(run).isInProgress();
-
         PipelineStepList steps = stepApi.getAllSteps();
         JSONObject json = JSONObject.fromObject(steps, jsonConfig);
-        json.element("runIsComplete", runIsComplete, jsonConfig);
         logger.debug("Steps: '{}'.", json);
         HttpResponse response = HttpResponses.okJSON(json);
 

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraph.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraph.java
@@ -8,7 +8,7 @@ import net.sf.json.processors.JsonBeanProcessor;
 public class PipelineGraph {
 
     final List<PipelineStage> stages;
-    private final boolean complete;
+    public final boolean complete;
 
     public PipelineGraph(List<PipelineStage> stages, boolean complete) {
         this.stages = stages;

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
@@ -82,17 +82,17 @@ public class PipelineStepApi {
         return text.trim();
     }
 
-    private PipelineStepList getSteps(String stageId, PipelineStepBuilderApi builder) {
+    private PipelineStepList getSteps(String stageId, PipelineStepBuilderApi builder, boolean runIsComplete) {
         List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
-        PipelineStepList steps = new PipelineStepList(parseSteps(stepNodes, stageId));
+        PipelineStepList steps = new PipelineStepList(parseSteps(stepNodes, stageId), runIsComplete);
         steps.sort();
         return steps;
     }
 
     /* Returns a PipelineStepList, sorted by stageId and Id. */
-    private PipelineStepList getAllSteps(PipelineStepBuilderApi builder) {
+    private PipelineStepList getAllSteps(PipelineStepBuilderApi builder, boolean runIsComplete) {
         Map<String, List<FlowNodeWrapper>> stepNodes = builder.getAllSteps();
-        PipelineStepList allSteps = new PipelineStepList();
+        PipelineStepList allSteps = new PipelineStepList(runIsComplete);
         for (Map.Entry<String, List<FlowNodeWrapper>> entry : stepNodes.entrySet()) {
             allSteps.addAll(parseSteps(entry.getValue(), entry.getKey()));
         }
@@ -101,11 +101,15 @@ public class PipelineStepApi {
     }
 
     public PipelineStepList getSteps(String stageId) {
-        return getSteps(stageId, CachedPipelineNodeGraphAdaptor.instance.getFor(run));
+        // Look up completed state before computing steps.
+        boolean runIsComplete = !PipelineState.of(run).isInProgress();
+        return getSteps(stageId, CachedPipelineNodeGraphAdaptor.instance.getFor(run), runIsComplete);
     }
 
     /* Returns a PipelineStepList, sorted by stageId and Id. */
     public PipelineStepList getAllSteps() {
-        return getAllSteps(CachedPipelineNodeGraphAdaptor.instance.getFor(run));
+        // Look up completed state before computing steps.
+        boolean runIsComplete = !PipelineState.of(run).isInProgress();
+        return getAllSteps(CachedPipelineNodeGraphAdaptor.instance.getFor(run), runIsComplete);
     }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepList.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepList.java
@@ -9,13 +9,16 @@ import net.sf.json.processors.JsonBeanProcessor;
 public class PipelineStepList {
 
     public final List<PipelineStep> steps;
+    public final boolean runIsComplete;
 
-    public PipelineStepList() {
+    public PipelineStepList(boolean runIsComplete) {
         this.steps = new ArrayList<>();
+        this.runIsComplete = runIsComplete;
     }
 
-    public PipelineStepList(List<PipelineStep> steps) {
+    public PipelineStepList(List<PipelineStep> steps, boolean runIsComplete) {
         this.steps = steps;
+        this.runIsComplete = runIsComplete;
     }
 
     /* Sorts the list of PipelineSteps by stageId and Id. */
@@ -46,6 +49,7 @@ public class PipelineStepList {
             }
             JSONObject json = new JSONObject();
             json.element("steps", stepList.steps, jsonConfig);
+            json.element("runIsComplete", stepList.runIsComplete, jsonConfig);
             return json;
         }
     }


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/757

There were multiple bugs in the previous implementation:

- The "checkComplete" parameter of "startPollingPipeline" had a spurious invert of "run.complete". With the effect that one a single poll was performed.
- A new "steps" polling loop was created after every poll of "run". These poll loops could run concurrently.
- The first steps lookup was performed concurrently to the first lookup of "run". For a "run" that had finished on page load, this meant that a total of three (and potentially more if the "run" request was slow) lookups of "steps" were performed.
- When selecting a step while the "steps" polling is in the "startPollingPipeline" phase, it resets the users selection as part of the automatic step selection. Cause: "userManuallySetNode" is stale.
- The polling loop never advanced the default stage/step as it had the condition for manually selecting a node flipped.
- Even after flipping said condition, it was operating on the "initial" steps as fetched from the top of the useEffect ("steps" vs "data").

Previously, most UI updates were triggered by the "run" polling cycle (3s), despite fetching "steps" more frequently (1s). The "steps" polling loop would merely update the "steps" without actioning them for advancing the default step/stage while a job was running. Now, the "default" stage/step is advanced every second. The "?selected-node" is also picked up every second.

This patch is detaching the polling loops for "run" and "steps". The "steps" response has been extended to include a hint whether the "run" is completed. This is allowing the "steps" polling loop (1s interval) to finish independently from the "run" loop (3s interval).

A single "steps" polling interval will be used moving forward. This is greatly simplifying the fetching/updating of steps.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```groovy
pipeline {
    agent any

    stages {
        stage('Hello') {
            steps {
                script {
                    for(int i=1; i<=3; i++) {
                        stage("Stage - ${i}") {
                            for(int j=1; j<=10; j++) {
                                sh "sleep 1 && echo ${j}"
                            }
                        }
                    }
                }
            }
        }
    }
}
```
- Trigger a build and see how the automatic advancing of the default step is picking up each step (1s update interval). Previously it would pick up every second or third step (3s update interval).

Before | After 
--- | --- 
<img width="284" height="790" alt="image" src="https://github.com/user-attachments/assets/04df7da3-e9bf-4f07-9a93-f59ef04ca9d2" /> | <img width="236" height="904" alt="image" src="https://github.com/user-attachments/assets/00e78827-08cc-4382-9540-033fc81c90a2" />

(Note: The output of steps is not accurate. -> https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/909)

---

- Reload the page after the build finishes
- See a single request for `allSteps`. Previously there would be 3.

---

See fixed test for "switches to next stage when current one finishes", it was expecting \_no\_ change before :detective: 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
