### PR TITLE
Change '/pipeline-overview' to '/stages'

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18,7 +18,7 @@ info:
     url: https://opensource.org/licenses/MIT
 
 servers:
-  - url: "{build_url}/pipeline-overview"
+  - url: "{build_url}/stages"
     description: Pipeline Overview API - Individual pipeline run
     variables:
       build_url:
@@ -612,7 +612,7 @@ components:
               synthetic: false
               placeholder: false
               agent: "linux"
-              url: "/job/my-pipeline/1/pipeline-overview?selected-node=6"
+              url: "/job/my-pipeline/1/stages?selected-node=6"
 
     StepListExample:
       summary: Example step list

--- a/src/main/frontend/common/RestClient.tsx
+++ b/src/main/frontend/common/RestClient.tsx
@@ -65,7 +65,7 @@ export interface ConsoleLogData {
 }
 
 export async function getRunStatusFromPath(url: string): Promise<RunStatus> {
-  const response = await fetch(url + "pipeline-overview/tree");
+  const response = await fetch(url + "stages/tree");
   if (!response.ok) {
     throw response.statusText;
   }

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
@@ -38,7 +38,7 @@ export default function Stages({
       {onRunPage && (
         <a
           className={"pgv-stages-graph__controls pgv-stages-graph__heading"}
-          href="pipeline-overview"
+          href="stages"
         >
           Stages
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -48,7 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PipelineConsoleViewAction extends Tab {
-    public static final String URL_NAME = "pipeline-overview";
+    public static final String URL_NAME = "stages";
     public static final int CACHE_AGE = (int) TimeUnit.DAYS.toSeconds(1);
 
     private static final Logger logger = LoggerFactory.getLogger(PipelineConsoleViewAction.class);
@@ -72,7 +72,7 @@ public class PipelineConsoleViewAction extends Tab {
 
     @Override
     public String getDisplayName() {
-        return "Stages";
+        return Messages.stages();
     }
 
     @Override

--- a/src/main/resources/components/temporary-wrapper.jelly
+++ b/src/main/resources/components/temporary-wrapper.jelly
@@ -95,13 +95,13 @@
 
                     <t:buildCaption controls="${controls}">
                         <j:if test="${it.previousBuildNumber!=null}">
-                            <a href="../../${it.previousBuildNumber}/pipeline-overview" class="jenkins-button jenkins-button--tertiary app-details__prev_next" tooltip="${%Previous Build}">
+                            <a href="../../${it.previousBuildNumber}/stages" class="jenkins-button jenkins-button--tertiary app-details__prev_next" tooltip="${%Previous Build}">
                                 <l:icon class="symbol-chevron-back-outline plugin-ionicons-api icon-md" />
                             </a>
                         </j:if>
                         ${it.buildDisplayName}
                         <j:if test="${it.nextBuildNumber!=null}">
-                            <a href="../../${it.nextBuildNumber}/pipeline-overview" class="jenkins-button jenkins-button--tertiary app-details__prev_next" tooltip="${%Next Build}">
+                            <a href="../../${it.nextBuildNumber}/stages" class="jenkins-button jenkins-button--tertiary app-details__prev_next" tooltip="${%Next Build}">
                                 <l:icon class="symbol-chevron-forward-outline plugin-ionicons-api icon-md" />
                             </a>
                         </j:if>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
@@ -1,3 +1,5 @@
+stages=Stages
+
 startedAgo=Started {0} ago
 noBuilds=No builds
 queued=Queued {0}

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewRebuildTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewRebuildTest.java
@@ -42,11 +42,11 @@ class PipelineGraphViewRebuildTest {
                 .goToPipelineOverview();
 
         String jobUrl = j.getURL() + job.getUrl();
-        assertThat(p).hasURL(jobUrl + "1/pipeline-overview/");
+        assertThat(p).hasURL(jobUrl + "1/stages/");
 
         op.rerun();
 
-        assertThat(p).hasURL(jobUrl + "2/pipeline-overview/");
+        assertThat(p).hasURL(jobUrl + "2/stages/");
 
         waitUntilBuildIsComplete(j, run);
     }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/playwright/PipelineOverviewPage.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/playwright/PipelineOverviewPage.java
@@ -18,7 +18,7 @@ public class PipelineOverviewPage extends JenkinsPage<PipelineOverviewPage> {
     private final String jobUrl;
 
     public PipelineOverviewPage(Page page, String jobUrl, String buildName) {
-        super(page, jobUrl + "pipeline-overview/");
+        super(page, jobUrl + "stages/");
         this.buildName = buildName;
         this.jobUrl = jobUrl;
         graph = new PipelineGraph(page.locator(".PWGx-PipelineGraph-container"));


### PR DESCRIPTION
Small PR to change '/pipeline-overview' to '/stages', also localises the tab display name.

### Testing done

* Works, no conflicts with other plugins

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
