### PR TITLE
Replace widget with console when there are no stages

### DIFF
--- a/src/main/frontend/common/RestClient.tsx
+++ b/src/main/frontend/common/RestClient.tsx
@@ -126,9 +126,9 @@ export async function getExceptionText(stepId: string): Promise<string[]> {
   }
 }
 
-export async function getConsoleBuildOutput(): Promise<string | null> {
+export async function getConsoleBuildOutput(url: string): Promise<string | null> {
   try {
-    const response = await fetch(`consoleBuildOutput`);
+    const response = await fetch(`${url}/stages/consoleBuildOutput`);
     if (!response.ok) throw response.statusText;
     return await response.text();
   } catch (e) {

--- a/src/main/frontend/common/RestClient.tsx
+++ b/src/main/frontend/common/RestClient.tsx
@@ -126,7 +126,9 @@ export async function getExceptionText(stepId: string): Promise<string[]> {
   }
 }
 
-export async function getConsoleBuildOutput(url: string): Promise<string | null> {
+export async function getConsoleBuildOutput(
+  url: string,
+): Promise<string | null> {
   try {
     const response = await fetch(`${url}/stages/consoleBuildOutput`);
     if (!response.ok) throw response.statusText;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/NoStageStepsFallback.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/NoStageStepsFallback.tsx
@@ -8,8 +8,8 @@ import { Result } from "../../../pipeline-graph-view/pipeline-graph/main/Pipelin
 
 const ConsoleLogStream = lazy(() => import("./ConsoleLogStream.tsx"));
 
-async function fetchData(): Promise<StepLogBufferInfo> {
-  const consoleBuildOutput = await getConsoleBuildOutput();
+async function fetchData(url: string): Promise<StepLogBufferInfo> {
+  const consoleBuildOutput = await getConsoleBuildOutput(url);
 
   return {
     lines: consoleBuildOutput?.split("\n") ?? [],
@@ -19,6 +19,7 @@ async function fetchData(): Promise<StepLogBufferInfo> {
 }
 
 interface NoStageStepsFallbackProps {
+  url: string;
   tailLogs: boolean;
   scrollToTail: (stepId: string, element: HTMLDivElement) => void;
 }
@@ -31,13 +32,13 @@ export function NoStageStepsFallback(props: NoStageStepsFallbackProps) {
   });
 
   useEffect(() => {
-    fetchData()
+    fetchData(props.url)
       .then((data) => {
         setLogBuffer(data);
         return data;
       })
       .catch((err) => console.log(err));
-  }, []);
+  }, [props.url]);
 
   return (
     <div className={"pgv-stage-steps"}>

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -161,7 +161,7 @@ export default function PipelineConsole() {
       )}
 
       {!loading && stages.length === 0 && (
-        <NoStageStepsFallback tailLogs={tailLogs} scrollToTail={scrollToTail} />
+        <NoStageStepsFallback url={currentRunPath} tailLogs={tailLogs} scrollToTail={scrollToTail} />
       )}
 
       <ScrollToTopBottom

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -161,7 +161,11 @@ export default function PipelineConsole() {
       )}
 
       {!loading && stages.length === 0 && (
-        <NoStageStepsFallback url={currentRunPath} tailLogs={tailLogs} scrollToTail={scrollToTail} />
+        <NoStageStepsFallback
+          url={currentRunPath}
+          tailLogs={tailLogs}
+          scrollToTail={scrollToTail}
+        />
       )}
 
       <ScrollToTopBottom

--- a/src/main/frontend/pipeline-graph-view/app.scss
+++ b/src/main/frontend/pipeline-graph-view/app.scss
@@ -46,3 +46,7 @@
   left: unset !important;
   top: unset !important;
 }
+
+.pgv-console-card {
+  margin: 0 -0.625rem -0.625rem -0.625rem;
+}

--- a/src/main/frontend/pipeline-graph-view/app.tsx
+++ b/src/main/frontend/pipeline-graph-view/app.tsx
@@ -1,27 +1,69 @@
 import "./app.scss";
 import "./pipeline-graph/styles/main.scss";
+import "../pipeline-console-view/pipeline-console/main/console-log-card.scss";
 
 import useRunPoller from "../common/tree-api.ts";
 import { UserPreferencesProvider } from "../common/user/user-preferences-provider.tsx";
 import Stages from "../pipeline-console-view/pipeline-console/main/components/stages.tsx";
+import { NoStageStepsFallback } from "../pipeline-console-view/pipeline-console/main/NoStageStepsFallback.tsx";
 import { StageViewPosition } from "../pipeline-console-view/pipeline-console/main/providers/user-preference-provider.tsx";
 
 export default function App() {
   const rootElement = document.getElementById("graph");
   const currentRunPath = rootElement?.dataset.currentRunPath!;
   const previousRunPath = rootElement?.dataset.previousRunPath;
-  const { run } = useRunPoller({
+  const { run, loading } = useRunPoller({
     currentRunPath,
     previousRunPath,
   });
 
   return (
     <UserPreferencesProvider>
-      <Stages
-        stages={run.stages}
-        stageViewPosition={StageViewPosition.TOP}
-        onRunPage
-      />
+      {!loading && run.stages.length === 0 && (
+        <>
+          <div className={"jenkins-card__title"}>
+            <a
+              href="stages"
+              className="jenkins-card__title-link jenkins-card__reveal"
+            >
+              Stages
+              {/* Markup copied from core */}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M184 112l144 144-144 144"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="48"
+                />
+              </svg>
+            </a>
+          </div>
+
+          <div className={"jenkins-card__content"}>
+            <div className={"pgv-console-card"}>
+              <NoStageStepsFallback
+                url={currentRunPath}
+                tailLogs={false}
+                scrollToTail={() => {}}
+              />
+            </div>
+          </div>
+        </>
+      )}
+
+      {run.stages.length > 0 && (
+        <Stages
+          stages={run.stages}
+          stageViewPosition={StageViewPosition.TOP}
+          onRunPage
+        />
+      )}
     </UserPreferencesProvider>
   );
 }


### PR DESCRIPTION
Small one to replace the widget with the console when there are no stages. When there's no stages the flow is a little awkward as it isn't immediately obvious whats happened. By showing the console we make it clear to the user what happened.

### Testing done

**Before**
<img width="1307" height="585" alt="Screenshot 2026-04-16 at 13 17 18" src="https://github.com/user-attachments/assets/863e6173-1c99-465c-a7ee-aaf5d84c2034" />

**After**
<img width="1317" height="621" alt="image" src="https://github.com/user-attachments/assets/9e59a947-96f0-4dc8-80b6-2640a115f0f9" />

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
