### PR TITLE
Fix sidepanel link

### DIFF
--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/action.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/action.jelly
@@ -5,6 +5,7 @@
     <l:userExperimentalFlag var="newBuildPage" flagClassName="jenkins.model.experimentalflags.NewBuildPageUserExperimentalFlag" />
 
     <j:if test="${!newBuildPage}">
-        <l:task icon="${action.iconFileName}" title="Pipeline Overview" href="${action.urlName}" />
+        <j:set var="url" value="${h.getNearestAncestorUrl(request2, it)}" />
+        <l:task icon="${action.iconFileName}" title="Pipeline Overview" href="${url}/${action.urlName}" />
     </j:if>
 </j:jelly>


### PR DESCRIPTION
Spotted when fixing JUnit's side panel link (https://github.com/jenkinsci/junit-plugin/pull/755) - this plugin also behaves the same way! Just not as noticeable as we hide our side panel.

Also, shout out to the folks at GitHub for this amazing feature:

<img width="1128" height="932" alt="image" src="https://github.com/user-attachments/assets/cb3e56e0-1e80-4db5-ad65-48f4242ac5bb" />

_Saving dumb folks like me that commit to the wrong branch._

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
