### PR TITLE
Wrap details rather than overflowing

### DIFF
--- a/src/main/webapp/js/style.css
+++ b/src/main/webapp/js/style.css
@@ -25,18 +25,23 @@ h1 {
 .pgv-details {
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1rem 1.5rem;
   margin-left: 0.25rem;
   margin-bottom: 0.875rem;
   margin-top: -0.25rem;
+  flex-wrap: wrap;
+
+  @media (width <= 800px) {
+    margin-block: 0.75rem 1rem;
+  }
 
   & > div {
     display: flex;
     align-items: center;
     gap: 1ch;
-    font-size: 14px;
+    font-size: var(--font-size-sm);
     color: var(--text-color-secondary);
-    font-weight: 450;
+    font-weight: var(--font-bold-weight);
     text-box: trim-both;
 
     a {


### PR DESCRIPTION
Icons get distorted and causes unnecessary page scrolling when there's too many details.

**Before**
<img width="556" height="206" alt="image" src="https://github.com/user-attachments/assets/b0285c32-e874-445a-84e5-a2e432a684e4" />

**After**
<img width="560" height="183" alt="image" src="https://github.com/user-attachments/assets/a48450d7-bd07-4a30-a334-38399b79e70d" />

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
