### PR TITLE
Remove old CSS variable fallbacks

### DIFF
--- a/src/main/frontend/common/components/status-icon.scss
+++ b/src/main/frontend/common/components/status-icon.scss
@@ -29,9 +29,3 @@
     }
   }
 }
-
-// TODO - can be removed when Jenkins >= 2.506
-.jenkins-\!-skipped-color {
-  --color: var(--text-color-secondary);
-  color: var(--color);
-}

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/console-log-card.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/console-log-card.scss
@@ -145,11 +145,7 @@ a.console-line-number {
   margin-bottom: -0.375rem;
   margin-left: -0.375rem;
   margin-right: -0.375rem;
-  // TODO - var fallback can removed after baseline is moved >= 2.496
-  border-top: var(
-    --jenkins-border,
-    2px solid color-mix(in srgb, var(--text-color-secondary) 10%, transparent)
-  );
+  border-top: var(--jenkins-border);
   background-color: color-mix(in srgb, var(--accent-color) 2.5%, transparent);
   border-bottom-left-radius: 0.375rem;
   border-bottom-right-radius: 0.375rem;
@@ -183,8 +179,7 @@ div.console-output-line {
         var(--blue) 15%,
         transparent
       ) !important;
-      // TODO - var fallback can removed after baseline is moved >= 2.496
-      border: var(--jenkins-border-width, 2px) solid
+      border: var(--jenkins-border-width) solid
         color-mix(in srgb, var(--blue) 10%, transparent);
       opacity: 1;
     }
@@ -199,8 +194,7 @@ div.console-output-line {
       var(--text-color-secondary) 5%,
       transparent
     );
-    // TODO - var fallback can removed after baseline is moved >= 2.496
-    border: var(--jenkins-border-width, 2px) solid
+    border: var(--jenkins-border-width) solid
       color-mix(in srgb, var(--text-color-secondary) 2.5%, transparent);
     border-radius: 0.375rem;
     opacity: 0;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/data-tree-view.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/data-tree-view.scss
@@ -11,13 +11,9 @@ $pgv-item-padding-inline: 0.7rem;
     content: "";
     position: absolute;
     inset: 0;
-    background: var(--input-color);
+    background: var(--card-background);
+    border: var(--card-border-width) solid var(--card-border-color);
     border-radius: var(--form-input-border-radius);
-    // TODO - var fallback can removed after baseline is moved >= 2.496
-    border: var(
-      --jenkins-border,
-      2px solid color-mix(in srgb, var(--text-color-secondary) 10%, transparent)
-    );
     box-shadow: var(--form-input-glow);
     transition: var(--standard-transition);
   }
@@ -271,19 +267,13 @@ $pgv-item-padding-inline: 0.7rem;
     content: "";
     position: absolute;
     top: 0.375rem;
-    // TODO - var fallback can removed after baseline is moved >= 2.496
     left: calc(
-      $pgv-item-padding-inline + ($pgv-icon-size / 2) -
-        (var(--jenkins-border-width, 2px) / 2)
+      $pgv-item-padding-inline +
+        ($pgv-icon-size / 2) - var(--jenkins-border-width / 2)
     );
     bottom: 0.375rem;
-    // TODO - var fallback can removed after baseline is moved >= 2.496
-    background-color: var(
-      --jenkins-border-color,
-      color-mix(in srgb, var(--text-color-secondary) 25%, transparent)
-    );
-    // TODO - var fallback can removed after baseline is moved >= 2.496
-    width: var(--jenkins-border-width, 2px);
+    background-color: var(--jenkins-border-color);
+    width: var(--jenkins-border-width);
     border-radius: var(--form-input-border-radius);
   }
 }

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/split-view.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/split-view.scss
@@ -33,12 +33,10 @@
   &::after {
     content: "";
     position: absolute;
-    // TODO - var fallback can removed after baseline is moved >= 2.496
-    right: calc(50% - (var(--jenkins-border-width, 2px) / 2));
+    right: calc(50% - (var(--jenkins-border-width) / 2));
     top: 0;
     bottom: 0;
-    // TODO - var fallback can removed after baseline is moved >= 2.496
-    width: var(--jenkins-border-width, 2px);
+    width: var(--jenkins-border-width);
     border-radius: 5px;
     transition: var(--standard-transition);
     background-color: var(--text-color-secondary);
@@ -73,10 +71,8 @@
       right: 0;
       top: unset;
       width: unset;
-      // TODO - var fallback can removed after baseline is moved >= 2.496
-      bottom: calc(50% - (var(--jenkins-border-width, 2px) / 2));
-      // TODO - var fallback can removed after baseline is moved >= 2.496
-      height: var(--jenkins-border-width, 2px);
+      bottom: calc(50% - (var(--jenkins-border-width) / 2));
+      height: var(--jenkins-border-width);
     }
 
     &:hover {

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.scss
@@ -6,9 +6,7 @@
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 0 0.5rem;
-  // TODO - var fallback can removed after baseline is moved >= 2.496
-  padding: 0.125rem calc(1rem + var(--jenkins-border-width, 2px));
-  padding-right: 0.7rem;
+  padding: 0.125rem 0.7rem 0.125rem calc(1rem + var(--jenkins-border-width));
   border-radius: var(--form-input-border-radius);
   margin-bottom: 0.75rem;
   z-index: 101;
@@ -18,8 +16,7 @@
     position: absolute;
     inset: 0;
     background: oklch(from var(--bg-color) l c h / 0.075);
-    // TODO - var fallback can removed after baseline is moved >= 2.496
-    border: var(--jenkins-border-width, 2px) solid
+    border: var(--jenkins-border-width) solid
       oklch(from var(--bg-color) l c h / 0.1);
     border-radius: inherit;
     transition: var(--standard-transition);

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-steps.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-steps.scss
@@ -2,12 +2,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.375rem;
-  // TODO - var fallback can removed after baseline is moved >= 2.496
-  border: var(
-    --jenkins-border,
-    2px solid color-mix(in srgb, var(--text-color-secondary) 10%, transparent)
-  );
   background: var(--card-background);
+  border: var(--card-border-width) solid var(--card-border-color);
   border-radius: var(--form-input-border-radius);
   padding: 0.375rem;
 }


### PR DESCRIPTION
Small one to remove old CSS variable fallbacks now that our baseline is high enough. Also standardised some of the variables so that the search bar and cards look consistent.

### Testing done

* Works as expected

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
