### PR TITLE
Fetch exception text separately from console output

### DIFF
--- a/src/main/frontend/common/RestClient.tsx
+++ b/src/main/frontend/common/RestClient.tsx
@@ -49,6 +49,8 @@ export interface StepLogBufferInfo {
     promise: Promise<ConsoleLogData | null>;
   };
   fullyFetched?: boolean;
+  exceptionText?: string[];
+  pendingExceptionText?: Promise<string[]>;
 }
 
 // Returned from API, gets converted to 'StepLogBufferInfo'.
@@ -101,6 +103,18 @@ export async function getConsoleTextOffset(
   } catch (e) {
     console.error(`Caught error when fetching console: '${e}'`);
     return null;
+  }
+}
+
+export async function getExceptionText(stepId: string): Promise<string[]> {
+  try {
+    const response = await fetch(`exceptionText?nodeId=${stepId}`);
+    if (!response.ok) throw response.statusText;
+    const text = await response.text();
+    return text.split("\n");
+  } catch (e) {
+    console.error(`Caught error when fetching console: '${e}'`);
+    return [];
   }
 }
 

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.spec.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.spec.tsx
@@ -52,6 +52,7 @@ describe("ConsoleLogCard", () => {
     onMoreConsoleClick: () => {
       console.log("onMoreConsoleClick triggered");
     },
+    fetchExceptionText: () => {},
   } as ConsoleLogCardProps;
 
   it("renders step header only when not expanded", async () => {

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
@@ -29,6 +29,7 @@ export default function ConsoleLogCard({
   isExpanded,
   onMoreConsoleClick,
   onStepToggle,
+  fetchExceptionText,
 }: ConsoleLogCardProps) {
   useEffect(() => {
     if (isExpanded) {
@@ -53,15 +54,7 @@ export default function ConsoleLogCard({
 
   const inputStep = step.inputStep;
   if (inputStep && !inputStep.parameters) {
-    return (
-      <InputStep
-        step={step}
-        stepBuffer={stepBuffer}
-        isExpanded={isExpanded}
-        onStepToggle={onStepToggle}
-        onMoreConsoleClick={onMoreConsoleClick}
-      />
-    );
+    return <InputStep step={step} />;
   }
 
   return (
@@ -151,6 +144,7 @@ export default function ConsoleLogCard({
           step={step}
           stepBuffer={stepBuffer}
           onMoreConsoleClick={onMoreConsoleClick}
+          fetchExceptionText={fetchExceptionText}
           isExpanded={false}
           onStepToggle={onStepToggle}
         />
@@ -163,6 +157,7 @@ function ConsoleLogBody({
   step,
   stepBuffer,
   onMoreConsoleClick,
+  fetchExceptionText,
 }: ConsoleLogCardProps) {
   const prettySizeString = (size: number) => {
     const kib = 1024;
@@ -204,6 +199,7 @@ function ConsoleLogBody({
         <ConsoleLogStream
           logBuffer={stepBuffer}
           onMoreConsoleClick={onMoreConsoleClick}
+          fetchExceptionText={fetchExceptionText}
           step={step}
           maxHeightScale={0.65}
         />
@@ -218,4 +214,5 @@ export type ConsoleLogCardProps = {
   isExpanded: boolean;
   onStepToggle: (nodeId: string) => void;
   onMoreConsoleClick: (nodeId: string, startByte: number) => void;
+  fetchExceptionText: (nodeId: string) => void;
 };

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogStream.spec.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogStream.spec.tsx
@@ -50,10 +50,26 @@ describe("ConsoleLogStream", () => {
     onMoreConsoleClick: () => {
       console.log("onMoreConsoleClick triggered");
     },
+    fetchExceptionText: vi.fn(),
   } as ConsoleLogStreamProps;
 
   it("renders step console", async () => {
     const { findByText } = render(TestComponent({ ...DefaultTestProps }));
     expect(findByText(/Hello, world!/));
+    expect(DefaultTestProps.fetchExceptionText).not.toBeCalled();
+  });
+
+  it("fetches exception text", async () => {
+    const { findByText } = render(
+      TestComponent({
+        ...DefaultTestProps,
+        step: {
+          ...baseStep,
+          state: Result.failure,
+        },
+      }),
+    );
+    expect(findByText(/Hello, world!/));
+    expect(DefaultTestProps.fetchExceptionText).toBeCalledWith(baseStep.id);
   });
 });

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogStream.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogStream.tsx
@@ -16,6 +16,7 @@ export default function ConsoleLogStream({
   step,
   logBuffer,
   onMoreConsoleClick,
+  fetchExceptionText,
 }: ConsoleLogStreamProps) {
   const appendInterval = useRef<number | null>(null);
   const [stickToBottom, setStickToBottom] = useState(false);
@@ -27,6 +28,12 @@ export default function ConsoleLogStream({
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (step.state === Result.failure) {
+      fetchExceptionText(step.id);
+    }
+  }, [step.id, step.state, fetchExceptionText]);
 
   useEffect(() => {
     if (stickToBottom && logBuffer.lines.length > 0 && canStickToBottom()) {
@@ -125,6 +132,7 @@ export default function ConsoleLogStream({
 export interface ConsoleLogStreamProps {
   logBuffer: StepLogBufferInfo;
   onMoreConsoleClick: (nodeId: string, startByte: number) => void;
+  fetchExceptionText: (nodeId: string) => void;
   step: StepInfo;
   maxHeightScale: number;
 }

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/NoStageStepsFallback.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/NoStageStepsFallback.tsx
@@ -52,6 +52,7 @@ export function NoStageStepsFallback() {
           onMoreConsoleClick={() => {}}
           step={step}
           maxHeightScale={0.65}
+          fetchExceptionText={() => {}}
         />
       </div>
     </div>

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -36,6 +36,7 @@ export default function PipelineConsole() {
     handleStageSelect,
     onStepToggle,
     onMoreConsoleClick,
+    fetchExceptionText,
     loading,
   } = useStepsPoller({ currentRunPath, previousRunPath });
 
@@ -137,6 +138,7 @@ export default function PipelineConsole() {
                   expandedSteps={expandedSteps}
                   onStepToggle={onStepToggle}
                   onMoreConsoleClick={onMoreConsoleClick}
+                  fetchExceptionText={fetchExceptionText}
                 />
               )}
             </div>

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.spec.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.spec.tsx
@@ -51,6 +51,7 @@ describe("StageView", () => {
           expandedSteps={["step-1"]}
           onStepToggle={vi.fn()}
           onMoreConsoleClick={vi.fn()}
+          fetchExceptionText={vi.fn()}
         />,
       );
     });

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
@@ -17,6 +17,7 @@ export default function StageView(props: StageViewProps) {
         expandedSteps={props.expandedSteps}
         onStepToggle={props.onStepToggle}
         onMoreConsoleClick={props.onMoreConsoleClick}
+        fetchExceptionText={props.fetchExceptionText}
       />
     </>
   );
@@ -29,4 +30,5 @@ export interface StageViewProps {
   expandedSteps: string[];
   onStepToggle: (nodeId: string) => void;
   onMoreConsoleClick: (nodeId: string, startByte: number) => void;
+  fetchExceptionText: (nodeId: string) => void;
 }

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.spec.ts
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.spec.ts
@@ -34,17 +34,18 @@ vi.mock("../../../../common/tree-api.ts", () => ({
 vi.mock("../PipelineConsoleModel.tsx", async () => ({
   ...(await vi.importActual("../PipelineConsoleModel.tsx")),
   getRunSteps: vi.fn(),
-  getConsoleTextOffset: vi.fn().mockResolvedValue({
-    text: "log line\n",
-    startByte: 0,
-    endByte: 100,
-  }),
-  getExceptionText: vi.fn().mockResolvedValue("Error message"),
+  getConsoleTextOffset: vi.fn(),
+  getExceptionText: vi.fn().mockResolvedValue(["Error message"]),
   POLL_INTERVAL: 50,
 }));
 
 beforeEach(() => {
   (model.getRunSteps as Mock).mockResolvedValue({ steps: mockSteps });
+  (model.getConsoleTextOffset as Mock).mockResolvedValue({
+    text: "log line\n",
+    startByte: 0,
+    endByte: 100,
+  });
   window.history.pushState({}, "", "/");
 });
 

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.ts
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.ts
@@ -58,7 +58,9 @@ export function useStepsPoller(props: RunPollerProps) {
       }
       if (!response) return;
 
-      const newLogLines = response.text.trim().split("\n") || [];
+      const newLogLines = response.text.split("\n");
+      // Remove trailing empty new line caused by a) splitting an empty string or b) a trailing new line character in the response.
+      if (newLogLines[newLogLines.length - 1] === "") newLogLines.pop();
 
       if (stepBuffer.endByte > 0 && stepBuffer.endByte <= startByte) {
         stepBuffer.lines = [...stepBuffer.lines, ...newLogLines];

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-steps.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-steps.tsx
@@ -11,6 +11,7 @@ export default function StageSteps({
   onStepToggle,
   expandedSteps,
   onMoreConsoleClick,
+  fetchExceptionText,
 }: StageStepsProps) {
   if (steps.length === 0) {
     return null;
@@ -36,6 +37,7 @@ export default function StageSteps({
             onStepToggle={onStepToggle}
             isExpanded={expandedSteps.includes(stepItemData.id)}
             onMoreConsoleClick={onMoreConsoleClick}
+            fetchExceptionText={fetchExceptionText}
             key={`step-console-card-${stepItemData.id}`}
           />
         );
@@ -51,4 +53,5 @@ interface StageStepsProps {
   expandedSteps: string[];
   onStepToggle: (nodeId: string) => void;
   onMoreConsoleClick: (nodeId: string, startByte: number) => void;
+  fetchExceptionText: (nodeId: string) => void;
 }

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/steps/InputStep.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/steps/InputStep.tsx
@@ -1,5 +1,5 @@
 import StatusIcon from "../../../../common/components/status-icon.tsx";
-import { ConsoleLogCardProps } from "../ConsoleLogCard.tsx";
+import { StepInfo } from "../../../../common/RestClient.tsx";
 
 declare global {
   interface Window {
@@ -11,8 +11,8 @@ declare global {
   }
 }
 
-export default function InputStep(props: ConsoleLogCardProps) {
-  const inputStep = props.step.inputStep!;
+export default function InputStep({ step }: { step: StepInfo }) {
+  const inputStep = step.inputStep!;
   function handler(id: string, action: string) {
     fetch(`../input/${id}/${action}`, {
       method: "POST",
@@ -40,10 +40,7 @@ export default function InputStep(props: ConsoleLogCardProps) {
   return (
     <div className="pgv-input-step">
       <div className="pgv-step-detail-header__content">
-        <StatusIcon
-          status={props.step.state}
-          percentage={props.step.completePercent}
-        />
+        <StatusIcon status={step.state} percentage={step.completePercent} />
         <span>{inputStep.message}</span>
       </div>
       <div

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -91,6 +91,7 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
     @GET
     @WebMethod(name = "steps")
     public HttpResponse getSteps(StaplerRequest2 req) {
+        run.checkPermission(Item.READ);
         String nodeId = req.getParameter("nodeId");
         if (nodeId != null) {
             return HttpResponses.okJSON(getSteps(nodeId));
@@ -113,6 +114,7 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
     @GET
     @WebMethod(name = "allSteps")
     public void getAllSteps(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
+        run.checkPermission(Item.READ);
         PipelineStepList steps = stepApi.getAllSteps();
         JSONObject json = JSONObject.fromObject(steps, jsonConfig);
         logger.debug("Steps: '{}'.", json);
@@ -138,6 +140,7 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
             justification =
                     "Doesn't seem to matter in practice, docs aren't clear on how to handle and most places ignore it")
     public void getConsoleText(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
+        run.checkPermission(Item.READ);
         String nodeId = req.getParameter("nodeId");
 
         rsp.setContentType("text/plain;charset=UTF-8");
@@ -178,12 +181,14 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
             justification =
                     "Doesn't seem to matter in practice, docs aren't clear on how to handle and most places ignore it")
     public void getBuildConsole(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
+        run.checkPermission(Item.READ);
         run.getLogText().writeHtmlTo(0L, rsp.getWriter());
     }
 
     @GET
     @WebMethod(name = "exceptionText")
     public HttpResponse getExceptionText(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
+        run.checkPermission(Item.READ);
         String nodeId = req.getParameter("nodeId");
         if (nodeId == null) return HttpResponses.error(400, "missing ?nodeId");
         return HttpResponses.text(getNodeExceptionText(nodeId));
@@ -205,6 +210,7 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
     @GET
     @WebMethod(name = "consoleOutput")
     public HttpResponse getConsoleOutput(StaplerRequest2 req) throws IOException {
+        run.checkPermission(Item.READ);
         String nodeId = req.getParameter("nodeId");
         if (nodeId == null) {
             logger.error("'consoleJson' was not passed 'nodeId'.");
@@ -391,9 +397,6 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
     @RequirePOST
     @JavaScriptMethod
     public HttpResponse doRerun() {
-        if (run == null) {
-            return HttpResponses.errorJSON(Messages.scheduled_failure());
-        }
         run.checkPermission(Item.BUILD);
 
         if (!run.getParent().isBuildable()) {
@@ -416,9 +419,6 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
     @GET
     @WebMethod(name = "nextBuild")
     public HttpResponse hasNextBuild(StaplerRequest2 req) {
-        if (run == null) {
-            return HttpResponses.errorJSON("No run to check for next build");
-        }
         run.checkPermission(Item.READ);
         String queueId = req.getParameter("queueId");
         if (queueId == null || queueId.isBlank()) {
@@ -454,9 +454,6 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
     @RequirePOST
     @JavaScriptMethod
     public HttpResponse doCancel() {
-        if (run == null) {
-            return HttpResponses.errorJSON("No run to cancel");
-        }
         run.checkPermission(getCancelPermission());
         if (run.isBuilding()) {
             run.doStop();
@@ -498,12 +495,6 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
     @GET
     @WebMethod(name = "tree")
     public void getTree(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
-        if (run == null) {
-            HttpResponse response = HttpResponses.errorJSON("No run to get tree for");
-            rsp.setStatus(200);
-            response.generateResponse(req, rsp, null);
-            return;
-        }
         run.checkPermission(Item.READ);
 
         PipelineGraph tree = graphApi.createTree();

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -181,6 +181,14 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
         run.getLogText().writeHtmlTo(0L, rsp.getWriter());
     }
 
+    @GET
+    @WebMethod(name = "exceptionText")
+    public HttpResponse getExceptionText(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
+        String nodeId = req.getParameter("nodeId");
+        if (nodeId == null) return HttpResponses.error(400, "missing ?nodeId");
+        return HttpResponses.text(getNodeExceptionText(nodeId));
+    }
+
     /*
      * The default behavior of this functions differs from 'getConsoleOutput' in that it will use LOG_THRESHOLD from the end of the string.
      * Note: if 'startByte' is negative and falls outside of the console text then we will start from byte 0.
@@ -259,16 +267,6 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
             text = PipelineNodeUtil.convertLogToString(logText, startByte);
             endByte = textLength;
         }
-        // If has an exception, return the exception text (inc. stacktrace).
-        if (isUnhandledException(nodeId)) {
-            // Set logText to exception text. This is a little hacky - maybe it would be better update the
-            // frontend to handle steps and exceptions differently?
-            String nodeExceptionText = getNodeExceptionText(nodeId);
-            if (nodeExceptionText != null) {
-                text += nodeExceptionText;
-            }
-            endByte += text.length();
-        }
         JSONObject json = new JSONObject();
         json.element("text", text);
         json.element("startByte", startByte);
@@ -286,7 +284,7 @@ public class PipelineConsoleViewAction implements Action, IconSpec {
         return null;
     }
 
-    private String getNodeExceptionText(String nodeId) throws IOException {
+    protected String getNodeExceptionText(String nodeId) throws IOException {
         FlowExecution execution = run.getExecution();
         if (execution != null) {
             logger.debug("getNodeException found execution.");

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction.java
@@ -71,6 +71,7 @@ public class MultiPipelineGraphViewAction implements Action, IconSpec {
     @GET
     @WebMethod(name = "runs")
     public void getRuns(StaplerRequest2 req, StaplerResponse2 rsp) throws ServletException, IOException {
+        target.checkPermission(Item.READ);
         RunList<WorkflowRun> runs = target.getBuilds();
         List<PipelineRun> pipelineRuns = new ArrayList<>();
 

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItemTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/cards/items/ChangesRunDetailsItemTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.model.Result;
+import hudson.plugins.git.GitSCM;
 import io.jenkins.plugins.pipelinegraphview.Messages;
 import io.jenkins.plugins.pipelinegraphview.cards.RunDetailsItem;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
@@ -31,9 +32,22 @@ class ChangesRunDetailsItemTest {
         WorkflowJob job = TestUtils.createJob(j, "simpleWithSCM", "singleStagePipelineWithSCM.jenkinsfile", true);
         // build twice to establish a change set
         j.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
+        assertEquals(1, job.getLastBuild().getNumber());
+        assertEquals(
+                "b6dc82faf9248fece30bc704c09edbb4708c9756",
+                ((GitSCM) (job.getLastBuild().getSCMs().get(0)))
+                        .getBranches()
+                        .get(0)
+                        .getName());
         j.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
         WorkflowRun run = job.getLastBuild();
+        assertEquals(2, run.getNumber());
+        assertEquals(
+                "1dc41d9c9758a111baebebe5f6bcd39c66040941",
+                ((GitSCM) (run.getSCMs().get(0))).getBranches().get(0).getName());
+        assertEquals(1, run.getChangeSets().size());
+        assertEquals(21, run.getChangeSets().get(0).getItems().length);
 
         Optional<RunDetailsItem> detailsItem = ChangesRunDetailsItem.get(run);
 

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -42,7 +42,7 @@ class PipelineConsoleViewActionTest {
 
     @Issue("GH#224")
     @Test
-    void getConsoleLogReturnsErrorText(JenkinsRule j) throws Exception {
+    void getConsoleLogReturnsNoErrorText(JenkinsRule j) throws Exception {
         WorkflowRun run =
                 TestUtils.createAndRunJob(j, "hello_world_scripted", "simpleError.jenkinsfile", Result.FAILURE);
 
@@ -53,9 +53,25 @@ class PipelineConsoleViewActionTest {
 
         PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
         JSONObject consoleJson = consoleAction.getConsoleOutputJson(errorStep.getId(), 0L);
-        assertThat(consoleJson.getString("endByte"), equalTo("16"));
+        assertThat(consoleJson.getString("endByte"), equalTo("0"));
         assertThat(consoleJson.getString("startByte"), equalTo("0"));
-        assertThat(consoleJson.getString("text"), equalTo("This is an error"));
+        assertThat(consoleJson.getString("text"), equalTo(""));
+    }
+
+    @Issue("GH#224")
+    @Test
+    void getNodeExceptionTextWithScriptError(JenkinsRule j) throws Exception {
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "hello_world_scripted", "simpleError.jenkinsfile", Result.FAILURE);
+
+        PipelineNodeGraphAdapter builder = new PipelineNodeGraphAdapter(run);
+        String stageId = TestUtils.getNodesByDisplayName(run, "A").get(0).getId();
+        List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
+        FlowNodeWrapper errorStep = stepNodes.get(0);
+
+        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
+        String message = consoleAction.getNodeExceptionText(errorStep.getId());
+        assertThat(message, equalTo("This is an error"));
     }
 
     @Issue("GH#224")
@@ -149,8 +165,26 @@ class PipelineConsoleViewActionTest {
         PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
         JSONObject consoleJson = consoleAction.getConsoleOutputJson(execStep.getId(), 0L);
         assertThat(consoleJson.getString("startByte"), equalTo("0"));
+        assertThat(consoleJson.getString("endByte"), equalTo("44"));
         assertThat(
                 consoleJson.getString("text"),
-                stringContainsInOrder("echo", "Hello, world!", "script returned exit code 1"));
+                stringContainsInOrder("echo Hello, world!", "Hello, world!", "+ exit 1"));
+    }
+
+    @Issue("GH#224")
+    @Test
+    void getNodeExceptionTextWithStepError(JenkinsRule j) throws Exception {
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "exec_returns_error", "execStepReturnsError.jenkinsfile", Result.FAILURE);
+        PipelineNodeGraphAdapter builder = new PipelineNodeGraphAdapter(run);
+        String stageId =
+                TestUtils.getNodesByDisplayName(run, "Say Hello").get(0).getId();
+        List<FlowNodeWrapper> stepNodes = builder.getStageSteps(stageId);
+        // There is an 'isUnix()' step before this.
+        FlowNodeWrapper execStep = stepNodes.get(1);
+
+        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
+        String message = consoleAction.getNodeExceptionText(execStep.getId());
+        assertThat(message, equalTo("script returned exit code 1"));
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -165,10 +165,7 @@ class PipelineConsoleViewActionTest {
         PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
         JSONObject consoleJson = consoleAction.getConsoleOutputJson(execStep.getId(), 0L);
         assertThat(consoleJson.getString("startByte"), equalTo("0"));
-        assertThat(consoleJson.getString("endByte"), equalTo("44"));
-        assertThat(
-                consoleJson.getString("text"),
-                stringContainsInOrder("echo Hello, world!", "Hello, world!", "+ exit 1"));
+        assertThat(consoleJson.getString("text"), stringContainsInOrder("echo", "Hello, world!"));
     }
 
     @Issue("GH#224")


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

For https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/704

In preparation for streaming the console log using progressive-text, fetch the exception text separately from the console log.

This change was also recorded as suggestion in code.

https://github.com/jenkinsci/pipeline-graph-view-plugin/blob/23e636851f81e7e0ca338146071130ad2e62a251/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java#L256-L257

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

- See added/updated tests
- Pipeline with script error
- Pipeline with Groovy error

```
node {
    sh 'exit 1'
}
```

```
node {
    foo()
}
```

Side note: The traceback is a bit verbose in the dev-server.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
