### PR TITLE
Give all the the NodeInfo variants a "type" property

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.spec.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.spec.ts
@@ -2,11 +2,7 @@ import { describe, expect } from "vitest";
 
 import { DEFAULT_LOCALE } from "../../../common/i18n/index.ts";
 import { defaultMessages } from "../../../common/i18n/messages.ts";
-import {
-  CounterNodeInfo,
-  createNodeColumns,
-  layoutGraph,
-} from "./PipelineGraphLayout.ts";
+import { createNodeColumns, layoutGraph } from "./PipelineGraphLayout.ts";
 import {
   LayoutInfo,
   Result,
@@ -440,9 +436,7 @@ describe("PipelineGraphLayout", () => {
         );
 
       const counterFor = (graph: ReturnType<typeof callLayout>) => {
-        return graph.nodes.find(
-          (node) => node.key === "counter-node",
-        ) as CounterNodeInfo;
+        return graph.nodes.find((node) => node.type === "counter");
       };
 
       it("uses the default threshold of 13 when no override is provided", () => {

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.ts
@@ -1,11 +1,11 @@
 import { LocalizedMessageKey, Messages } from "../../../common/i18n/index.ts";
 import {
   CompositeConnection,
+  CounterNodeInfo,
   LayoutInfo,
   NodeColumn,
   NodeInfo,
   NodeLabelInfo,
-  PlaceholderNodeInfo,
   PositionedGraph,
   Result,
   StageInfo,
@@ -116,11 +116,10 @@ export function layoutGraph(
     const result = [start, ...visibleNodes];
 
     if (hiddenNodes.length > 0) {
-      (counter.rows[0][0] as CounterNodeInfo).stages = hiddenNodes.flatMap(
-        (node) =>
-          node.rows.flatMap((row) =>
-            row.flatMap((e) => (e as StageNodeInfo).stage),
-          ),
+      counterNode.stages = hiddenNodes.flatMap((node) =>
+        node.rows.flatMap((row) =>
+          row.flatMap((e) => (e as StageNodeInfo).stage),
+        ),
       );
       result.push(counter);
     }
@@ -174,10 +173,6 @@ export function layoutGraph(
   };
 }
 
-export interface CounterNodeInfo extends PlaceholderNodeInfo {
-  stages: StageInfo[];
-}
-
 /**
  * Generate an array of columns, based on the top-level stages
  */
@@ -199,6 +194,7 @@ export function createNodeColumns(
       seqContainerName,
       isPlaceholder: false,
       key: "n_" + stage.id,
+      type: "stage",
     };
   };
 
@@ -293,7 +289,7 @@ function positionNodes(
       // Advance X position
       if (previousTopNode.isPlaceholder || topNode.isPlaceholder) {
         // Don't space placeholder nodes (start/end) as wide as normal.
-        if (topNode.key === "counter-node") {
+        if (topNode.type === "counter") {
           xp += nodeSpacingH;
         } else {
           xp += Math.floor(nodeSpacingH * 0.7);
@@ -358,7 +354,7 @@ function createBigLabels(
   for (const column of columns) {
     const node = column.rows[0][0];
 
-    if (node.isPlaceholder && node.type === "counter") {
+    if (node.type === "counter") {
       continue;
     }
     const stage = column.topStage;

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
@@ -76,6 +76,7 @@ export interface StageNodeInfo extends BaseNodeInfo {
   isPlaceholder: false;
 
   // -- Unique
+  type: "stage";
   stage: StageInfo;
   seqContainerName?: string; // Used within a parallel branch to denote the name of the container of the parallel sequential stages
 }
@@ -85,10 +86,19 @@ export interface PlaceholderNodeInfo extends BaseNodeInfo {
   isPlaceholder: true;
 
   // -- Unique
-  type: "start" | "end" | "counter";
+  type: "start" | "end";
 }
 
-export type NodeInfo = StageNodeInfo | PlaceholderNodeInfo;
+export interface CounterNodeInfo extends BaseNodeInfo {
+  // -- Marker
+  isPlaceholder: true;
+
+  // -- Unique
+  type: "counter";
+  stages: StageInfo[];
+}
+
+export type NodeInfo = StageNodeInfo | PlaceholderNodeInfo | CounterNodeInfo;
 
 export interface NodeColumn {
   topStage?: StageInfo; // Top-most stage for this column, which will have no rendered nodes if it's parallel

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.spec.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.spec.tsx
@@ -3,8 +3,13 @@ import { describe, expect, it } from "vitest";
 
 import { DEFAULT_LOCALE } from "../../../../common/i18n/index.ts";
 import { defaultMessages } from "../../../../common/i18n/messages.ts";
-import { CounterNodeInfo, layoutGraph } from "../PipelineGraphLayout.ts";
-import { LayoutInfo, Result, StageInfo } from "../PipelineGraphModel.tsx";
+import { layoutGraph } from "../PipelineGraphLayout.ts";
+import {
+  CounterNodeInfo,
+  LayoutInfo,
+  Result,
+  StageInfo,
+} from "../PipelineGraphModel.tsx";
 import { Node } from "./nodes.tsx";
 
 describe("Counter node with 50+ parallel stages", () => {
@@ -55,9 +60,7 @@ describe("Counter node with 50+ parallel stages", () => {
       maxColumns,
     );
   const counterFor = (graph: ReturnType<typeof buildGraphWithManyStages>) => {
-    return graph.nodes.find(
-      (node) => node.key === "counter-node",
-    ) as CounterNodeInfo;
+    return graph.nodes.find((node) => node.type === "counter");
   };
 
   describe("layout with 50+ stages", () => {
@@ -65,23 +68,23 @@ describe("Counter node with 50+ parallel stages", () => {
       const graph = buildGraphWithManyStages(55, 5);
       const counter = counterFor(graph);
       expect(counter).toBeDefined();
-      expect(counter.stages.length).toBe(50);
+      expect(counter?.stages.length).toBe(50);
     });
 
     it("collapses 100 stages into a counter node with correct count", () => {
       const graph = buildGraphWithManyStages(100, 5);
       const counter = counterFor(graph);
       expect(counter).toBeDefined();
-      expect(counter.stages.length).toBe(95);
+      expect(counter?.stages.length).toBe(95);
     });
 
     it("counter node holds all stage references for 60 stages at default threshold", () => {
       const graph = buildGraphWithManyStages(60, 13);
       const counter = counterFor(graph);
       expect(counter).toBeDefined();
-      expect(counter.stages.length).toBe(47);
+      expect(counter?.stages.length).toBe(47);
       // Each stage should retain its identity
-      counter.stages.forEach((stage) => {
+      counter?.stages.forEach((stage) => {
         expect(stage.name).toMatch(/^Stage \d+$/);
         expect(stage.url).toContain("selected-node=");
       });

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.tsx
@@ -9,7 +9,6 @@ import {
 import Tooltip from "../../../../common/components/tooltip.tsx";
 import { classNames } from "../../../../common/utils/classnames.ts";
 import LiveTotal from "../../../../common/utils/live-total.tsx";
-import { CounterNodeInfo } from "../PipelineGraphLayout.ts";
 import { LayoutInfo, NodeInfo, StageInfo } from "../PipelineGraphModel.tsx";
 
 type SVGChildren = Array<any>; // Fixme: Maybe refine this? Not sure what should go here, we have working code I can't make typecheck
@@ -31,11 +30,9 @@ function NodeImpl({ node, collapsed, onStageSelect, isSelected }: NodeProps) {
 
   if (node.isPlaceholder) {
     if (node.type === "counter") {
-      const mappedNode = node as CounterNodeInfo;
-
       const tooltip = (
         <ol className="pgv-node__counter-tooltip">
-          {mappedNode.stages.map((stage) => (
+          {node.stages.map((stage) => (
             <li key={stage.id}>
               <a
                 className={"jenkins-button jenkins-button--tertiary"}
@@ -69,7 +66,7 @@ function NodeImpl({ node, collapsed, onStageSelect, isSelected }: NodeProps) {
             className={"PWGx-pipeline-node"}
           >
             <span className={"PWGx-pipeline-node-counter"}>
-              {mappedNode.stages.length}
+              {node.stages.length}
             </span>
           </div>
         </Tooltip>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- For #1155
- For https://github.com/jenkinsci/pipeline-graph-view-plugin/pull/1269

Add type-safety to Counter node access:
- Move `CounterNodeInfo` into `PipelineGraphModel.tsx` and make `CounterNodeInfo` another variant of `NodeInfo`
- Give all `NodeInfo` variants a `type` field. With that in place, we can safely access `node.type` everywhere for selecting the Counter node and access its fields.

### Testing done

This is covered by existing tests. I've also tested it with pipelines that have many stages, a counter is shown on the job page when the screen width is narrow.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
