### PR TITLE
Cache `WarningAction`s

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/analysis/StatusAndTiming.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/analysis/StatusAndTiming.java
@@ -31,6 +31,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Action;
 import hudson.model.Result;
+import io.jenkins.plugins.pipelinegraphview.livestate.LiveGraphRegistry;
+import io.jenkins.plugins.pipelinegraphview.livestate.WarningActionCache;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -349,7 +351,18 @@ public class StatusAndTiming {
         if (DISABLE_WARNING_ACTION_LOOKUP) {
             return null;
         }
-        // TODO: Cache the result?
+        // Only memoise closed blocks: once a BlockEndNode exists, the set of inner nodes is
+        // fixed and WarningActions on them don't change. For open-ended chunks (start == end,
+        // or end isn't a block end) the scan is either trivial or the result may still change.
+        boolean cacheable = start != end && end instanceof BlockEndNode<?>;
+        WarningActionCache cache = cacheable ? LiveGraphRegistry.get().warningActionCache(start.getExecution()) : null;
+        if (cache != null) {
+            return cache.getOrCompute(start.getId(), end.getId(), () -> scanForWarning(start, end));
+        }
+        return scanForWarning(start, end);
+    }
+
+    private static @CheckForNull WarningAction scanForWarning(@NonNull FlowNode start, @NonNull FlowNode end) {
         DepthFirstScanner scanner = new DepthFirstScanner();
         if (!scanner.setup(end, Collections.singletonList(start))) {
             return null;

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphRegistry.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphRegistry.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.pipelinegraphview.livestate;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineGraph;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineStepList;
 import java.time.Duration;
@@ -140,7 +141,7 @@ public final class LiveGraphRegistry {
      * Returns a per-run monitor that callers can synchronise on to dedup concurrent graph
      * rebuilds. Null when the live state isn't present (caller just computes directly).
      */
-    @edu.umd.cs.findbugs.annotations.CheckForNull
+    @CheckForNull
     public Object graphComputeLock(WorkflowRun run) {
         if (disabled()) {
             return null;
@@ -150,13 +151,30 @@ public final class LiveGraphRegistry {
     }
 
     /** See {@link #graphComputeLock(WorkflowRun)} — the matching lock for the steps path. */
-    @edu.umd.cs.findbugs.annotations.CheckForNull
+    @CheckForNull
     public Object allStepsComputeLock(WorkflowRun run) {
         if (disabled()) {
             return null;
         }
         LiveGraphState state = states.getIfPresent(run.getExternalizableId());
         return state == null ? null : state.allStepsComputeLock();
+    }
+
+    /**
+     * Returns the {@link WarningActionCache} for this execution, or {@code null} when the
+     * live state isn't present. Callers fall back to uncached scans on null.
+     */
+    @CheckForNull
+    public WarningActionCache warningActionCache(FlowExecution execution) {
+        if (disabled()) {
+            return null;
+        }
+        String key = keyFor(execution);
+        if (key == null) {
+            return null;
+        }
+        LiveGraphState state = states.getIfPresent(key);
+        return state == null ? null : state.warningActionCache();
     }
 
     private static String keyFor(FlowExecution execution) {

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphState.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphState.java
@@ -46,6 +46,8 @@ final class LiveGraphState {
     private VersionedCache<PipelineGraph> cachedGraph;
     private VersionedCache<PipelineStepList> cachedAllSteps;
 
+    private final WarningActionCache warningActionCache = new WarningActionCache();
+
     // Serialise concurrent rebuilds so N HTTP readers don't each do the same O(nodes) work.
     // Separate locks for tree vs steps — a slow tree rebuild must not starve steps.
     private final Object graphComputeLock = new Object();
@@ -170,6 +172,10 @@ final class LiveGraphState {
 
     Object allStepsComputeLock() {
         return allStepsComputeLock;
+    }
+
+    WarningActionCache warningActionCache() {
+        return warningActionCache;
     }
 
     private record VersionedCache<T>(long version, T value) {}

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/WarningActionCache.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/WarningActionCache.java
@@ -1,0 +1,47 @@
+package io.jenkins.plugins.pipelinegraphview.livestate;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import org.jenkinsci.plugins.workflow.actions.WarningAction;
+
+/**
+ * Per-run cache of {@link WarningAction} lookups between two flow nodes. The underlying scan
+ * in {@code StatusAndTiming.findWorstWarningBetween} walks every node between a stage's start
+ * and end, which dominates {@code /allSteps} on large completed runs. WarningActions don't
+ * change after attach, so once both endpoints exist (and for completed blocks, the set of
+ * inner nodes is fixed) the result is stable and can be memoised.
+ */
+public final class WarningActionCache {
+
+    // ConcurrentHashMap disallows null values, so we wrap each result in Optional — the
+    // Optional is never itself null, it's either present (a WarningAction) or empty
+    // (cached: no warning on this range). Map.get returning null means "not yet cached".
+    private final Map<String, Optional<WarningAction>> byRange = new ConcurrentHashMap<>();
+
+    WarningActionCache() {}
+
+    /**
+     * Returns the cached result for {@code (startId, endId)}, or invokes {@code computer} to
+     * resolve and caches the result before returning.
+     */
+    @CheckForNull
+    public WarningAction getOrCompute(
+            @NonNull String startId, @NonNull String endId, @NonNull Supplier<WarningAction> computer) {
+        String k = key(startId, endId);
+        Optional<WarningAction> cached = byRange.get(k);
+        if (cached != null) {
+            return cached.orElse(null);
+        }
+        WarningAction computed = computer.get();
+        byRange.put(k, Optional.ofNullable(computed));
+        return computed;
+    }
+
+    private static String key(String startId, String endId) {
+        return startId + ':' + endId;
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Follow up to https://github.com/jenkinsci/pipeline-graph-view-plugin/pull/1225

> cache findWorstWarningBetween results on the live snapshot alongside the ancestry/hideFromView data we already capture at onNewHead time. WarningActions are attached once
per node and never change, so the cache is stable per-version. That would knock another second or two off /allSteps.

Once we reach the end of the block we can cache the `WarningAction` so we aren't constantly walking the nodes to see if one is attached.

### Testing done

After running the 300K flowNode generator pipeline for 4 mins I get these results:

```
  15:42:46 allSteps   200     101.8ms    123334 bytes
  15:42:49 tree       200      50.9ms      3995 bytes
  15:42:49 allSteps   200      73.5ms    124354 bytes
  15:42:52 tree       200      52.3ms      3995 bytes
  15:42:52 allSteps   200     113.4ms    125581 bytes
  15:42:55 tree       200      34.1ms      3995 bytes
  15:42:56 allSteps   200      69.3ms    126836 bytes
  15:42:59 tree       200      42.7ms      3995 bytes
  15:42:59 allSteps   200      73.0ms    128030 bytes
```

Before and After is quite similar currently, once its been running for awhile I'll re-run the test with before and after and see the impact.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
