### PR TITLE
Make counter node tooltip scrollable for large parallel stage groups

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.scss
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.scss
@@ -3,14 +3,20 @@
   flex-direction: column;
   list-style-type: none;
   padding: 0;
-  margin: 0;
   margin: -0.15rem -0.5rem;
+  max-height: 28rem;
+  overflow-y: auto;
+  flex-shrink: 0;
 
   li {
-    display: contents;
+    display: flex;
+    flex-shrink: 0;
   }
 
   a {
+    flex: 1;
+    display: flex;
+    align-items: center;
     justify-content: start;
     gap: 0.5rem;
     color: var(--text-color);
@@ -23,6 +29,7 @@
     svg {
       width: 1.375rem;
       height: 1.375rem;
+      flex-shrink: 0;
     }
   }
 }

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.scss
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.scss
@@ -4,7 +4,7 @@
   list-style-type: none;
   padding: 0;
   margin: -0.15rem -0.5rem;
-  max-height: 28rem;
+  max-height: min(28rem, calc(50vh - 2rem));
   overflow-y: auto;
   flex-shrink: 0;
 

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.spec.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.spec.tsx
@@ -11,6 +11,7 @@ describe("Counter node with 50+ parallel stages", () => {
   const layout: LayoutInfo = {
     nodeSpacingH: 120,
     parallelSpacingH: 120,
+    nodeSpacingV: 70,
     nodeRadius: 12,
     terminalRadius: 7,
     curveRadius: 12,

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.spec.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.spec.tsx
@@ -1,0 +1,179 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_LOCALE } from "../../../../common/i18n/index.ts";
+import { defaultMessages } from "../../../../common/i18n/messages.ts";
+import {
+  CounterNodeInfo,
+  layoutGraph,
+} from "../PipelineGraphLayout.ts";
+import {
+  LayoutInfo,
+  Result,
+  StageInfo,
+} from "../PipelineGraphModel.tsx";
+import { Node } from "./nodes.tsx";
+
+describe("Counter node with 50+ parallel stages", () => {
+  const layout: LayoutInfo = {
+    nodeSpacingH: 120,
+    parallelSpacingH: 120,
+    nodeRadius: 12,
+    terminalRadius: 7,
+    curveRadius: 12,
+    connectorStrokeWidth: 3.5,
+    labelOffsetV: 20,
+    smallLabelOffsetV: 15,
+    ypStart: 55,
+  };
+
+  const baseStage: StageInfo = {
+    name: "",
+    title: "",
+    state: Result.success,
+    id: 0,
+    type: "STAGE",
+    children: [],
+    pauseDurationMillis: 0,
+    startTimeMillis: 0,
+    totalDurationMillis: 17000,
+    agent: "built-in",
+    url: "/?selected-node=0",
+  };
+
+  const makeStage = (id: number, name: string): StageInfo => ({
+    ...baseStage,
+    id,
+    name,
+    url: `/?selected-node=${id}`,
+  });
+
+  const buildGraphWithManyStages = (stageCount: number, maxColumns: number) =>
+    layoutGraph(
+      Array.from({ length: stageCount }, (_, i) =>
+        makeStage(i + 1, `Stage ${i + 1}`),
+      ),
+      layout,
+      true,
+      defaultMessages(DEFAULT_LOCALE),
+      false,
+      false,
+      maxColumns,
+    );
+
+  describe("layout with 50+ stages", () => {
+    it("collapses 55 stages into a counter node with correct count", () => {
+      const graph = buildGraphWithManyStages(55, 5);
+      const counterColumn = graph.nodeColumns.find(
+        (column) => column.rows[0][0].key === "counter-node",
+      );
+      expect(counterColumn).toBeDefined();
+      const counter = counterColumn!.rows[0][0] as CounterNodeInfo;
+      expect(counter.stages.length).toBe(50);
+    });
+
+    it("collapses 100 stages into a counter node with correct count", () => {
+      const graph = buildGraphWithManyStages(100, 5);
+      const counterColumn = graph.nodeColumns.find(
+        (column) => column.rows[0][0].key === "counter-node",
+      );
+      expect(counterColumn).toBeDefined();
+      const counter = counterColumn!.rows[0][0] as CounterNodeInfo;
+      expect(counter.stages.length).toBe(95);
+    });
+
+    it("counter node holds all stage references for 60 stages at default threshold", () => {
+      const graph = buildGraphWithManyStages(60, 13);
+      const counterColumn = graph.nodeColumns.find(
+        (column) => column.rows[0][0].key === "counter-node",
+      );
+      expect(counterColumn).toBeDefined();
+      const counter = counterColumn!.rows[0][0] as CounterNodeInfo;
+      expect(counter.stages.length).toBe(47);
+      // Each stage should retain its identity
+      counter.stages.forEach((stage) => {
+        expect(stage.name).toMatch(/^Stage \d+$/);
+        expect(stage.url).toContain("selected-node=");
+      });
+    });
+  });
+
+  describe("counter node tooltip rendering", () => {
+    it("renders counter node showing stage count", () => {
+      const counterNode: CounterNodeInfo = {
+        x: 100,
+        y: 50,
+        name: "Counter",
+        id: -2,
+        isPlaceholder: true,
+        key: "counter-node",
+        type: "counter",
+        stages: Array.from({ length: 55 }, (_, i) => makeStage(i + 1, `Stage ${i + 1}`)),
+      };
+
+      render(<Node node={counterNode} isSelected={false} />);
+      expect(screen.getByText("55")).toBeInTheDocument();
+    });
+
+    it("renders tooltip with all 55 stages as links", () => {
+      const stageCount = 55;
+      const counterNode: CounterNodeInfo = {
+        x: 100,
+        y: 50,
+        name: "Counter",
+        id: -2,
+        isPlaceholder: true,
+        key: "counter-node",
+        type: "counter",
+        stages: Array.from({ length: stageCount }, (_, i) =>
+          makeStage(i + 1, `Check service-${i + 1}`),
+        ),
+      };
+
+      render(<Node node={counterNode} isSelected={false} />);
+
+      // Trigger tooltip by hovering (mouseenter)
+      const counterBadge = screen.getByText(String(stageCount));
+      fireEvent.mouseEnter(counterBadge.closest(".PWGx-pipeline-node")!);
+
+      // The tooltip list should be present with all items
+      const tooltipList = document.querySelector(".pgv-node__counter-tooltip");
+      expect(tooltipList).not.toBeNull();
+      const items = tooltipList!.querySelectorAll("li");
+      expect(items.length).toBe(stageCount);
+
+      // Each item should be a link with the stage name
+      const links = tooltipList!.querySelectorAll("a");
+      expect(links.length).toBe(stageCount);
+      expect(links[0].textContent).toContain("Check service-1");
+      expect(links[stageCount - 1].textContent).toContain(
+        `Check service-${stageCount}`,
+      );
+    });
+
+    it("renders tooltip with 100 stages without dropping any", () => {
+      const stageCount = 100;
+      const counterNode: CounterNodeInfo = {
+        x: 100,
+        y: 50,
+        name: "Counter",
+        id: -2,
+        isPlaceholder: true,
+        key: "counter-node",
+        type: "counter",
+        stages: Array.from({ length: stageCount }, (_, i) =>
+          makeStage(i + 1, `Stage ${i + 1}`),
+        ),
+      };
+
+      render(<Node node={counterNode} isSelected={false} />);
+
+      const counterBadge = screen.getByText(String(stageCount));
+      fireEvent.mouseEnter(counterBadge.closest(".PWGx-pipeline-node")!);
+
+      const tooltipList = document.querySelector(".pgv-node__counter-tooltip");
+      expect(tooltipList).not.toBeNull();
+      expect(tooltipList!.querySelectorAll("li").length).toBe(stageCount);
+    });
+  });
+});

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.spec.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.spec.tsx
@@ -3,15 +3,8 @@ import { describe, expect, it } from "vitest";
 
 import { DEFAULT_LOCALE } from "../../../../common/i18n/index.ts";
 import { defaultMessages } from "../../../../common/i18n/messages.ts";
-import {
-  CounterNodeInfo,
-  layoutGraph,
-} from "../PipelineGraphLayout.ts";
-import {
-  LayoutInfo,
-  Result,
-  StageInfo,
-} from "../PipelineGraphModel.tsx";
+import { CounterNodeInfo, layoutGraph } from "../PipelineGraphLayout.ts";
+import { LayoutInfo, Result, StageInfo } from "../PipelineGraphModel.tsx";
 import { Node } from "./nodes.tsx";
 
 describe("Counter node with 50+ parallel stages", () => {
@@ -108,7 +101,9 @@ describe("Counter node with 50+ parallel stages", () => {
         isPlaceholder: true,
         key: "counter-node",
         type: "counter",
-        stages: Array.from({ length: 55 }, (_, i) => makeStage(i + 1, `Stage ${i + 1}`)),
+        stages: Array.from({ length: 55 }, (_, i) =>
+          makeStage(i + 1, `Stage ${i + 1}`),
+        ),
       };
 
       render(<Node node={counterNode} isSelected={false} />);


### PR DESCRIPTION
Add scrollable capability to counter node tooltip and implement tests.

Fixes #1264 

The counter-node tooltip (shown when collapsed parallel stages overflow) had no height bound, so for pipelines with 50+ parallel stages the list ran past the viewport and users couldn't reach the lower items.

Changes:

1. `nodes.scss`: cap the tooltip list at `max-height: 28rem` and add `overflow-y: auto`.
2. `nodes.scss`: switch list-item layout from `display: contents` to `display: flex` with `flex-shrink: 0` on rows, links, and SVG icons. Without this, items got squished together once the parent became a constrained scroll container.
3. `nodes.spec.tsx`: new test file covering counter-node behaviour with 55, 60, and 100 collapsed stages. Verifies the layout produces the right counter count and the tooltip renders every stage as a link.

### Testing done

1. `npm test`: 120/120 pass (6 new).
2. Manually verified in `mvn hpi:run` with a Jenkinsfile of 10 sequential stages + 55 parallel echo stages: tooltip caps at ~15 rows, scrolls smoothly to reveal all 55, items render at normal spacing.

### Screenshots
1. <img width="442" height="561" alt="image" src="https://github.com/user-attachments/assets/735d599b-d2eb-43cf-a2c2-e040406a5cec" />
2. <img width="452" height="543" alt="image" src="https://github.com/user-attachments/assets/621dc066-694b-4e55-9012-fe8814b542c3" />


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed