### PR TITLE
Reduce CPS lock contention

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphLifecycle.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphLifecycle.java
@@ -65,8 +65,8 @@ public class LiveGraphLifecycle extends FlowExecutionListener {
                 if (snapshot != null) {
                     // Share a single adapter so both graph and step builds reuse one
                     // tree-scanner pass.
-                    PipelineNodeGraphAdapter adapter =
-                            new PipelineNodeGraphAdapter(run, snapshot.nodes(), snapshot.enclosingIdsByNodeId());
+                    PipelineNodeGraphAdapter adapter = new PipelineNodeGraphAdapter(
+                            run, snapshot.nodes(), snapshot.enclosingIdsByNodeId(), snapshot.activeNodeIds());
                     // Force runIsComplete=true for the step list: WorkflowRun.isBuilding() can
                     // still return true here even though the execution is complete.
                     graph = new PipelineGraphApi(run)

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphRegistry.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphRegistry.java
@@ -86,7 +86,7 @@ public final class LiveGraphRegistry {
             return null;
         }
         LiveGraphState state = states.getIfPresent(run.getExternalizableId());
-        return state == null ? null : state.snapshot();
+        return state == null ? null : state.snapshot(run.getExecution());
     }
 
     void remove(FlowExecution execution) {

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphSnapshot.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphSnapshot.java
@@ -20,9 +20,8 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
  * so callers can derive a step's "hidden" flag by intersecting with the step's enclosing IDs.
  *
  * <p>{@code activeNodeIds} contains the IDs of all nodes considered "active" at snapshot
- * time (current heads plus their enclosing block starts). Status resolution uses this
- * instead of {@link org.jenkinsci.plugins.workflow.graph.FlowNode#isActive()}, which takes
- * the {@code CpsFlowExecution} monitor per call.
+ * time: the execution's current heads plus every enclosing block start. Status resolution
+ * reads liveness from this set.
  *
  * <p>{@code version} is a monotonic counter that bumps on every new flow node, so callers
  * can use it as a cache key for computed DTOs.

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphSnapshot.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphSnapshot.java
@@ -19,6 +19,11 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
  * <p>{@code hideFromViewBlockStartIds} is the set of {@code hideFromView} block-start IDs,
  * so callers can derive a step's "hidden" flag by intersecting with the step's enclosing IDs.
  *
+ * <p>{@code activeNodeIds} contains the IDs of all nodes considered "active" at snapshot
+ * time (current heads plus their enclosing block starts). Status resolution uses this
+ * instead of {@link org.jenkinsci.plugins.workflow.graph.FlowNode#isActive()}, which takes
+ * the {@code CpsFlowExecution} monitor per call.
+ *
  * <p>{@code version} is a monotonic counter that bumps on every new flow node, so callers
  * can use it as a cache key for computed DTOs.
  */
@@ -27,4 +32,5 @@ public record LiveGraphSnapshot(
         List<FlowNode> workspaceNodes,
         Map<String, List<String>> enclosingIdsByNodeId,
         Set<String> hideFromViewBlockStartIds,
+        Set<String> activeNodeIds,
         long version) {}

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphState.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphState.java
@@ -145,9 +145,8 @@ final class LiveGraphState {
 
     /**
      * Resolves the "active" node set for this snapshot: all current heads plus every
-     * enclosing block start. Status-resolution code consults this set instead of calling
-     * {@link FlowNode#isActive()}, which takes the {@code CpsFlowExecution} monitor per call.
-     * Prefers the already-captured {@link #enclosingIdsByNodeId} over a fresh storage walk.
+     * enclosing block start. Prefers the already-captured {@link #enclosingIdsByNodeId} over
+     * a fresh storage walk when looking up a head's enclosing chain.
      */
     private Set<String> computeActiveNodeIds(FlowExecution execution) {
         if (execution == null || execution.isComplete()) {

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphState.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphState.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 
@@ -107,7 +108,7 @@ final class LiveGraphState {
         return version;
     }
 
-    LiveGraphSnapshot snapshot() {
+    LiveGraphSnapshot snapshot(FlowExecution execution) {
         // Only the node lists need to be copied — enclosingIds and hideFromView are on
         // concurrent structures we can publish by reference. Keeping the monitor-held
         // section down to a couple of array copies means addNode (on the CPS VM thread)
@@ -137,7 +138,42 @@ final class LiveGraphState {
         }
         // Concurrent maps/sets are published by reference — consumers must treat them as
         // read-only (see {@link LiveGraphSnapshot}).
-        return new LiveGraphSnapshot(nodesCopy, workspaceNodes, enclosingIdsByNodeId, hideFromViewBlockStartIds, v);
+        Set<String> activeNodeIds = computeActiveNodeIds(execution);
+        return new LiveGraphSnapshot(
+                nodesCopy, workspaceNodes, enclosingIdsByNodeId, hideFromViewBlockStartIds, activeNodeIds, v);
+    }
+
+    /**
+     * Resolves the "active" node set for this snapshot: all current heads plus every
+     * enclosing block start. Status-resolution code consults this set instead of calling
+     * {@link FlowNode#isActive()}, which takes the {@code CpsFlowExecution} monitor per call.
+     * Prefers the already-captured {@link #enclosingIdsByNodeId} over a fresh storage walk.
+     */
+    private Set<String> computeActiveNodeIds(FlowExecution execution) {
+        if (execution == null || execution.isComplete()) {
+            return Set.of();
+        }
+        Set<String> active = new HashSet<>();
+        try {
+            for (FlowNode head : execution.getCurrentHeads()) {
+                active.add(head.getId());
+                List<String> enclosing = enclosingIdsByNodeId.get(head.getId());
+                if (enclosing != null) {
+                    active.addAll(enclosing);
+                } else {
+                    try {
+                        active.addAll(head.getAllEnclosingIds());
+                    } catch (Throwable ignored) {
+                        // Best-effort: a missing enclosing chain just means a few block
+                        // starts won't be flagged active, which degrades gracefully.
+                    }
+                }
+            }
+        } catch (Throwable ignored) {
+            // Execution may become invalid; callers fall back to FlowNode#isActive().
+            return Set.of();
+        }
+        return Set.copyOf(active);
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
@@ -136,11 +136,9 @@ public class NodeRelationship {
     }
 
     /**
-     * Same as {@link #getStatus(WorkflowRun)} but with a pre-resolved {@code activeNodeIds}
-     * set so per-node {@link FlowNode#isActive()} calls (which take the CPS monitor) can be
-     * replaced with a lock-free {@link Set#contains(Object)} lookup. Only the step-node leaf
-     * uses the set; block-case resolution defers to {@link #getStatus(WorkflowRun)} so
-     * subclass overrides (e.g. {@link ParallelBlockRelationship}) still apply.
+     * Same as {@link #getStatus(WorkflowRun)} but threads {@code activeNodeIds} through to
+     * the step-node leaf. Block cases defer to {@link #getStatus(WorkflowRun)} so subclass
+     * overrides (e.g. {@link ParallelBlockRelationship}) apply.
      */
     public @NonNull NodeRunStatus getStatus(WorkflowRun run, @CheckForNull Set<String> activeNodeIds) {
         if (activeNodeIds == null) {
@@ -158,13 +156,9 @@ public class NodeRelationship {
                 return new NodeRunStatus(GenericStatus.fromResult(warningAction.getResult()));
             }
         }
-        // Step node: start and end are the same FlowNode. Skip FlowNode#isActive in favour
-        // of the pre-resolved set.
         if (this.start.getId().equals(this.end.getId())) {
             return new NodeRunStatus(this.start, activeNodeIds);
         }
-        // Block case — subclass may override getStatus(WorkflowRun) to aggregate across
-        // children (e.g. parallel branches), so defer to it.
         return getStatus(run);
     }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
@@ -8,6 +8,7 @@ import io.jenkins.plugins.pipelinegraphview.analysis.TimingInfo;
 import io.jenkins.plugins.pipelinegraphview.utils.BlueRun;
 import io.jenkins.plugins.pipelinegraphview.utils.NodeRunStatus;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineNodeUtil;
+import java.util.Set;
 import org.jenkinsci.plugins.workflow.actions.WarningAction;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -105,6 +106,15 @@ public class NodeRelationship {
      * Gets Status for relationship.
      */
     public @NonNull NodeRunStatus getStatus(WorkflowRun run) {
+        return getStatus(run, null);
+    }
+
+    /**
+     * Same as {@link #getStatus(WorkflowRun)} but with a pre-resolved {@code activeNodeIds}
+     * set so per-node {@link FlowNode#isActive()} calls (which take the CPS monitor) can be
+     * replaced with a lock-free {@link Set#contains(Object)} lookup.
+     */
+    public @NonNull NodeRunStatus getStatus(WorkflowRun run, @CheckForNull Set<String> activeNodeIds) {
         boolean skippedStage = PipelineNodeUtil.isSkippedStage(start);
         if (skippedStage) {
             return new NodeRunStatus(BlueRun.BlueRunResult.NOT_BUILT, BlueRun.BlueRunState.SKIPPED);
@@ -126,7 +136,7 @@ public class NodeRelationship {
 
         // If start and end are equal this is a StepNode
         if (this.start.getId().equals(this.end.getId())) {
-            return new NodeRunStatus(this.start);
+            return new NodeRunStatus(this.start, activeNodeIds);
         }
 
         // Catch-all if none of the above are applicable.

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
@@ -106,15 +106,6 @@ public class NodeRelationship {
      * Gets Status for relationship.
      */
     public @NonNull NodeRunStatus getStatus(WorkflowRun run) {
-        return getStatus(run, null);
-    }
-
-    /**
-     * Same as {@link #getStatus(WorkflowRun)} but with a pre-resolved {@code activeNodeIds}
-     * set so per-node {@link FlowNode#isActive()} calls (which take the CPS monitor) can be
-     * replaced with a lock-free {@link Set#contains(Object)} lookup.
-     */
-    public @NonNull NodeRunStatus getStatus(WorkflowRun run, @CheckForNull Set<String> activeNodeIds) {
         boolean skippedStage = PipelineNodeUtil.isSkippedStage(start);
         if (skippedStage) {
             return new NodeRunStatus(BlueRun.BlueRunResult.NOT_BUILT, BlueRun.BlueRunState.SKIPPED);
@@ -136,11 +127,44 @@ public class NodeRelationship {
 
         // If start and end are equal this is a StepNode
         if (this.start.getId().equals(this.end.getId())) {
-            return new NodeRunStatus(this.start, activeNodeIds);
+            return new NodeRunStatus(this.start);
         }
 
         // Catch-all if none of the above are applicable.
         return new NodeRunStatus(
                 StatusAndTiming.computeChunkStatus2(run, this.before, this.start, this.end, this.after));
+    }
+
+    /**
+     * Same as {@link #getStatus(WorkflowRun)} but with a pre-resolved {@code activeNodeIds}
+     * set so per-node {@link FlowNode#isActive()} calls (which take the CPS monitor) can be
+     * replaced with a lock-free {@link Set#contains(Object)} lookup. Only the step-node leaf
+     * uses the set; block-case resolution defers to {@link #getStatus(WorkflowRun)} so
+     * subclass overrides (e.g. {@link ParallelBlockRelationship}) still apply.
+     */
+    public @NonNull NodeRunStatus getStatus(WorkflowRun run, @CheckForNull Set<String> activeNodeIds) {
+        if (activeNodeIds == null) {
+            return getStatus(run);
+        }
+        if (PipelineNodeUtil.isSkippedStage(start)) {
+            return new NodeRunStatus(BlueRun.BlueRunResult.NOT_BUILT, BlueRun.BlueRunState.SKIPPED);
+        }
+        if (PipelineNodeUtil.isPaused(this.end)) {
+            return new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.PAUSED);
+        }
+        if (PipelineNodeUtil.isStage(start)) {
+            WarningAction warningAction = start.getPersistentAction(WarningAction.class);
+            if (warningAction != null) {
+                return new NodeRunStatus(GenericStatus.fromResult(warningAction.getResult()));
+            }
+        }
+        // Step node: start and end are the same FlowNode. Skip FlowNode#isActive in favour
+        // of the pre-resolved set.
+        if (this.start.getId().equals(this.end.getId())) {
+            return new NodeRunStatus(this.start, activeNodeIds);
+        }
+        // Block case — subclass may override getStatus(WorkflowRun) to aggregate across
+        // children (e.g. parallel branches), so defer to it.
+        return getStatus(run);
     }
 }

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeGraphAdapter.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeGraphAdapter.java
@@ -45,10 +45,8 @@ public class PipelineNodeGraphAdapter implements PipelineGraphBuilderApi, Pipeli
 
     /**
      * Builds the adapter over a pre-collected node set plus pre-computed snapshot data.
-     * Supplying {@code enclosingIdsByNodeId} lets graph construction resolve ancestry without
-     * touching the execution's node storage. Supplying {@code activeNodeIds} replaces the
-     * synchronised {@link FlowNode#isActive()} call in per-node status resolution with a
-     * lock-free set membership check.
+     * Supply {@code enclosingIdsByNodeId} to read ancestry from the map instead of FlowNode
+     * storage, and {@code activeNodeIds} to use the set for per-node liveness checks.
      */
     public PipelineNodeGraphAdapter(
             WorkflowRun run,

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeGraphAdapter.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeGraphAdapter.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -39,20 +40,22 @@ public class PipelineNodeGraphAdapter implements PipelineGraphBuilderApi, Pipeli
 
     /** Builds the adapter over a pre-collected node set rather than walking the execution. */
     public PipelineNodeGraphAdapter(WorkflowRun run, Collection<FlowNode> preCollectedNodes) {
-        this(run, preCollectedNodes, null);
+        this(run, preCollectedNodes, null, null);
     }
 
     /**
-     * Builds the adapter over a pre-collected node set plus a pre-computed
-     * {@code nodeId → enclosingIds} map. Supplying the map lets graph construction resolve
-     * ancestry without touching the execution's node storage (and its read lock, which
-     * contends with the running build's writes).
+     * Builds the adapter over a pre-collected node set plus pre-computed snapshot data.
+     * Supplying {@code enclosingIdsByNodeId} lets graph construction resolve ancestry without
+     * touching the execution's node storage. Supplying {@code activeNodeIds} replaces the
+     * synchronised {@link FlowNode#isActive()} call in per-node status resolution with a
+     * lock-free set membership check.
      */
     public PipelineNodeGraphAdapter(
             WorkflowRun run,
             Collection<FlowNode> preCollectedNodes,
-            @CheckForNull Map<String, List<String>> enclosingIdsByNodeId) {
-        treeScanner = new PipelineNodeTreeScanner(run, preCollectedNodes, enclosingIdsByNodeId);
+            @CheckForNull Map<String, List<String>> enclosingIdsByNodeId,
+            @CheckForNull Set<String> activeNodeIds) {
+        treeScanner = new PipelineNodeTreeScanner(run, preCollectedNodes, enclosingIdsByNodeId, activeNodeIds);
     }
 
     private final Object pipelineLock = new Object();

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeTreeScanner.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeTreeScanner.java
@@ -61,11 +61,10 @@ public class PipelineNodeTreeScanner {
 
     /**
      * Builds from a caller-supplied node collection, skipping the {@link DepthFirstScanner}
-     * walk. The caller is responsible for having observed every node already. Pass
-     * {@code enclosingIdsByNodeId} to skip the storage read lock during ancestry resolution
-     * (the live-state path captures this on the CPS VM thread). Pass {@code activeNodeIds} to
-     * replace {@link FlowNode#isActive()}'s synchronised CPS lookup with a lock-free set
-     * membership check.
+     * walk. The caller is responsible for having observed every node already. Supply
+     * {@code enclosingIdsByNodeId} to read ancestry from the map instead of FlowNode storage,
+     * and {@code activeNodeIds} to use the set for liveness checks instead of
+     * {@link FlowNode#isActive()}.
      */
     public PipelineNodeTreeScanner(
             @NonNull WorkflowRun run,
@@ -202,8 +201,8 @@ public class PipelineNodeTreeScanner {
         @CheckForNull
         private final Map<String, List<String>> enclosingIdsByNodeId;
 
-        // Optional pre-computed set of node IDs that are active (current heads + enclosing
-        // blocks). When present, NodeRunStatus skips the synchronised FlowNode#isActive call.
+        // Node IDs considered active at snapshot time (current heads + enclosing blocks).
+        // When non-null, {@code NodeRunStatus} reads liveness from this set.
         @CheckForNull
         private final Set<String> activeNodeIds;
 

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeTreeScanner.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeTreeScanner.java
@@ -63,16 +63,19 @@ public class PipelineNodeTreeScanner {
      * Builds from a caller-supplied node collection, skipping the {@link DepthFirstScanner}
      * walk. The caller is responsible for having observed every node already. Pass
      * {@code enclosingIdsByNodeId} to skip the storage read lock during ancestry resolution
-     * (the live-state path captures this on the CPS VM thread).
+     * (the live-state path captures this on the CPS VM thread). Pass {@code activeNodeIds} to
+     * replace {@link FlowNode#isActive()}'s synchronised CPS lookup with a lock-free set
+     * membership check.
      */
     public PipelineNodeTreeScanner(
             @NonNull WorkflowRun run,
             @NonNull Collection<FlowNode> nodes,
-            @CheckForNull Map<String, List<String>> enclosingIdsByNodeId) {
+            @CheckForNull Map<String, List<String>> enclosingIdsByNodeId,
+            @CheckForNull Set<String> activeNodeIds) {
         this.run = run;
         this.execution = run.getExecution();
         this.declarative = run.getAction(ExecutionModelAction.class) != null;
-        this.buildFrom(nodes, enclosingIdsByNodeId);
+        this.buildFrom(nodes, enclosingIdsByNodeId, activeNodeIds);
     }
 
     /**
@@ -83,7 +86,7 @@ public class PipelineNodeTreeScanner {
             logger.debug("Building graph");
         }
         if (execution != null) {
-            buildFrom(getAllNodes(), null);
+            buildFrom(getAllNodes(), null, null);
         } else {
             this.stageNodeMap = new LinkedHashMap<>();
             this.stepNodeMap = new LinkedHashMap<>();
@@ -93,7 +96,10 @@ public class PipelineNodeTreeScanner {
         }
     }
 
-    private void buildFrom(Collection<FlowNode> nodes, @CheckForNull Map<String, List<String>> enclosingIdsByNodeId) {
+    private void buildFrom(
+            Collection<FlowNode> nodes,
+            @CheckForNull Map<String, List<String>> enclosingIdsByNodeId,
+            @CheckForNull Set<String> activeNodeIds) {
         if (execution == null || nodes.isEmpty()) {
             this.stageNodeMap = new LinkedHashMap<>();
             this.stepNodeMap = new LinkedHashMap<>();
@@ -101,7 +107,8 @@ public class PipelineNodeTreeScanner {
         }
         NodeRelationshipFinder finder = new NodeRelationshipFinder(enclosingIdsByNodeId);
         Map<String, NodeRelationship> relationships = finder.getNodeRelationships(nodes);
-        GraphBuilder builder = new GraphBuilder(nodes, relationships, this.run, this.execution, enclosingIdsByNodeId);
+        GraphBuilder builder =
+                new GraphBuilder(nodes, relationships, this.run, this.execution, enclosingIdsByNodeId, activeNodeIds);
         if (isDebugEnabled) {
             logger.debug("Original nodes: count={}", builder.getNodes().size());
         }
@@ -195,6 +202,11 @@ public class PipelineNodeTreeScanner {
         @CheckForNull
         private final Map<String, List<String>> enclosingIdsByNodeId;
 
+        // Optional pre-computed set of node IDs that are active (current heads + enclosing
+        // blocks). When present, NodeRunStatus skips the synchronised FlowNode#isActive call.
+        @CheckForNull
+        private final Set<String> activeNodeIds;
+
         private final Map<String, FlowNodeWrapper> wrappedNodeMap = new LinkedHashMap<>();
         // These two are populated when required using by filtering unwanted nodes from
         // 'wrappedNodeMap' into a new map.
@@ -217,13 +229,15 @@ public class PipelineNodeTreeScanner {
                 @NonNull Map<String, NodeRelationship> relationships,
                 @NonNull WorkflowRun run,
                 @NonNull FlowExecution execution,
-                @CheckForNull Map<String, List<String>> enclosingIdsByNodeId) {
+                @CheckForNull Map<String, List<String>> enclosingIdsByNodeId,
+                @CheckForNull Set<String> activeNodeIds) {
             this.nodes = nodes;
             this.relationships = relationships;
             this.run = run;
             this.inputAction = run.getAction(InputAction.class);
             this.execution = execution;
             this.enclosingIdsByNodeId = enclosingIdsByNodeId;
+            this.activeNodeIds = activeNodeIds;
             buildGraph();
         }
 
@@ -540,7 +554,7 @@ public class PipelineNodeTreeScanner {
                 status = parallelRelationship.getBranchStatus(this.run, (BlockStartNode) node);
             } else {
                 timing = relationship.getTimingInfo(this.run);
-                status = relationship.getStatus(this.run);
+                status = relationship.getStatus(this.run, activeNodeIds);
             }
 
             InputStep inputStep = null;

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/NodeRunStatus.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/NodeRunStatus.java
@@ -1,9 +1,11 @@
 package io.jenkins.plugins.pipelinegraphview.utils;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Result;
 import io.jenkins.plugins.pipelinegraphview.analysis.GenericStatus;
 import io.jenkins.plugins.pipelinegraphview.analysis.StatusAndTiming;
+import java.util.Set;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.actions.NotExecutedNodeAction;
 import org.jenkinsci.plugins.workflow.actions.QueueItemAction;
@@ -18,6 +20,16 @@ public class NodeRunStatus {
     public final BlueRun.BlueRunState state;
 
     public NodeRunStatus(@NonNull FlowNode endNode) {
+        this(endNode, null);
+    }
+
+    /**
+     * When {@code activeNodeIds} is non-null it replaces {@link FlowNode#isActive()} — the latter
+     * synchronises on {@code CpsFlowExecution} per call, which contends with the CPS VM thread
+     * for every one of thousands of per-node status checks.
+     */
+    public NodeRunStatus(@NonNull FlowNode endNode, @CheckForNull Set<String> activeNodeIds) {
+        boolean active = activeNodeIds != null ? activeNodeIds.contains(endNode.getId()) : endNode.isActive();
         ErrorAction errorAction = endNode.getError();
         WarningAction warningAction = endNode.getPersistentAction(WarningAction.class);
         if (errorAction != null) {
@@ -26,17 +38,17 @@ public class NodeRunStatus {
                 result = ((FlowInterruptedException) errorAction.getError()).getResult();
             }
             this.result = result != null ? BlueRun.BlueRunResult.fromResult(result) : BlueRun.BlueRunResult.FAILURE;
-            this.state = endNode.isActive() ? BlueRun.BlueRunState.RUNNING : BlueRun.BlueRunState.FINISHED;
+            this.state = active ? BlueRun.BlueRunState.RUNNING : BlueRun.BlueRunState.FINISHED;
         } else if (warningAction != null) {
             this.result = BlueRun.BlueRunResult.fromResult(warningAction.getResult());
-            this.state = endNode.isActive() ? BlueRun.BlueRunState.RUNNING : BlueRun.BlueRunState.FINISHED;
+            this.state = active ? BlueRun.BlueRunState.RUNNING : BlueRun.BlueRunState.FINISHED;
         } else if (QueueItemAction.getNodeState(endNode) == QueueItemAction.QueueState.QUEUED) {
             this.result = BlueRun.BlueRunResult.UNKNOWN;
             this.state = BlueRun.BlueRunState.QUEUED;
         } else if (QueueItemAction.getNodeState(endNode) == QueueItemAction.QueueState.CANCELLED) {
             this.result = BlueRun.BlueRunResult.ABORTED;
             this.state = BlueRun.BlueRunState.FINISHED;
-        } else if (endNode.isActive()) {
+        } else if (active) {
             this.result = BlueRun.BlueRunResult.UNKNOWN;
             this.state = BlueRun.BlueRunState.RUNNING;
         } else if (NotExecutedNodeAction.isExecuted(endNode)) {

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/NodeRunStatus.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/NodeRunStatus.java
@@ -24,9 +24,8 @@ public class NodeRunStatus {
     }
 
     /**
-     * When {@code activeNodeIds} is non-null it replaces {@link FlowNode#isActive()} — the latter
-     * synchronises on {@code CpsFlowExecution} per call, which contends with the CPS VM thread
-     * for every one of thousands of per-node status checks.
+     * When {@code activeNodeIds} is non-null, liveness is read from the set rather than from
+     * {@link FlowNode#isActive()}.
      */
     public NodeRunStatus(@NonNull FlowNode endNode, @CheckForNull Set<String> activeNodeIds) {
         boolean active = activeNodeIds != null ? activeNodeIds.contains(endNode.getId()) : endNode.isActive();

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
@@ -226,7 +226,8 @@ public class PipelineGraphApi {
                 LiveGraphSnapshot snapshot = LiveGraphRegistry.get().snapshot(run);
                 if (snapshot != null) {
                     PipelineGraph computed = createTree(
-                            new PipelineNodeGraphAdapter(run, snapshot.nodes(), snapshot.enclosingIdsByNodeId()),
+                            new PipelineNodeGraphAdapter(
+                                    run, snapshot.nodes(), snapshot.enclosingIdsByNodeId(), snapshot.activeNodeIds()),
                             snapshot.workspaceNodes(),
                             snapshot.enclosingIdsByNodeId());
                     LiveGraphRegistry.get().cacheGraph(run, snapshot.version(), computed);

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApi.java
@@ -181,7 +181,8 @@ public class PipelineStepApi {
                 LiveGraphSnapshot snapshot = LiveGraphRegistry.get().snapshot(run);
                 if (snapshot != null) {
                     PipelineStepList computed = getAllSteps(
-                            new PipelineNodeGraphAdapter(run, snapshot.nodes(), snapshot.enclosingIdsByNodeId()),
+                            new PipelineNodeGraphAdapter(
+                                    run, snapshot.nodes(), snapshot.enclosingIdsByNodeId(), snapshot.activeNodeIds()),
                             runIsComplete,
                             snapshot.hideFromViewBlockStartIds(),
                             snapshot.enclosingIdsByNodeId());


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

  Follow-up after the `WarningActionCache`, sort-caching, and `unmodifiable`-wrapper PRs. A 100-dump thread-dump run on the 300k-node perf pipeline showed the next dominant hot spot as
  `FlowNode.isActive()` → `CpsFlowExecution.isCurrentHead`, a **synchronised** lookup taken once per `NodeRunStatus` construction:

  - 3 RUNNABLE samples holding the CPS monitor inside `isCurrentHead`
  - 3 BLOCKED samples waiting to acquire the same monitor
  - 2 samples inside `TreeMap.successor` as part of `isCurrentHead`

  That's 8/67 samples (~12%) concentrated on one synchronised code path, and it contended with the CPS VM thread that was still producing new flow nodes on the live build.

------

Compute the "active" node set **once** per snapshot, publish it with the snapshot, and swap the per-node `FlowNode.isActive()` call for a lock-free `Set.contains(id)`.

  Active set = current heads ∪ enclosing block starts of those heads. That matches the `StandardGraphLookupView.isActive` semantics (a head is active; a block-start is active while its block hasn't
  ended).

  The set is resolved in `LiveGraphState.snapshot(FlowExecution)`:

  - If execution is complete → empty set.
  - Otherwise take one pass over `execution.getCurrentHeads()`, reading each head's enclosing IDs from the already-captured `enclosingIdsByNodeId` map (falling back to `getAllEnclosingIds()` only for
  nodes missing from the map).


### Testing done

Run it in a combined branch against the 300k flow node job:

```
  22:23:19 allSteps   200     466.9ms   1398761 bytes
  22:23:23 tree       200     240.4ms     30099 bytes
  22:23:23 allSteps   200     444.3ms   1400249 bytes
  22:23:27 tree       200     257.1ms     30099 bytes
  22:23:27 allSteps   200     571.1ms   1401549 bytes
  22:23:31 tree       200     234.7ms     30099 bytes
  22:23:31 allSteps   200     464.8ms   1402412 bytes
  22:23:35 tree       200     235.9ms     30099 bytes
  22:23:35 allSteps   200     474.4ms   1403464 bytes
  22:23:39 tree       200     358.4ms     30099 bytes
  22:23:40 allSteps   000     947.3ms  0000,0,0 bytes
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
