### PR TITLE
Implement incremental tailing of logs

### DIFF
--- a/src/main/frontend/common/RestClient.tsx
+++ b/src/main/frontend/common/RestClient.tsx
@@ -44,7 +44,7 @@ export interface StepLogBufferInfo {
   lines: string[];
   startByte: number;
   endByte: number;
-  pending?: Promise<ConsoleLogData | null>;
+  pending?: Promise<void>;
   consoleAnnotator?: string;
   lastFetched?: number;
   stopTailing?: boolean;

--- a/src/main/frontend/common/RestClient.tsx
+++ b/src/main/frontend/common/RestClient.tsx
@@ -44,11 +44,10 @@ export interface StepLogBufferInfo {
   lines: string[];
   startByte: number;
   endByte: number;
-  pending?: {
-    startByte: number;
-    promise: Promise<ConsoleLogData | null>;
-  };
-  fullyFetched?: boolean;
+  pending?: Promise<ConsoleLogData | null>;
+  consoleAnnotator?: string;
+  lastFetched?: number;
+  stopTailing?: boolean;
   exceptionText?: string[];
   pendingExceptionText?: Promise<string[]>;
 }
@@ -59,6 +58,7 @@ export interface ConsoleLogData {
   startByte: number;
   endByte: number;
   nodeIsActive: boolean;
+  consoleAnnotator: string;
 }
 
 export async function getRunStatusFromPath(
@@ -92,14 +92,21 @@ export async function getRunSteps(): Promise<AllStepsData | null> {
 export async function getConsoleTextOffset(
   stepId: string,
   startByte: number,
+  consoleAnnotator: string,
 ): Promise<ConsoleLogData | null> {
+  const headers = new Headers();
+  if (consoleAnnotator) headers.set("X-ConsoleAnnotator", consoleAnnotator);
   try {
     const response = await fetch(
       `consoleOutput?nodeId=${stepId}&startByte=${startByte}`,
+      { headers },
     );
     if (!response.ok) throw response.statusText;
     const json = await response.json();
-    return json.data;
+    return {
+      ...json.data,
+      consoleAnnotator: response.headers.get("X-ConsoleAnnotator") || "",
+    };
   } catch (e) {
     console.error(`Caught error when fetching console: '${e}'`);
     return null;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogCard.tsx
@@ -18,6 +18,7 @@ import {
   LOG_FETCH_SIZE,
   StepInfo,
   StepLogBufferInfo,
+  TAIL_CONSOLE_LOG,
 } from "./PipelineConsoleModel.tsx";
 import InputStep from "./steps/InputStep.tsx";
 
@@ -33,7 +34,7 @@ export default function ConsoleLogCard({
 }: ConsoleLogCardProps) {
   useEffect(() => {
     if (isExpanded) {
-      onMoreConsoleClick(step.id, stepBuffer.startByte);
+      onMoreConsoleClick(step.id, TAIL_CONSOLE_LOG);
     }
   }, [isExpanded, onMoreConsoleClick, step.id, stepBuffer]);
 

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogStream.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/ConsoleLogStream.tsx
@@ -2,9 +2,11 @@ import { useEffect, useRef, useState } from "react";
 
 import { ConsoleLine } from "./ConsoleLine.tsx";
 import {
+  POLL_INTERVAL,
   Result,
   StepInfo,
   StepLogBufferInfo,
+  TAIL_CONSOLE_LOG,
 } from "./PipelineConsoleModel.tsx";
 
 function canStickToBottom() {
@@ -69,13 +71,13 @@ export default function ConsoleLogStream({
 
   useEffect(() => {
     const shouldRequestMoreLogs =
-      step.state === Result.running || logBuffer.startByte < 0;
+      step.state === Result.running || logBuffer.endByte < 0;
 
     if (stickToBottom && shouldRequestMoreLogs) {
       if (!appendInterval.current) {
         appendInterval.current = window.setInterval(() => {
-          onMoreConsoleClick(step.id, logBuffer.startByte);
-        }, 1000);
+          onMoreConsoleClick(step.id, TAIL_CONSOLE_LOG);
+        }, POLL_INTERVAL);
       }
     } else if (appendInterval.current) {
       clearInterval(appendInterval.current);

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsoleModel.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsoleModel.tsx
@@ -8,3 +8,4 @@ export { Result } from "../../../pipeline-graph-view/pipeline-graph/main/Pipelin
 
 export const LOG_FETCH_SIZE = 150 * 1024;
 export const POLL_INTERVAL = 1000;
+export const TAIL_CONSOLE_LOG = -LOG_FETCH_SIZE;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.ts
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.ts
@@ -5,7 +5,6 @@ import {
   getConsoleTextOffset,
   getExceptionText,
   getRunSteps,
-  LOG_FETCH_SIZE,
   POLL_INTERVAL,
   Result,
   StageInfo,

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-steps.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-steps.tsx
@@ -2,7 +2,7 @@ import "./stage-steps.scss";
 
 import { StepInfo, StepLogBufferInfo } from "../../../common/RestClient.tsx";
 import ConsoleLogCard from "./ConsoleLogCard.tsx";
-import { LOG_FETCH_SIZE, StageInfo } from "./PipelineConsoleModel.tsx";
+import { StageInfo, TAIL_CONSOLE_LOG } from "./PipelineConsoleModel.tsx";
 
 export default function StageSteps({
   stage,
@@ -27,12 +27,11 @@ export default function StageSteps({
           <ConsoleLogCard
             step={stepItemData}
             stepBuffer={
-              stepBuffers.get(stepItemData.id) ??
-              ({
-                lines: [] as string[],
-                startByte: 0 - LOG_FETCH_SIZE,
-                endByte: -1,
-              } as StepLogBufferInfo)
+              stepBuffers.get(stepItemData.id) ?? {
+                lines: [],
+                startByte: 0,
+                endByte: TAIL_CONSOLE_LOG,
+              }
             }
             onStepToggle={onStepToggle}
             isExpanded={expandedSteps.includes(stepItemData.id)}


### PR DESCRIPTION
While working on the streaming based console log (#704), it stood out that we are repeatedly fetching the same log bytes, rather than incrementally fetching them:

Currently:
- fetch last 150KiB -> determines startByte
- every second or earlier based on steps polling: fetch logs from startByte

This PR:
- fetch last 150KiB -> determines endByte
- every second: fetch log from last endByte

The console annotations can be partially read and the `X-ConsoleAnnotator` response header is carried over to the next incremental fetch. Realistically, this is only relevant for multi-line console annotations as non completed steps are read to the last new line character only. (I'm not aware of any producer for multi-line annotations.)

Implementation details:
- Determine next tailing startByte from inside updateStepConsoleOffset to avoid using a stale endByte from a previous react render.
- Use a constant for signaling a tailing action: `TAIL_CONSOLE_LOG`.
- Debounce tailing requests to once every `POLL_INTERVAL=1s`.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```
stage('10 MiB') {
    node {
        sh "head -c \$(expr 10 \\* 1024 \\* 1024) /dev/urandom | base64 --wrap=1000 | xargs -I% sh -c 'sleep 0.001 && echo %'"
    }
}
```

It takes about a minute for the pipeline to run on my laptop and the log file weights 13.35MiB.

Immediately scroll to the end to start the tailing of the logs.

Before: 240MiB transferred in 45 requests (the last few requests take >1s to process, hence some polling is skipped). See  the last 150KiB at the end (13MiB hidden -- another bug that's fixed here :slightly_smiling_face: ).

After: 14MiB transferred in 55 requests. See the full log at the end (minus any logs that were skipped in the initial tailing request -- so <1MiB hidden).

Re-run, this time reload the page a few second into the run, then click on "there is more to see" to fetch the hidden logs. Tailing continues as expected.

---

I've also added frontend tests for different combinations of incremental fetches including interleaved fetching of logs from the start -> new test suite "incremental log fetching".

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
