### PR TITLE
Save computed graph to disk if build is complete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,10 @@
   <dependencies>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
+      <artifactId>caffeine-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
       <artifactId>ionicons-api</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
@@ -157,6 +157,10 @@ public class PipelineGraphApi {
     }
 
     public PipelineGraph createTree() {
+        return PipelineGraphViewCache.get().getGraph(run, this::computeTree);
+    }
+
+    PipelineGraph computeTree() {
         return createTree(CachedPipelineNodeGraphAdaptor.instance.getFor(run));
     }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphViewCache.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphViewCache.java
@@ -44,9 +44,6 @@ public class PipelineGraphViewCache {
             return compute.get();
         }
         CachedPayload payload = load(run);
-        if (payload.graph != null) {
-            return payload.graph;
-        }
         synchronized (payload) {
             if (payload.graph == null) {
                 payload.graph = compute.get();
@@ -62,9 +59,6 @@ public class PipelineGraphViewCache {
             return compute.get();
         }
         CachedPayload payload = load(run);
-        if (payload.allSteps != null) {
-            return payload.allSteps;
-        }
         synchronized (payload) {
             if (payload.allSteps == null) {
                 payload.allSteps = compute.get();

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphViewCache.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphViewCache.java
@@ -1,0 +1,134 @@
+package io.jenkins.plugins.pipelinegraphview.utils;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import hudson.XmlFile;
+import hudson.util.XStream2;
+import io.jenkins.plugins.pipelinegraphview.analysis.TimingInfo;
+import java.io.File;
+import java.io.IOException;
+import java.util.function.Supplier;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Disk-backed cache for the computed pipeline graph and step list of completed runs.
+ * For in-progress runs the cache is transparent (every call recomputes). Once a run is
+ * no longer building, results are persisted under the run's directory, so later
+ * requests — including after a Jenkins restart — are served without recomputation.
+ */
+public class PipelineGraphViewCache {
+
+    /**
+     * Hand-bump when any persisted DTO shape changes in a non-backwards-compatible way.
+     * Older files are ignored and recomputed on the next read.
+     */
+    static final int SCHEMA_VERSION = 1;
+
+    private static final String CACHE_FILE_NAME = "pipeline-graph-view-cache.xml";
+    private static final Logger logger = LoggerFactory.getLogger(PipelineGraphViewCache.class);
+    private static final PipelineGraphViewCache INSTANCE = new PipelineGraphViewCache();
+
+    private final Cache<String, CachedPayload> memCache =
+            Caffeine.newBuilder().maximumSize(256).build();
+
+    public static PipelineGraphViewCache get() {
+        return INSTANCE;
+    }
+
+    PipelineGraphViewCache() {}
+
+    public PipelineGraph getGraph(WorkflowRun run, Supplier<PipelineGraph> compute) {
+        if (run.isBuilding()) {
+            return compute.get();
+        }
+        CachedPayload payload = load(run);
+        if (payload.graph != null) {
+            return payload.graph;
+        }
+        synchronized (payload) {
+            if (payload.graph == null) {
+                payload.graph = compute.get();
+                payload.schemaVersion = SCHEMA_VERSION;
+                write(run, payload);
+            }
+            return payload.graph;
+        }
+    }
+
+    public PipelineStepList getAllSteps(WorkflowRun run, Supplier<PipelineStepList> compute) {
+        if (run.isBuilding()) {
+            return compute.get();
+        }
+        CachedPayload payload = load(run);
+        if (payload.allSteps != null) {
+            return payload.allSteps;
+        }
+        synchronized (payload) {
+            if (payload.allSteps == null) {
+                payload.allSteps = compute.get();
+                payload.schemaVersion = SCHEMA_VERSION;
+                write(run, payload);
+            }
+            return payload.allSteps;
+        }
+    }
+
+    private CachedPayload load(WorkflowRun run) {
+        return memCache.get(run.getExternalizableId(), k -> readFromDisk(run));
+    }
+
+    private CachedPayload readFromDisk(WorkflowRun run) {
+        XmlFile file = cacheFile(run);
+        if (!file.exists()) {
+            return new CachedPayload();
+        }
+        try {
+            Object read = file.read();
+            if (read instanceof CachedPayload loaded && loaded.schemaVersion == SCHEMA_VERSION) {
+                return loaded;
+            }
+            logger.debug("Discarding pipeline graph cache for {}: schema version mismatch", run.getExternalizableId());
+        } catch (IOException e) {
+            logger.warn("Failed to read pipeline graph cache for {}", run.getExternalizableId(), e);
+        }
+        return new CachedPayload();
+    }
+
+    private void write(WorkflowRun run, CachedPayload payload) {
+        try {
+            cacheFile(run).write(payload);
+        } catch (IOException e) {
+            logger.warn("Failed to write pipeline graph cache for {}", run.getExternalizableId(), e);
+        }
+    }
+
+    private XmlFile cacheFile(WorkflowRun run) {
+        return new XmlFile(XSTREAM, new File(run.getRootDir(), CACHE_FILE_NAME));
+    }
+
+    /** Test hook: drop in-memory entries so the next call goes through the disk read path. */
+    void invalidateMemory() {
+        memCache.invalidateAll();
+    }
+
+    static class CachedPayload {
+        int schemaVersion;
+        PipelineGraph graph;
+        PipelineStepList allSteps;
+    }
+
+    private static final XStream2 XSTREAM = new XStream2();
+
+    static {
+        XSTREAM.alias("pipeline-graph-view-cache", CachedPayload.class);
+        XSTREAM.alias("pipeline-graph", PipelineGraph.class);
+        XSTREAM.alias("pipeline-stage", PipelineStage.class);
+        XSTREAM.alias("pipeline-step", PipelineStep.class);
+        XSTREAM.alias("pipeline-step-list", PipelineStepList.class);
+        XSTREAM.alias("pipeline-input-step", PipelineInputStep.class);
+        XSTREAM.alias("timing-info", TimingInfo.class);
+        XSTREAM.alias("pipeline-state", PipelineState.class);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
@@ -105,13 +105,20 @@ public class PipelineStepApi {
     }
 
     public PipelineStepList getSteps(String stageId) {
-        // Look up the completed state before computing steps.
-        boolean runIsComplete = !run.isBuilding();
-        return getSteps(stageId, CachedPipelineNodeGraphAdaptor.instance.getFor(run), runIsComplete);
+        PipelineStepList all = getAllSteps();
+        List<PipelineStep> filtered =
+                all.steps.stream().filter(s -> stageId.equals(s.stageId)).collect(Collectors.toList());
+        PipelineStepList result = new PipelineStepList(filtered, all.runIsComplete);
+        result.sort();
+        return result;
     }
 
     /* Returns a PipelineStepList, sorted by stageId and Id. */
     public PipelineStepList getAllSteps() {
+        return PipelineGraphViewCache.get().getAllSteps(run, this::computeAllSteps);
+    }
+
+    PipelineStepList computeAllSteps() {
         // Look up the completed state before computing steps.
         boolean runIsComplete = !run.isBuilding();
         return getAllSteps(CachedPipelineNodeGraphAdaptor.instance.getFor(run), runIsComplete);

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewTest.java
@@ -15,14 +15,10 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @WithJenkinsConfiguredWithCode
 @UsePlaywright(PlaywrightConfig.class)
 class PipelineGraphViewTest {
-    private static final Logger log = LoggerFactory.getLogger(PipelineGraphViewTest.class);
-
     // Code generation can be generated against local using to give an idea of what commands to use
     // mvn exec:java -e -D exec.mainClass="com.microsoft.playwright.CLI" -Dexec.classpathScope=test -Dexec.args="codegen
     // http://localhost:8080/jenkins
@@ -168,7 +164,7 @@ class PipelineGraphViewTest {
     @Test
     @ConfiguredWithCode("configure-appearance.yml")
     void errorWithMessage(Page p, JenkinsConfiguredWithCodeRule j) throws Exception {
-        String name = "gh1169";
+        String name = "gh1169_errorWithMessage";
         WorkflowRun run = TestUtils.createAndRunJob(j, name, "gh1169_errorWithMessage.jenkinsfile", Result.FAILURE);
 
         // Note that the locator used in stageHasSteps accumulates the error step's message text content into the found

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphViewCacheTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphViewCacheTest.java
@@ -1,0 +1,138 @@
+package io.jenkins.plugins.pipelinegraphview.utils;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep.*;
+
+import hudson.XmlFile;
+import hudson.model.Result;
+import hudson.util.XStream2;
+import io.jenkins.plugins.pipelinegraphview.utils.PipelineGraphViewCache.CachedPayload;
+import java.io.File;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class PipelineGraphViewCacheTest {
+
+    private static final String CACHE_FILE_NAME = "pipeline-graph-view-cache.xml";
+
+    private JenkinsRule j;
+    private PipelineGraphViewCache cache;
+
+    @BeforeEach
+    void setUp(JenkinsRule j) {
+        this.j = j;
+        // Use a fresh per-test instance so state doesn't leak between cases.
+        this.cache = new PipelineGraphViewCache();
+    }
+
+    @Test
+    void coldCache_computesAndWritesFile() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(j, "cold", "smokeTest.jenkinsfile", Result.FAILURE);
+        File cacheFile = new File(run.getRootDir(), CACHE_FILE_NAME);
+        assertThat("no cache file before first call", cacheFile.exists(), is(false));
+
+        AtomicInteger computes = new AtomicInteger();
+        PipelineGraph graph = cache.getGraph(run, () -> {
+            computes.incrementAndGet();
+            return new PipelineGraphApi(run).computeTree();
+        });
+
+        assertThat(graph, is(not(nullValue())));
+        assertThat(graph.stages.isEmpty(), is(false));
+        assertThat("supplier ran exactly once", computes.get(), equalTo(1));
+        assertThat("cache file exists after first call", cacheFile.exists(), is(true));
+        assertThat("cache file is non-empty", Files.size(cacheFile.toPath()), greaterThan(0L));
+    }
+
+    @Test
+    void warmCache_returnsPayloadWithoutComputing() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(j, "warm", "smokeTest.jenkinsfile", Result.FAILURE);
+        cache.getGraph(run, () -> new PipelineGraphApi(run).computeTree());
+
+        // Drop in-memory cache to force re-read from disk on next call.
+        cache.invalidateMemory();
+
+        AtomicInteger computes = new AtomicInteger();
+        PipelineGraph again = cache.getGraph(run, () -> {
+            computes.incrementAndGet();
+            return new PipelineGraphApi(run).computeTree();
+        });
+
+        assertThat(again, is(not(nullValue())));
+        assertThat("supplier did not run — served from disk", computes.get(), equalTo(0));
+        assertThat(again.stages.isEmpty(), is(false));
+    }
+
+    @Test
+    void inProgressRun_doesNotPersist() throws Exception {
+        WorkflowRun run = startLongRunningJob();
+        try {
+            AtomicInteger computes = new AtomicInteger();
+            cache.getGraph(run, () -> {
+                computes.incrementAndGet();
+                return new PipelineGraphApi(run).computeTree();
+            });
+            cache.getGraph(run, () -> {
+                computes.incrementAndGet();
+                return new PipelineGraphApi(run).computeTree();
+            });
+
+            File cacheFile = new File(run.getRootDir(), CACHE_FILE_NAME);
+            assertThat("no cache file while run is in-progress", cacheFile.exists(), is(false));
+            assertThat("both calls recomputed", computes.get(), equalTo(2));
+        } finally {
+            run.getExecutor().interrupt();
+            j.waitForCompletion(run);
+        }
+    }
+
+    @Test
+    void schemaVersionMismatch_isIgnoredAndRecomputed() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(j, "schema", "smokeTest.jenkinsfile", Result.FAILURE);
+        File cacheFile = new File(run.getRootDir(), CACHE_FILE_NAME);
+
+        // Write a stale-version payload directly to disk.
+        CachedPayload stale = new CachedPayload();
+        stale.schemaVersion = Integer.MIN_VALUE;
+        XStream2 xstream = new XStream2();
+        xstream.alias("pipeline-graph-view-cache", CachedPayload.class);
+        new XmlFile(xstream, cacheFile).write(stale);
+        assertThat(cacheFile.exists(), is(true));
+
+        AtomicInteger computes = new AtomicInteger();
+        PipelineGraph graph = cache.getGraph(run, () -> {
+            computes.incrementAndGet();
+            return new PipelineGraphApi(run).computeTree();
+        });
+
+        assertThat("stale file ignored; supplier ran", computes.get(), equalTo(1));
+        assertThat(graph.stages.isEmpty(), is(false));
+    }
+
+    private WorkflowRun startLongRunningJob() throws Exception {
+        String jenkinsfile = "node { echo 'hi'; semaphore 'wait' }";
+        var job = j.createProject(WorkflowJob.class, "running");
+        job.setDefinition(new CpsFlowDefinition(jenkinsfile, true));
+        var future = job.scheduleBuild2(0);
+        WorkflowRun run = future.waitForStart();
+        // Wait until the semaphore step is actually blocking so the run is reliably "building".
+        await().atMost(Duration.ofSeconds(30)).until(run::isBuilding);
+        waitForStart("wait/1", run);
+        return run;
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fixes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/885

### Testing done

- Automated tests

Manually checked in debugger that breakpoints are hit as expected
* Running builds compute each time
* Graph isn't recomputed after the first time

_Note: Browser caching means page refresh doesn't request it to be computed again, this is still useful if multiple developers hit the same build I think_


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
