### PR TITLE
Don't wrap collections in unmodifiable

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphSnapshot.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphSnapshot.java
@@ -6,15 +6,18 @@ import java.util.Set;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
 /**
- * Immutable projection of a {@link LiveGraphState} at a point in time.
+ * Projection of a {@link LiveGraphState} at a point in time.
+ *
+ * <p><strong>Consumers must treat every collection here as read-only.</strong>
+ * {@code enclosingIdsByNodeId} and {@code hideFromViewBlockStartIds} are the live concurrent
+ * structures from the underlying state — the CPS VM thread continues to write to them while
+ * the snapshot is in use. Iteration is safe (weakly consistent), mutation is not.
  *
  * <p>{@code enclosingIdsByNodeId} carries each captured node's ancestor chain so graph
- * construction can resolve parentage without touching the execution's FlowNode storage
- * (and its read lock, which contends with the running build's writes).
+ * construction can resolve parentage without touching the execution's FlowNode storage.
  *
  * <p>{@code hideFromViewBlockStartIds} is the set of {@code hideFromView} block-start IDs,
- * so callers can derive a step's "hidden" flag by intersecting with the step's enclosing
- * IDs — no per-step storage walk required.
+ * so callers can derive a step's "hidden" flag by intersecting with the step's enclosing IDs.
  *
  * <p>{@code version} is a monotonic counter that bumps on every new flow node, so callers
  * can use it as a cache key for computed DTOs.

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphState.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphState.java
@@ -126,8 +126,7 @@ final class LiveGraphState {
         }
         // Concurrent maps/sets are published by reference — consumers must treat them as
         // read-only (see {@link LiveGraphSnapshot}).
-        return new LiveGraphSnapshot(
-                nodesCopy, workspaceNodes, enclosingIdsByNodeId, hideFromViewBlockStartIds, v);
+        return new LiveGraphSnapshot(nodesCopy, workspaceNodes, enclosingIdsByNodeId, hideFromViewBlockStartIds, v);
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphState.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphState.java
@@ -4,7 +4,6 @@ import io.jenkins.plugins.pipelinegraphview.steps.HideFromViewStep;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineGraph;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineStepList;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -125,12 +124,10 @@ final class LiveGraphState {
                 workspaceNodes.add(n);
             }
         }
+        // Concurrent maps/sets are published by reference — consumers must treat them as
+        // read-only (see {@link LiveGraphSnapshot}).
         return new LiveGraphSnapshot(
-                Collections.unmodifiableList(nodesCopy),
-                Collections.unmodifiableList(workspaceNodes),
-                Collections.unmodifiableMap(enclosingIdsByNodeId),
-                Collections.unmodifiableSet(hideFromViewBlockStartIds),
-                v);
+                nodesCopy, workspaceNodes, enclosingIdsByNodeId, hideFromViewBlockStartIds, v);
     }
 
     /**


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Whilst its nice to do this it introduces overhead when the collections get large.

 Follow-up to #1225 / #1230. A 100-sample thread-dump run on the 300k-node perf pipeline showed 4 of 64 runnable samples landing in `Collections$UnmodifiableCollection$1.hasNext` /
  `Collections$UnmodifiableMap.get`. 

Those wrappers were added in `LiveGraphState.snapshot()` to signal immutability to consumers, but every access goes through a delegation call that JIT doesn't fully
  leave out on the hot path.

### Testing done

Automated tests so far

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
