### PR TITLE
Cache per-block timing and status

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/BlockResolutionCache.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/BlockResolutionCache.java
@@ -1,0 +1,42 @@
+package io.jenkins.plugins.pipelinegraphview.livestate;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.jenkins.plugins.pipelinegraphview.analysis.TimingInfo;
+import io.jenkins.plugins.pipelinegraphview.utils.NodeRunStatus;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Per-run cache of computed {@link TimingInfo} and {@link NodeRunStatus} for closed
+ * block relationships, keyed by {@code (startId, endId)}. Entries are stable once the
+ * block has ended, so the cache never needs to invalidate.
+ */
+public final class BlockResolutionCache {
+
+    private final Map<String, TimingInfo> timingByRange = new ConcurrentHashMap<>();
+    private final Map<String, NodeRunStatus> statusByRange = new ConcurrentHashMap<>();
+
+    BlockResolutionCache() {}
+
+    @NonNull
+    public TimingInfo getOrComputeTiming(
+            @NonNull String startId, @NonNull String endId, @NonNull Supplier<TimingInfo> computer) {
+        return timingByRange.computeIfAbsent(key(startId, endId), k -> computer.get());
+    }
+
+    @NonNull
+    public NodeRunStatus getOrComputeStatus(
+            @NonNull String startId, @NonNull String endId, @NonNull Supplier<NodeRunStatus> computer) {
+        return statusByRange.computeIfAbsent(key(startId, endId), k -> computer.get());
+    }
+
+    /** Visible for testing — combined size of the timing and status caches. */
+    int size() {
+        return timingByRange.size() + statusByRange.size();
+    }
+
+    private static String key(String startId, String endId) {
+        return startId + ':' + endId;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphRegistry.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphRegistry.java
@@ -177,6 +177,23 @@ public final class LiveGraphRegistry {
         return state == null ? null : state.warningActionCache();
     }
 
+    /**
+     * Returns the {@link BlockResolutionCache} for this execution, or {@code null} when the
+     * live state isn't present. Callers fall back to uncached resolution on null.
+     */
+    @CheckForNull
+    public BlockResolutionCache blockResolutionCache(FlowExecution execution) {
+        if (disabled()) {
+            return null;
+        }
+        String key = keyFor(execution);
+        if (key == null) {
+            return null;
+        }
+        LiveGraphState state = states.getIfPresent(key);
+        return state == null ? null : state.blockResolutionCache();
+    }
+
     private static String keyFor(FlowExecution execution) {
         try {
             Object exec = execution.getOwner().getExecutable();

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphState.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/livestate/LiveGraphState.java
@@ -52,6 +52,7 @@ final class LiveGraphState {
     private VersionedCache<PipelineStepList> cachedAllSteps;
 
     private final WarningActionCache warningActionCache = new WarningActionCache();
+    private final BlockResolutionCache blockResolutionCache = new BlockResolutionCache();
 
     // Serialise concurrent rebuilds so N HTTP readers don't each do the same O(nodes) work.
     // Separate locks for tree vs steps — a slow tree rebuild must not starve steps.
@@ -183,6 +184,10 @@ final class LiveGraphState {
 
     WarningActionCache warningActionCache() {
         return warningActionCache;
+    }
+
+    BlockResolutionCache blockResolutionCache() {
+        return blockResolutionCache;
     }
 
     private record VersionedCache<T>(long version, T value) {}

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeTreeScanner.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeTreeScanner.java
@@ -3,6 +3,8 @@ package io.jenkins.plugins.pipelinegraphview.treescanner;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.plugins.pipelinegraphview.analysis.TimingInfo;
+import io.jenkins.plugins.pipelinegraphview.livestate.BlockResolutionCache;
+import io.jenkins.plugins.pipelinegraphview.livestate.LiveGraphRegistry;
 import io.jenkins.plugins.pipelinegraphview.utils.FlowNodeWrapper;
 import io.jenkins.plugins.pipelinegraphview.utils.NodeRunStatus;
 import io.jenkins.plugins.pipelinegraphview.utils.PipelineNodeUtil;
@@ -539,8 +541,23 @@ public class PipelineNodeTreeScanner {
                 timing = parallelRelationship.getBranchTimingInfo(this.run, (BlockStartNode) node);
                 status = parallelRelationship.getBranchStatus(this.run, (BlockStartNode) node);
             } else {
-                timing = relationship.getTimingInfo(this.run);
-                status = relationship.getStatus(this.run);
+                FlowNode start = relationship.getStart();
+                FlowNode end = relationship.getEnd();
+                // Timing and status for a closed block are stable once the BlockEndNode
+                // exists; memoise so subsequent requests don't re-walk actions per block.
+                BlockResolutionCache cache =
+                        (start != end && end instanceof BlockEndNode<?>)
+                                ? LiveGraphRegistry.get().blockResolutionCache(execution)
+                                : null;
+                if (cache != null) {
+                    timing = cache.getOrComputeTiming(
+                            start.getId(), end.getId(), () -> relationship.getTimingInfo(this.run));
+                    status = cache.getOrComputeStatus(
+                            start.getId(), end.getId(), () -> relationship.getStatus(this.run));
+                } else {
+                    timing = relationship.getTimingInfo(this.run);
+                    status = relationship.getStatus(this.run);
+                }
             }
 
             InputStep inputStep = null;

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeTreeScanner.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/PipelineNodeTreeScanner.java
@@ -545,10 +545,9 @@ public class PipelineNodeTreeScanner {
                 FlowNode end = relationship.getEnd();
                 // Timing and status for a closed block are stable once the BlockEndNode
                 // exists; memoise so subsequent requests don't re-walk actions per block.
-                BlockResolutionCache cache =
-                        (start != end && end instanceof BlockEndNode<?>)
-                                ? LiveGraphRegistry.get().blockResolutionCache(execution)
-                                : null;
+                BlockResolutionCache cache = (start != end && end instanceof BlockEndNode<?>)
+                        ? LiveGraphRegistry.get().blockResolutionCache(execution)
+                        : null;
                 if (cache != null) {
                     timing = cache.getOrComputeTiming(
                             start.getId(), end.getId(), () -> relationship.getTimingInfo(this.run));

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/livestate/BlockResolutionCacheTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/livestate/BlockResolutionCacheTest.java
@@ -1,0 +1,67 @@
+package io.jenkins.plugins.pipelinegraphview.livestate;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+import io.jenkins.plugins.pipelinegraphview.analysis.TimingInfo;
+import io.jenkins.plugins.pipelinegraphview.utils.BlueRun;
+import io.jenkins.plugins.pipelinegraphview.utils.NodeRunStatus;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class BlockResolutionCacheTest {
+
+    @Test
+    void cachesTimingAndStatusPerRange() {
+        BlockResolutionCache cache = new BlockResolutionCache();
+        TimingInfo timing = new TimingInfo(100, 10, 1L);
+        NodeRunStatus status = new NodeRunStatus(BlueRun.BlueRunResult.SUCCESS, BlueRun.BlueRunState.FINISHED);
+        AtomicInteger timingCalls = new AtomicInteger();
+        AtomicInteger statusCalls = new AtomicInteger();
+
+        TimingInfo t1 = cache.getOrComputeTiming("3", "8", () -> {
+            timingCalls.incrementAndGet();
+            return timing;
+        });
+        TimingInfo t2 = cache.getOrComputeTiming("3", "8", () -> {
+            timingCalls.incrementAndGet();
+            return timing;
+        });
+        NodeRunStatus s1 = cache.getOrComputeStatus("3", "8", () -> {
+            statusCalls.incrementAndGet();
+            return status;
+        });
+        NodeRunStatus s2 = cache.getOrComputeStatus("3", "8", () -> {
+            statusCalls.incrementAndGet();
+            return status;
+        });
+
+        assertThat(t1, sameInstance(timing));
+        assertThat(t2, sameInstance(timing));
+        assertThat(s1, sameInstance(status));
+        assertThat(s2, sameInstance(status));
+        assertThat(timingCalls.get(), is(1));
+        assertThat(statusCalls.get(), is(1));
+    }
+
+    @Test
+    void differentRangesCacheIndependently() {
+        BlockResolutionCache cache = new BlockResolutionCache();
+        TimingInfo timingA = new TimingInfo(100, 0, 1L);
+        TimingInfo timingB = new TimingInfo(200, 0, 2L);
+
+        assertThat(cache.getOrComputeTiming("1", "5", () -> timingA), sameInstance(timingA));
+        assertThat(cache.getOrComputeTiming("6", "9", () -> timingB), sameInstance(timingB));
+        assertThat(
+                cache.getOrComputeTiming("1", "5", () -> {
+                    throw new AssertionError("should be cached");
+                }),
+                sameInstance(timingA));
+        assertThat(
+                cache.getOrComputeTiming("6", "9", () -> {
+                    throw new AssertionError("should be cached");
+                }),
+                sameInstance(timingB));
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

 Follow-up after the CPS-lock-contention and unmodifiable-wrapper PRs. A 100-dump thread-dump run on the 300k-node perf pipeline showed ~10 samples concentrated on `NodeRelationship.getTimingInfo` →
  `PauseAction.getPauseActions` and `getStatus`, called once per wrapped stage/parallel block in `GraphBuilder.wrapNode`. For closed blocks those computations are stable — the end node exists, actions
  don't change after attach — so they can be memoised across requests, same shape as `WarningActionCache`.


-----

Noticed `isSkippedStage` has a similar issue, will look into it in a follow-up


### Testing done

Ran it on the 300k node pipeline, one `getStatus` showed up, was probably an in-progress block, getTimingInfo didn't show at all

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
