### PR TITLE
Read explicit placeholder flag

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
@@ -57,7 +57,7 @@ function BigLabelImpl({
   if (details.stage?.skeleton) {
     classNames.push("pgv-graph-node--skeleton");
   }
-  if (details.node.id < 0) {
+  if (details.node.isPlaceholder) {
     classNames.push("pgv-graph-node--skeleton");
   }
 
@@ -116,7 +116,7 @@ function TimingsLabelImpl({
   if (details.stage?.skeleton) {
     classNames.push("pgv-graph-node--skeleton");
   }
-  if (details.node.id < 0) {
+  if (details.node.isPlaceholder) {
     classNames.push("pgv-graph-node--skeleton");
   }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- For #1155
- For https://github.com/jenkinsci/pipeline-graph-view-plugin/pull/1269

Use the explicit flag for placeholder nodes when building labels.

Context: In #1269 I'm inserting "fake" intermediate stages with `stage.id = -originalStage.id`. The would be false-positive placeholder nodes with the code on main.

### Testing done

See #1269: The start/end nodes use grayed text for the big label.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
