### PR TITLE
Fix reset of ANSI text attributes on global reset command

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/Ansi.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/Ansi.tsx
@@ -101,6 +101,15 @@ export function parseEscapeCode(escapeCode: string): Result {
           result.resetBG = true;
           result.setBG = false;
         }
+
+        // ANSI code 0 should reset all formatting attributes
+        if (num === 0) {
+          result.setBold = false;
+          result.setFaint = false;
+          result.setItalic = false;
+          result.setUnderline = false;
+          result.setStrikeThrough = false;
+        }
       }
     }
   }


### PR DESCRIPTION
This pull request fixes ANSI text attributes reset on `\x1b[0m` SGR reset command.
The issue was introduced in #1001.

<!-- Please describe your pull request here. -->

### Testing done

* Added more complex and realistic test with switching text styles and colors on the same line

    <details>

    <summary>Test Jenkins Pipeline</summary>

    ```groovy
    pipeline {
        agent any
        options {
            ansiColor('xterm')
        }
        stages {
            stage("Test") {
                steps {
                    sh '''
                    set +x
                    echo "prefix: [36;2m12:41:38[0m [36;2m[[22;1mINF[22;2m][0m [36;2mx1:[0m [1mhello, world[0m"
                    echo "prefix: [36;2m12:41:38[0m [36;2m[[22;1mINF[22;2m][0m [36;2mx2:[0m [1msend request[0m [36;2mrequest-id[0m[36;2m=[0m[36m[0m4b037517[36m[0m [36;2mmethod[0m[36;2m=[0m[36m[0mGET[36m[0m [36;2murl[0m[36;2m=[0m[36m[0mhttps://world.com/hello[36m[0m"
                    echo "prefix: [36;2m12:41:39[0m [36;2m[[22;1mINF[22;2m][0m [36;2mx2:[0m [1mgot response[0m [36;2mrequest-id[0m[36;2m=[0m[36m[0m4b037517[36m[0m [36;2mstatus-code[0m[36;2m=[0m[32m200[0m [36;2mduration[0m[36;2m=[0m[34m00:00:00.061[0m"
                    '''.stripIndent()
                }            
            }
        }
    }
    ```

    </details>

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Dark theme – Before
<img width="955" height="634" alt="Screenshot 2025-10-07 at 15 11 45" src="https://github.com/user-attachments/assets/a539d47a-5e82-42b7-bc8b-54877617b87f" />

### Dark theme – After
<img width="955" height="634" alt="Screenshot 2025-10-07 at 15 11 35" src="https://github.com/user-attachments/assets/62393a31-de22-4295-aba7-0b9b63d6f890" />

### Light theme – Before
<img width="955" height="634" alt="Screenshot 2025-10-07 at 15 11 55" src="https://github.com/user-attachments/assets/bac1e394-0c7d-488a-a9b3-d8b86e9eea17" />

### Light theme – After
<img width="955" height="634" alt="Screenshot 2025-10-07 at 15 12 06" src="https://github.com/user-attachments/assets/95a491eb-865b-478a-90ca-c909f0c022bc" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
