### PR TITLE
Include starting of pipeline info

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.spec.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.spec.tsx
@@ -1,0 +1,186 @@
+/** * @vitest-environment jsdom */
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { TextEncoder } from "util";
+import { vi } from "vitest";
+
+import {
+  Result,
+  StageInfo,
+} from "../../../pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx";
+import { useStepsPoller } from "./hooks/use-steps-poller.ts";
+import PipelineConsole from "./PipelineConsole.tsx";
+import { FilterProvider } from "./providers/filter-provider.tsx";
+import { useLayoutPreferences } from "./providers/user-preference-provider.tsx";
+
+(globalThis as any).TextEncoder = TextEncoder;
+
+vi.mock("./hooks/use-steps-poller.ts", () => ({
+  useStepsPoller: vi.fn(),
+}));
+
+vi.mock("./providers/user-preference-provider.tsx", async () => ({
+  ...(await vi.importActual("./providers/user-preference-provider.tsx")),
+  useLayoutPreferences: vi.fn(),
+}));
+
+vi.mock("./ConsoleLogStream.tsx", () => ({
+  default: ({ logBuffer }: any) => (
+    <div data-testid="console-log-stream">
+      {logBuffer.lines.map((line: string, i: number) => (
+        <div key={i}>{line}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("../../../common/user/user-permission-provider.tsx", () => ({
+  useUserPermissions: () => ({ canConfigure: false }),
+}));
+
+vi.mock("../../../common/RestClient.tsx", async () => {
+  const actual: any = await vi.importActual("../../../common/RestClient.tsx");
+  return {
+    ...actual,
+    getConsoleBuildOutput: vi
+      .fn()
+      .mockResolvedValue(
+        [
+          "Started by user Administrator",
+          "Obtained Jenkinsfile from git",
+          "[Pipeline] Start of Pipeline",
+          "[Pipeline] node",
+          "Still waiting to schedule task",
+          "Waiting for next available executor on 'w01'",
+        ].join("\n"),
+      ),
+  };
+});
+
+const placeholderStage: StageInfo = {
+  id: 2,
+  name: "System Generated",
+  title: "System Generated",
+  state: Result.queued,
+  type: "PIPELINE_START",
+  children: [],
+  synthetic: true,
+  placeholder: true,
+  causeOfBlockage: "Waiting for next available executor on ‘w01’",
+  pauseDurationMillis: 0,
+  startTimeMillis: Date.now(),
+  agent: "w01",
+  url: "",
+};
+
+beforeEach(() => {
+  document.body.innerHTML =
+    "<header></header>" +
+    '<div class="jenkins-app-bar"></div>' +
+    '<div id="console-pipeline-root" data-current-run-path="/jenkins/job/x/1/"></div>' +
+    '<div id="console-pipeline-overflow-root"></div>';
+
+  if (!(globalThis as any).IntersectionObserver) {
+    (globalThis as any).IntersectionObserver = class {
+      observe = () => {};
+      unobserve = () => {};
+      disconnect = () => {};
+      takeRecords = () => [];
+      root = null;
+      rootMargin = "";
+      thresholds = [];
+    };
+  }
+
+  (useLayoutPreferences as any).mockReturnValue({
+    stageViewPosition: "top",
+    mainViewVisibility: "both",
+    setStageViewPosition: () => {},
+    setMainViewVisibility: () => {},
+    stageViewWidth: 0,
+    stageViewHeight: 0,
+    setStageViewWidth: () => {},
+    setStageViewHeight: () => {},
+    isMobile: false,
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PipelineConsole — queued placeholder fallback", () => {
+  it("renders StageDetails + NoStageStepsFallback when only stage is a queued placeholder", async () => {
+    (useStepsPoller as any).mockReturnValue({
+      complete: false,
+      tailLogs: false,
+      scrollToTail: () => {},
+      startTailingLogs: () => {},
+      stopTailingLogs: () => {},
+      openStage: placeholderStage,
+      openStageSteps: [],
+      stepBuffers: new Map(),
+      expandedSteps: [],
+      stages: [placeholderStage],
+      handleStageSelect: () => {},
+      onStepToggle: () => {},
+      fetchLogText: async () => ({ lines: [], startByte: 0, endByte: 0 }),
+      fetchExceptionText: async () => ({ lines: [], startByte: 0, endByte: 0 }),
+      loading: false,
+    });
+
+    await act(async () => {
+      render(
+        <FilterProvider>
+          <PipelineConsole />
+        </FilterProvider>,
+      );
+    });
+
+    expect(
+      screen.getAllByText(/Waiting for next available executor on/).length,
+    ).toBeGreaterThan(0);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Obtained Jenkinsfile from git/),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText(/Still waiting to schedule task/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the structured graph when the placeholder is no longer queued", async () => {
+    (useStepsPoller as any).mockReturnValue({
+      complete: false,
+      tailLogs: false,
+      scrollToTail: () => {},
+      startTailingLogs: () => {},
+      stopTailingLogs: () => {},
+      openStage: { ...placeholderStage, state: Result.running },
+      openStageSteps: [],
+      stepBuffers: new Map(),
+      expandedSteps: [],
+      stages: [{ ...placeholderStage, state: Result.running }],
+      handleStageSelect: () => {},
+      onStepToggle: () => {},
+      fetchLogText: async () => ({ lines: [], startByte: 0, endByte: 0 }),
+      fetchExceptionText: async () => ({ lines: [], startByte: 0, endByte: 0 }),
+      loading: false,
+    });
+
+    await act(async () => {
+      render(
+        <FilterProvider>
+          <PipelineConsole />
+        </FilterProvider>,
+      );
+    });
+
+    // The fallback's canned console output must NOT render in the running case.
+    expect(
+      screen.queryByText(/Obtained Jenkinsfile from git/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -10,6 +10,7 @@ import {
   SETTINGS,
 } from "../../../common/components/symbols.tsx";
 import { useUserPermissions } from "../../../common/user/user-permission-provider.tsx";
+import { Result } from "../../../pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx";
 import Skeleton from "./components/skeleton.tsx";
 import Stages from "./components/stages.tsx";
 import StagesCustomization from "./components/stages-customization.tsx";
@@ -19,6 +20,7 @@ import { NoStageStepsFallback } from "./NoStageStepsFallback.tsx";
 import { useLayoutPreferences } from "./providers/user-preference-provider.tsx";
 import ScrollToTopBottom from "./scroll-to-top-bottom.tsx";
 import SplitView from "./split-view.tsx";
+import StageDetails from "./stage-details.tsx";
 import StageView from "./StageView.tsx";
 
 export default function PipelineConsole() {
@@ -45,9 +47,12 @@ export default function PipelineConsole() {
     loading,
   } = useStepsPoller({ currentRunPath, previousRunPath });
 
-  const showSplitView = loading || (!loading && stages.length > 0);
-
   const isOnlyPlaceholderNode = stages.length === 1 && stages[0].placeholder;
+  const onlyQueuedPlaceholder =
+    isOnlyPlaceholderNode && stages[0].state === Result.queued;
+
+  const showSplitView =
+    loading || (!loading && stages.length > 0 && !onlyQueuedPlaceholder);
 
   const { canConfigure } = useUserPermissions();
 
@@ -160,6 +165,17 @@ export default function PipelineConsole() {
             </div>
           </SplitView>
         </SplitView>
+      )}
+
+      {!loading && onlyQueuedPlaceholder && (
+        <>
+          <StageDetails stage={stages[0]} />
+          <NoStageStepsFallback
+            currentRunPath={currentRunPath}
+            tailLogs={tailLogs}
+            scrollToTail={scrollToTail}
+          />
+        </>
       )}
 
       {!loading && stages.length === 0 && (

--- a/src/main/frontend/pipeline-graph-view/app.tsx
+++ b/src/main/frontend/pipeline-graph-view/app.tsx
@@ -7,6 +7,7 @@ import { UserPreferencesProvider } from "../common/user/user-preferences-provide
 import Stages from "../pipeline-console-view/pipeline-console/main/components/stages.tsx";
 import { NoStageStepsFallback } from "../pipeline-console-view/pipeline-console/main/NoStageStepsFallback.tsx";
 import { StageViewPosition } from "../pipeline-console-view/pipeline-console/main/providers/user-preference-provider.tsx";
+import { Result } from "./pipeline-graph/main/PipelineGraphModel.tsx";
 
 export default function App() {
   const rootElement = document.getElementById("graph");
@@ -17,9 +18,16 @@ export default function App() {
     previousRunPath,
   });
 
+  const onlyQueuedPlaceholder =
+    run.stages.length === 1 &&
+    run.stages[0].placeholder === true &&
+    run.stages[0].state === Result.queued;
+  const showBuildConsoleFallback =
+    !loading && (run.stages.length === 0 || onlyQueuedPlaceholder);
+
   return (
     <UserPreferencesProvider>
-      {!loading && run.stages.length === 0 && (
+      {showBuildConsoleFallback && (
         <>
           <div className={"jenkins-card__title"}>
             <a
@@ -57,7 +65,7 @@ export default function App() {
         </>
       )}
 
-      {run.stages.length > 0 && (
+      {run.stages.length > 0 && !onlyQueuedPlaceholder && (
         <Stages
           stages={run.stages}
           stageViewPosition={StageViewPosition.TOP}

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/analysis/StatusAndTiming.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/analysis/StatusAndTiming.java
@@ -278,7 +278,10 @@ public class StatusAndTiming {
         }
         boolean isLastChunk = after == null || exec.isCurrentHead(lastNode);
         if (isLastChunk) {
-            if (run.isBuilding()) {
+            // FlowExecutionListener.onCompleted seeds the cache while WorkflowRun.isBuilding()
+            // can still return true; preferring the execution's own complete flag avoids
+            // persisting a final chunk as IN_PROGRESS in that window.
+            if (run.isBuilding() && !exec.isComplete()) {
                 if (exec.getCurrentHeads().size() > 1
                         && lastNode instanceof BlockEndNode) { // Check to see if all the action is on other branches
                     BlockStartNode start = ((BlockEndNode) lastNode).getStartNode();

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -163,6 +163,7 @@ public class PipelineConsoleViewAction extends Tab {
                     "Doesn't seem to matter in practice, docs aren't clear on how to handle and most places ignore it")
     public void getBuildConsole(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
         run.checkPermission(Item.READ);
+        rsp.setContentType("text/html;charset=UTF-8");
         run.getLogText().writeHtmlTo(0L, rsp.getWriter());
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fixes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/1221

Includes pipeline starting info pre-stage until a stage comes along.

### Testing done

Took a node offline then tried to grab it:

Then restarted Jenkins a couple of times to get more output.

<img width="1422" height="541" alt="image" src="https://github.com/user-attachments/assets/f0559758-e83d-4f23-a72f-f6baf86f8872" />


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
