### PR TITLE
Install Chromium-only Playwright browser during test lifecycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,10 +180,10 @@
         <executions>
           <execution>
             <id>install-playwright-chromium</id>
-            <phase>generate-test-resources</phase>
             <goals>
               <goal>java</goal>
             </goals>
+            <phase>generate-test-resources</phase>
             <configuration>
               <mainClass>com.microsoft.playwright.CLI</mainClass>
               <classpathScope>test</classpathScope>

--- a/pom.xml
+++ b/pom.xml
@@ -170,10 +170,37 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.6.3</version>
+        <executions>
+          <execution>
+            <id>install-playwright-chromium</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>com.microsoft.playwright.CLI</mainClass>
+              <classpathScope>test</classpathScope>
+              <!-- Playwright CLI calls System.exit; without blocking it, it halts Maven execution. -->
+              <blockSystemExit>true</blockSystemExit>
+              <arguments>
+                <argument>install</argument>
+                <argument>chromium</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
+          <environmentVariables>
+            <PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD>1</PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD>
+          </environmentVariables>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Updated the use of playwright to only install the browsers that are used in the tests.

- run Playwright CLI from Maven before tests
- install Chromium only instead of all Playwright browsers
- prevent Playwright CLI System.exit from stopping Maven
- disable browser auto-download during surefire execution

### Testing done

Unit tests run and the logs clearly show only chromium instance (and deps) being installed.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
