### PR TITLE
Inline TreeNode.onSelect to fix memo

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/DataTreeView.tsx
@@ -3,7 +3,6 @@ import "./data-tree-view.scss";
 import {
   memo,
   MouseEvent as ReactMouseEvent,
-  useCallback,
   useEffect,
   useState,
 } from "react";
@@ -25,13 +24,6 @@ export default function DataTreeView({
 }: DataTreeViewProps) {
   const { search, setSearch, visibleStatuses } = useFilter();
   const filteredStages = filterStageTree(search, visibleStatuses, stages);
-
-  const handleSelect = useCallback(
-    (event: ReactMouseEvent, nodeId: string) => {
-      onNodeSelect(event, nodeId);
-    },
-    [onNodeSelect],
-  );
 
   if (stages.length === 1 && stages[0].placeholder) {
     return null;
@@ -97,7 +89,7 @@ export default function DataTreeView({
             key={stage.id}
             stage={stage}
             selected={String(selected)}
-            onSelect={handleSelect}
+            onSelect={onNodeSelect}
           />
         ))}
       </ol>
@@ -164,7 +156,7 @@ const TreeNode = memo(function TreeNode({
 
             history.replaceState({}, "", `?selected-node=` + stage.id);
             if (!isSelected) {
-              onSelect(e, String(stage.id));
+              onSelect(String(stage.id));
             }
             setIsExpanded(!isExpanded);
           }}
@@ -271,11 +263,11 @@ const filterStageTree = (
 interface DataTreeViewProps {
   stages: StageInfo[];
   selected?: number;
-  onNodeSelect: (event: ReactMouseEvent, nodeId: string) => void;
+  onNodeSelect: (nodeId: string) => void;
 }
 
 interface TreeNodeProps {
   stage: StageInfo;
   selected: string;
-  onSelect: (event: ReactMouseEvent, id: string) => void;
+  onSelect: (id: string) => void;
 }

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -122,7 +122,7 @@ export default function PipelineConsole() {
                     </div>
                   ) : (
                     <DataTreeView
-                      onNodeSelect={(_, nodeId) => handleStageSelect(nodeId)}
+                      onNodeSelect={handleStageSelect}
                       selected={openStage?.id}
                       stages={stages}
                     />


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

The `PipelineConsole` invokes `DataTreeView` -> `TreeNode` with an anonymous function, which will invalidate the `handleSelect=useCallback(..., [anonymousFunction])`, which in turn will render the `memo(function TreeNode() {})` useless as each re-render sees new props.

### Testing done

Run pipeline with many nested stages. The stage listing looks good, it updates as the build progresses.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
