### PR TITLE
Cache `WorkspaceAction` candidates

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphState.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphState.java
@@ -35,6 +35,12 @@ final class LiveGraphState {
     // whether a step is hidden by intersecting with the step's enclosing IDs, avoiding a
     // per-step {@code iterateEnclosingBlocks} walk through storage.
     private final Set<String> hideFromViewBlockStartIds = ConcurrentHashMap.newKeySet();
+
+    // StepStartNodes observed so far — the only flow-node kind that can carry a
+    // WorkspaceAction. Scanning {@code nodes} for WorkspaceAction at snapshot time was
+    // O(N) with ~300k nodes even though only a handful are actual {@code node{}} blocks;
+    // keeping this narrower list means snapshot scans O(candidates) instead.
+    private final List<FlowNode> workspaceCandidates = new ArrayList<>();
     private long version = 0;
     private volatile boolean poisoned = false;
 
@@ -66,8 +72,8 @@ final class LiveGraphState {
         } catch (Throwable ignored) {
             enclosingIdsByNodeId.put(node.getId(), List.of());
         }
-        // See the hideFromViewBlockStartIds field comment for why this is captured here.
         if (node instanceof StepStartNode stepStartNode) {
+            // See the hideFromViewBlockStartIds field comment for why this is captured here.
             try {
                 StepDescriptor descriptor = stepStartNode.getDescriptor();
                 if (descriptor != null && HideFromViewStep.class.getName().equals(descriptor.getId())) {
@@ -76,6 +82,9 @@ final class LiveGraphState {
             } catch (Throwable ignored) {
                 // Descriptor lookup is best-effort; fall back to "not hidden".
             }
+            // WorkspaceAction can only attach to a StepStartNode; track all of them so
+            // snapshot can check this narrower list instead of every FlowNode.
+            workspaceCandidates.add(node);
         }
         version++;
     }
@@ -100,17 +109,19 @@ final class LiveGraphState {
     }
 
     LiveGraphSnapshot snapshot() {
-        // Only the nodes list needs to be copied — enclosingIds and hideFromView are on
+        // Only the node lists need to be copied — enclosingIds and hideFromView are on
         // concurrent structures we can publish by reference. Keeping the monitor-held
-        // section down to a single array copy means addNode (on the CPS VM thread) almost
-        // never blocks on a snapshot.
+        // section down to a couple of array copies means addNode (on the CPS VM thread)
+        // almost never blocks on a snapshot.
         List<FlowNode> nodesCopy;
+        List<FlowNode> candidatesCopy;
         long v;
         synchronized (this) {
             if (poisoned || !ready) {
                 return null;
             }
             nodesCopy = new ArrayList<>(nodes);
+            candidatesCopy = new ArrayList<>(workspaceCandidates);
             v = version;
         }
         // Scan for WorkspaceAction outside the monitor: each getAction call walks the node's
@@ -119,8 +130,8 @@ final class LiveGraphState {
         // order matches DepthFirstScanner so PipelineGraphApi#getStageNode picks the
         // innermost workspace for nested agents.
         List<FlowNode> workspaceNodes = new ArrayList<>();
-        for (int i = nodesCopy.size() - 1; i >= 0; i--) {
-            FlowNode n = nodesCopy.get(i);
+        for (int i = candidatesCopy.size() - 1; i >= 0; i--) {
+            FlowNode n = candidatesCopy.get(i);
             if (n.getAction(WorkspaceAction.class) != null) {
                 workspaceNodes.add(n);
             }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeTreeScanner.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeTreeScanner.java
@@ -260,9 +260,7 @@ public class PipelineNodeTreeScanner {
                         .filter(e -> isStartNode(e.getValue()))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             }
-            // Remap operates on each entry independently — the result doesn't depend on
-            // iteration order, so we skip the O(N log N) sort.
-            for (FlowNodeWrapper stage : new ArrayList<>(stageMap.values())) {
+            for (FlowNodeWrapper stage : stageMap.values()) {
                 FlowNodeWrapper firstParent = stage.getFirstParent();
                 // Remap parentage of stages that aren't children of stages (e.g. allocate node
                 // step).
@@ -346,9 +344,7 @@ public class PipelineNodeTreeScanner {
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
             Map<String, FlowNodeWrapper> stageMap = this.getStageMapping();
-            // Same story as getStageMapping — no cross-iteration dependency, so sorting the
-            // ~300k-entry step map was pure overhead.
-            for (FlowNodeWrapper step : new ArrayList<>(stepMap.values())) {
+            for (FlowNodeWrapper step : stepMap.values()) {
                 FlowNodeWrapper firstParent = step.getFirstParent();
                 // Remap parentage of steps that aren't children of stages (e.g. are in Step
                 // Block).

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeTreeScanner.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeTreeScanner.java
@@ -260,9 +260,9 @@ public class PipelineNodeTreeScanner {
                         .filter(e -> isStartNode(e.getValue()))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             }
-            List<FlowNodeWrapper> nodeList = new ArrayList<>(stageMap.values());
-            nodeList.sort(new FlowNodeWrapper.NodeComparator());
-            for (FlowNodeWrapper stage : nodeList) {
+            // Remap operates on each entry independently — the result doesn't depend on
+            // iteration order, so we skip the O(N log N) sort.
+            for (FlowNodeWrapper stage : new ArrayList<>(stageMap.values())) {
                 FlowNodeWrapper firstParent = stage.getFirstParent();
                 // Remap parentage of stages that aren't children of stages (e.g. allocate node
                 // step).
@@ -346,9 +346,9 @@ public class PipelineNodeTreeScanner {
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
             Map<String, FlowNodeWrapper> stageMap = this.getStageMapping();
-            List<FlowNodeWrapper> nodeList = new ArrayList<>(stepMap.values());
-            nodeList.sort(new FlowNodeWrapper.NodeComparator());
-            for (FlowNodeWrapper step : nodeList) {
+            // Same story as getStageMapping — no cross-iteration dependency, so sorting the
+            // ~300k-entry step map was pure overhead.
+            for (FlowNodeWrapper step : new ArrayList<>(stepMap.values())) {
                 FlowNodeWrapper firstParent = step.getFirstParent();
                 // Remap parentage of steps that aren't children of stages (e.g. are in Step
                 // Block).


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- LiveGraphState.snapshot() walked every node in the live-state (~300k) calling getAction(WorkspaceAction.class) to build the workspace-node list. WorkspaceAction can only attach to a StepStartNode, so
  the vast majority of that work was wasted.
- GraphBuilder.getStageMapping / getStepMapping each sorted their entire value list with NodeComparator before iterating, but the loops check each entry's parent independently with no cross-iteration
  dependency. The sort was pure overhead — TimSort on the ~300k step map showed up as a top frame in most active samples.

## Changes

  - Narrower workspace scan. LiveGraphState tracks a workspaceCandidates list populated in addNode when a StepStartNode arrives. snapshot() iterates that list for the workspace scan instead of every node
  — O(candidates) instead of O(N).
  - Drop the remap sorts. Both getStageMapping and getStepMapping loops now iterate map values directly. No ordering dependency, no sort.

### Testing done

  From before/after thread dumps on the same 300k-node pipeline:

  - FlowNode.getAction(WorkspaceAction.class) from LiveGraphState.snapshot — was 1-2 of every ~10 active samples, now absent.
  - TimSort.binarySort from getStageMapping / getStepMapping — was 4-5 of every ~10 active samples, now absent.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
