### PR TITLE
Improve rendering of nested parallel stages

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.spec.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.spec.ts
@@ -351,6 +351,36 @@ describe("PipelineGraphLayout", () => {
         },
       ]);
     });
+
+    it("returns next best columns (GH#1155)", () => {
+      // The "proper columns" will require rendering of nested rows.
+      const columns = createNodeColumns([
+        makeStage(4, "top", [
+          makeParallel(7, "BranchA", [
+            makeStage(10, "Branch A", [
+              makeParallel(16, "A-1"),
+              makeParallel(17, "A-2"),
+            ]),
+          ]),
+          makeParallel(8, "BranchB", [
+            makeStage(12, "Branch B", [
+              makeParallel(21, "B-1"),
+              makeParallel(22, "B-2"),
+            ]),
+          ]),
+        ]),
+      ]);
+
+      expect(columns).toMatchObject([
+        {
+          hasBranchLabels: true,
+          rows: [
+            [makeNode(16, "A-1", "Branch A"), makeNode(17, "A-2", "Branch A")],
+            [makeNode(21, "B-1", "Branch B"), makeNode(22, "B-2", "Branch B")],
+          ],
+        },
+      ]);
+    });
   });
 
   describe("layoutGraph", () => {

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.ts
@@ -217,9 +217,18 @@ export function createNodeColumns(
       const rowNodes: Array<NodeInfo> = [];
       if (!willRecurse && stageHasChildren(nodeStage)) {
         column.hasBranchLabels = true;
-        forEachChildStage(nodeStage, (parentStage, childStage, _) =>
-          rowNodes.push(makeNodeForStage(childStage, parentStage.name)),
-        );
+        forEachChildStage(nodeStage, (parentStage, childStage, _) => {
+          const hasNestedParallel =
+            stageHasChildren(childStage) &&
+            childStage.children[0].type === "PARALLEL";
+          if (hasNestedParallel) {
+            for (const nested of childStage.children) {
+              rowNodes.push(makeNodeForStage(nested, childStage.name));
+            }
+          } else {
+            rowNodes.push(makeNodeForStage(childStage, parentStage.name));
+          }
+        });
       } else {
         rowNodes.push(makeNodeForStage(nodeStage));
       }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- For #1155

This PR is improving the rendering of nested parallel stages by displaying the nested stages.

The nested stages are displayed horizontal instead of vertical. This is a limitation of the current rendering/layout implementation. It only supports one layer of nesting. Adding support of nested "rows" is a significant piece of work.

This change is a best-effort to display nested parallel stages in the current layout architecture.

### Testing done

<img width="1066" height="412" alt="image" src="https://github.com/user-attachments/assets/5c962ff2-9e13-4a36-904a-6858cc7526a3" />

<details>
<summary> pipeline from #1155 </summary>

```groovy
// node('default') {
    stage('Top level') {
        // outer parallel: two branches
        parallel(
            // First top-level branch
            BranchA: {
                stage('Branch A') {
                    echo "Starting Branch A"

                    // inner parallel inside Branch A
                    parallel(
                        'A-1': {
                            stage('A-1') {
                                echo "Doing work in A-1"
                                sleep 2
                            }
                        },
                        'A-2': {
                            stage('A-2') {
                                echo "Doing work in A-2"
                                sleep 2
                            }
                        }
                    )

                    echo "Finished Branch A"
                }
            },

            // Second top-level branch
            BranchB: {
                stage('Branch B') {
                    echo "Starting Branch B"

                    // inner parallel inside Branch B
                    parallel(
                        'B-1': {
                            stage('B-1') {
                                echo "Doing work in B-1"
                                sleep 2
                            }
                        },
                        'B-2': {
                            stage('B-2') {
                                echo "Doing work in B-2"
                                sleep 2
                            }
                        }
                    )

                    echo "Finished Branch B"
                }
            }
        )
    }
// }
```
</details>


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
