### PR TITLE
Improve graph performance

### DIFF
--- a/src/main/frontend/common/components/status-icon.tsx
+++ b/src/main/frontend/common/components/status-icon.tsx
@@ -226,16 +226,8 @@ function Group({
   status: Result;
   children: ReactNode;
 }) {
-  return (
-    <g
-      style={{
-        transform: currentStatus !== status ? "scale(0)" : "scale(1)",
-        opacity: currentStatus !== status ? 0 : 1,
-      }}
-    >
-      {children}
-    </g>
-  );
+  if (currentStatus !== status) return null;
+  return <>{children}</>;
 }
 
 export function resultToColor(result: Result, skeleton: boolean | undefined) {

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
@@ -1,6 +1,6 @@
 import "./stages.scss";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import {
   TransformComponent,
   TransformWrapper,
@@ -22,6 +22,14 @@ export default function Stages({
   onRunPage,
 }: StagesProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+
+  const handleStageSelect = useCallback(
+    (nodeId: string) => {
+      onStageSelect?.(nodeId);
+      setIsExpanded(false);
+    },
+    [onStageSelect],
+  );
 
   return (
     <div
@@ -101,12 +109,7 @@ export default function Stages({
           <PipelineGraph
             stages={stages}
             selectedStage={selectedStage}
-            {...(onStageSelect && {
-              onStageSelect: (e) => {
-                onStageSelect(e);
-                setIsExpanded(false);
-              },
-            })}
+            {...(onStageSelect && { onStageSelect: handleStageSelect })}
           />
         </TransformComponent>
       </TransformWrapper>

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useContext, useMemo } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Context as TransformContext } from "react-zoom-pan-pinch";
 
 import { I18NContext } from "../../../common/i18n/index.ts";
 import { useUserPreferences } from "../../../common/user/user-preferences-provider.tsx";
@@ -12,6 +20,15 @@ import {
   TimingsLabel,
 } from "./support/labels.tsx";
 import { Node, SelectionHighlight } from "./support/nodes.tsx";
+
+interface Viewport {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+const VIEWPORT_MARGIN = 300;
 
 export function PipelineGraph({
   stages = [],
@@ -59,9 +76,112 @@ export function PipelineGraph({
     [selectedStage],
   );
 
-  const nodes = nodeColumns.flatMap((column) => {
-    return column.rows.flatMap((row) => row);
-  });
+  const nodes = useMemo(
+    () => nodeColumns.flatMap((column) => column.rows.flatMap((row) => row)),
+    [nodeColumns],
+  );
+
+  // When inside a TransformWrapper, only mount the nodes/labels intersecting
+  // the visible region. Mounting thousands of absolute-positioned divs forces
+  // a synchronous layout flush that blocks the main thread for seconds.
+  const transform = useContext(TransformContext);
+  const virtualize = transform != null;
+  const [viewport, setViewport] = useState<Viewport | null>(null);
+  const cachedViewport = useRef<Viewport | null>(null);
+
+  useEffect(() => {
+    if (!transform) return;
+    let raf = 0;
+    const compute = () => {
+      raf = 0;
+      const wrapper = transform.wrapperComponent;
+      if (!wrapper) return;
+      const { positionX, positionY, scale } = transform.state;
+      const next: Viewport = {
+        x: -positionX / scale,
+        y: -positionY / scale,
+        w: wrapper.offsetWidth / scale,
+        h: wrapper.offsetHeight / scale,
+      };
+      const prev = cachedViewport.current;
+      if (
+        prev &&
+        Math.abs(prev.x - next.x) < 50 &&
+        Math.abs(prev.y - next.y) < 50 &&
+        Math.abs(prev.w - next.w) < 50 &&
+        Math.abs(prev.h - next.h) < 50
+      ) {
+        return;
+      }
+      cachedViewport.current = next;
+      setViewport(next);
+    };
+    const schedule = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(compute);
+    };
+    schedule();
+    const unsubChange = transform.onChange(schedule);
+    const unsubInit = transform.wrapperComponent
+      ? undefined
+      : transform.onInit(() => schedule());
+    const observer = new ResizeObserver(schedule);
+    const observed = transform.wrapperComponent;
+    if (observed) observer.observe(observed);
+    const unsubInitObserve = transform.wrapperComponent
+      ? undefined
+      : transform.onInit((ctx) => {
+          if (ctx.instance.wrapperComponent) {
+            observer.observe(ctx.instance.wrapperComponent);
+          }
+        });
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      unsubChange();
+      unsubInit?.();
+      unsubInitObserve?.();
+      observer.disconnect();
+    };
+  }, [transform]);
+
+  const isInViewport = useCallback(
+    (x: number, y: number): boolean => {
+      if (!virtualize) return true;
+      if (!viewport) return false;
+      return (
+        x >= viewport.x - VIEWPORT_MARGIN &&
+        x <= viewport.x + viewport.w + VIEWPORT_MARGIN &&
+        y >= viewport.y - VIEWPORT_MARGIN &&
+        y <= viewport.y + viewport.h + VIEWPORT_MARGIN
+      );
+    },
+    [viewport, virtualize],
+  );
+
+  const selectedStageId = selectedStage?.id;
+  const visibleNodes = useMemo(() => {
+    const filtered = nodes.filter((n) => isInViewport(n.x, n.y));
+    if (!virtualize || selectedStageId == null) return filtered;
+    if (
+      filtered.some((n) => !n.isPlaceholder && n.stage?.id === selectedStageId)
+    ) {
+      return filtered;
+    }
+    const sel = nodes.find(
+      (n) => !n.isPlaceholder && n.stage?.id === selectedStageId,
+    );
+    return sel ? [...filtered, sel] : filtered;
+  }, [nodes, isInViewport, virtualize, selectedStageId]);
+
+  const visibleSmallLabels = useMemo(
+    () => smallLabels.filter((l) => isInViewport(l.x, l.y)),
+    [smallLabels, isInViewport],
+  );
+
+  const visibleBranchLabels = useMemo(
+    () => branchLabels.filter((l) => isInViewport(l.x, l.y)),
+    [branchLabels, isInViewport],
+  );
 
   const outerDivStyle = {
     position: "relative" as const,
@@ -81,7 +201,7 @@ export function PipelineGraph({
           />
         </svg>
 
-        {nodes.map((node) => (
+        {visibleNodes.map((node) => (
           <Node
             key={node.id}
             node={node}
@@ -113,7 +233,7 @@ export function PipelineGraph({
           />
         ))}
 
-        {smallLabels.map((label) => (
+        {visibleSmallLabels.map((label) => (
           <SmallLabel
             key={label.key}
             details={label}
@@ -122,7 +242,7 @@ export function PipelineGraph({
           />
         ))}
 
-        {branchLabels.map((label) => (
+        {visibleBranchLabels.map((label) => (
           <SequentialContainerLabel
             key={label.key}
             details={label}

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties } from "react";
+import { CSSProperties, memo } from "react";
 
 import LiveTotal from "../../../../common/utils/live-total.tsx";
 import { sequentialStagesLabelOffset } from "../PipelineGraphLayout.ts";
@@ -14,10 +14,9 @@ interface RenderBigLabelProps {
   isSelected: boolean;
 }
 
-/**
- * Generate the Component for a big label
- */
-export function BigLabel({
+export const BigLabel = memo(BigLabelImpl);
+
+function BigLabelImpl({
   details,
   layout,
   measuredHeight,
@@ -73,10 +72,9 @@ export function BigLabel({
   );
 }
 
-/**
- * Generate the Component for a big label
- */
-export function TimingsLabel({
+export const TimingsLabel = memo(TimingsLabelImpl);
+
+function TimingsLabelImpl({
   details,
   layout,
   measuredHeight,
@@ -139,10 +137,9 @@ interface SmallLabelProps {
   isSelected?: boolean;
 }
 
-/**
- * Generate the Component for a small label
- */
-export function SmallLabel({ details, layout, isSelected }: SmallLabelProps) {
+export const SmallLabel = memo(SmallLabelImpl);
+
+function SmallLabelImpl({ details, layout, isSelected }: SmallLabelProps) {
   const {
     nodeSpacingH,
     nodeSpacingV,
@@ -194,10 +191,9 @@ interface SequentialContainerLabelProps {
   layout: LayoutInfo;
 }
 
-/**
- * Generate the Component for a small label denoting the name of the container of a group of sequential parallel stages
- */
-export function SequentialContainerLabel({
+export const SequentialContainerLabel = memo(SequentialContainerLabelImpl);
+
+function SequentialContainerLabelImpl({
   details,
   layout,
 }: SequentialContainerLabelProps) {

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.tsx
@@ -1,6 +1,6 @@
 import "./nodes.scss";
 
-import { CSSProperties, ReactElement } from "react";
+import { CSSProperties, memo, ReactElement } from "react";
 
 import {
   resultToColor,
@@ -29,15 +29,9 @@ interface NodeProps {
   isSelected: boolean;
 }
 
-/**
- * Generate the SVG elements to represent a node.
- */
-export function Node({
-  node,
-  collapsed,
-  onStageSelect,
-  isSelected,
-}: NodeProps) {
+export const Node = memo(NodeImpl);
+
+function NodeImpl({ node, collapsed, onStageSelect, isSelected }: NodeProps) {
   const key = node.key;
 
   if (node.isPlaceholder) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Follow up to https://github.com/jenkinsci/pipeline-graph-view-plugin/pull/1238 which improved the "Stages" / tree view component. This is for faster loading of the Graph.

Before this change the graph took ~4s to load.

A CPU profile pointed at `getComponentsSizes` in `react-zoom-pan-pinch` (~2.9s self-time).

It reads `wrapperComponent.offsetWidth` during init, which forces a synchronous layout flush over the ~36k DOM elements the graph mounts. 

Two changes:
  - `StatusIcon` rendered all ten status groups per icon with `transform: scale(0)` for non-matching ones. `Group` now returns `null` when not matching, dropping ~85k hidden SVG elements.
  - `PipelineGraph` now reads `react-zoom-pan-pinch`'s `Context` and viewport-culls `Node` / `SmallLabel` / `SequentialContainerLabel` to those intersecting the visible region (with margin). Initial
  render mounts nothing, the wrapper measures cheaply, the effect captures the viewport, and the next render mounts only the visible subset (~67 nodes vs 3,009). Outside `TransformWrapper` (e.g.
  `MultiPipelineGraph`'s `SingleRun`) virtualisation is off and everything renders. The selected stage is always included so the highlight has a target. 

A `ResizeObserver` on the wrapper picks up size changes (fullscreen toggle, window resize) since `transform.onChange` only fires on transform-state changes.

A separate optimisation:
  `Node`, `BigLabel`, `TimingsLabel`, `SmallLabel`, `SequentialContainerLabel` are wrapped in `React.memo` and `onStageSelect` is stabilised with `useCallback` at the call site so polling-driven parent
  re-renders don't churn through thousands of children.


### Testing done

Tested with the 300k node pipeline, instant loading now.

Tested with:
* Just graph
* Just stages
* Both

Checked a running pipeline works fine
Checked skeleton is fine

Not checked leaving the tab open while running on large amount of nodes yet, will try check that.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
