### PR TITLE
fix: use palette colors matching ANSI standard for ANSI basic colors

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/pipeline-console.scss
@@ -2,12 +2,12 @@
   // can be removed and `--header-height` used directly when jenkins baseline is 2.507
   --pgv-header-height: var(--header-height, 45.5938px);
   --ansi-0: var(--black, #333);
-  --ansi-1: var(--danger, #cc0003);
-  --ansi-2: var(--success, #138347);
-  --ansi-3: var(--warning, #ea6b19);
-  --ansi-4: var(--primary, #0b6aa2);
-  --ansi-5: var(--unknown-color, #bd0fe1);
-  --ansi-6: var(--paused-color, #24b0d5);
+  --ansi-1: var(--red, oklch(70% 0.15 27));
+  --ansi-2: var(--green, oklch(70% 0.15 145));
+  --ansi-3: var(--orange, oklch(70% 0.15 75));
+  --ansi-4: var(--blue, oklch(70% 0.15 270));
+  --ansi-5: var(--purple, oklch(70% 0.15 335));
+  --ansi-6: var(--cyan, oklch(70% 0.15 210));
   --ansi-7: var(--white, #fff);
   --ansi-8: var(--secondary-text, #445);
   --ansi-9: oklch(from var(--ansi-1) calc(l * 1.125) calc(c * 1.25) h);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This pull request changes the palette colors used for ANSI basic colors from purpose-based to those that correspond to the ANSI standard.

The goal is to improve portability in general and resolve the Chocolate theme issue, where **blue** was rendered as **yellow**.

⚠️ The colors most affected by the change are **blue**, **magenta** and **cyan**. Blue referenced `var(--primary-color)`, so it could match almost any color. Magenta and cyan used `var(--unknown-color)` and `var(--paused-color)`, which are apparently non-standard. Since these variables were undefined, so the colors fell back to the hard-coded variants. Check the changes in the **Catppuccin** and **Nord**  themes — their versions of magenta and cyan colors were especially inconsistent with the theme colors. 

The only exception is **yellow**. **Yellow** references **orange** primarily because it seems more portable, especially in light themes. Additionally, all themes currently map `var(--warning)` to **orange**.

### Testing done

* Tested the changes with all themes and the results look acceptable.

#### Chocolate theme

##### Before
<img width="1025" height="730" alt="chocolate-before" src="https://github.com/user-attachments/assets/ef07d08d-1138-4dd6-a4f1-dc600043f8b2" /> 

##### After
<img width="1025" height="730" alt="chocolate-after" src="https://github.com/user-attachments/assets/040a2069-4b8d-4ff8-9a81-e13cab565c2d" />

<details>

<summary>Other themes</summary>

#### Dark theme

##### Before
<img width="1025" height="730" alt="dark-before" src="https://github.com/user-attachments/assets/e42c7ac6-17d3-47ee-8b0a-c1026722da50" />

##### After
<img width="1025" height="730" alt="dark-after" src="https://github.com/user-attachments/assets/bac45d40-a519-43dc-a973-0c2fd68acde2" />

#### Light theme

##### Before
<img width="1025" height="730" alt="light-before" src="https://github.com/user-attachments/assets/c07ee59d-93a6-4f3f-a301-3fe44fdbb2b2" />

##### After
<img width="1025" height="730" alt="light-after" src="https://github.com/user-attachments/assets/70136928-d02c-4b2b-b979-aeb9323e11c1" />

#### Catppuccin Frappe theme

##### Before
<img width="1025" height="730" alt="catppuccin-frappe-before" src="https://github.com/user-attachments/assets/4e574579-aaf6-4634-b188-d733ac4bd2fe" />

##### After
<img width="1025" height="730" alt="catppuccin-frappe-after" src="https://github.com/user-attachments/assets/4003be42-fa78-4995-9b62-779b67f0672d" />

#### Catppuccin Macchiato theme

##### Before
<img width="1025" height="730" alt="catppuccin-frappe-macchiato-before" src="https://github.com/user-attachments/assets/29f84533-9af3-401e-9487-2b8db2f57e52" />

##### After
<img width="1025" height="730" alt="catppuccin-frappe-macchiato-after" src="https://github.com/user-attachments/assets/44dd3a13-d3e8-465e-aeff-126d993514cd" />

#### Catppuccin Mocha theme

##### Before
<img width="1025" height="730" alt="catppuccin-frappe-mocha-before" src="https://github.com/user-attachments/assets/ff65d069-6a16-443f-9b1e-aa8909e21ac1" />

##### After
<img width="1025" height="730" alt="catppuccin-frappe-mocha-after" src="https://github.com/user-attachments/assets/c36da832-b6f0-4a9a-8e5c-d9ab69d03228" />

#### Catppuccin Latte theme

##### Before
<img width="1025" height="730" alt="catppuccin-latte-before" src="https://github.com/user-attachments/assets/addea671-34fa-47ae-bc3c-7087d0b88749" />

##### After
<img width="1025" height="730" alt="catppuccin-latte-after" src="https://github.com/user-attachments/assets/09ef6210-bdfb-41b0-a4d5-a9277a903804" />

#### Material Green theme

##### Before
<img width="1025" height="730" alt="material-green-before" src="https://github.com/user-attachments/assets/fd69dfef-5555-4667-87ed-307c0bdce91c" />

##### After
<img width="1025" height="730" alt="material-green-after" src="https://github.com/user-attachments/assets/e3a381af-25ab-4eb2-9576-23dd2ed27197" />

#### Nord theme

##### Before
<img width="1025" height="730" alt="nord-before" src="https://github.com/user-attachments/assets/b5b11d8e-7b05-452a-aa05-3b5338ac8909" />

##### After
<img width="1025" height="730" alt="nord-after" src="https://github.com/user-attachments/assets/f11bf3f3-6177-4899-be84-54d5f703ce8f" />

#### Solarized Dark theme

##### Before
<img width="1025" height="730" alt="solarized-dark-before" src="https://github.com/user-attachments/assets/8e5015f6-6d61-4c32-99cb-594b04395f2d" />

##### After
<img width="1025" height="730" alt="solarized-dark-after" src="https://github.com/user-attachments/assets/7c32780f-c325-4a22-835e-18d1e2c1a907" />

#### Solarized Light theme

##### Before
<img width="1025" height="730" alt="solarized-light-before" src="https://github.com/user-attachments/assets/81fcf7c8-cf51-4b9f-8b6d-9f768d214804" />

##### After
<img width="1025" height="730" alt="solarized-light-after" src="https://github.com/user-attachments/assets/5c4b684a-709e-4ddf-8be5-ba93811f6233" />

</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
