### PR TITLE
fix: fixed ANSI SGR codes for color reset

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/Ansi.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/Ansi.tsx
@@ -59,12 +59,12 @@ export function parseEscapeCode(escapeCode: string): Result {
       } else if (num >= 40 && num <= 47) {
         result.setBG = num - 40; // Normal BG set
       } else {
-        if (num === 38 || num === 0) {
+        if (num === 39 || num === 0) {
           result.resetFG = true;
           result.setFG = false;
         }
 
-        if (num === 48 || num === 0) {
+        if (num === 49 || num === 0) {
           result.resetBG = true;
           result.setBG = false;
         }


### PR DESCRIPTION
This pull request fixes wrong ANSI SGR codes used to reset foreground and background colors.
According to the [wikipedia article](https://en.wikipedia.org/wiki/ANSI_escape_code) codes [**39**: _Default foreground color_] and [**49**: _Default background color_] are used to reset colors.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
