### PR TITLE
Align nodes on nodeSpacingH when parallel nodes have branch labels

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.ts
@@ -12,8 +12,6 @@ import {
   StageNodeInfo,
 } from "./PipelineGraphModel.tsx";
 
-export const sequentialStagesLabelOffset = 80;
-
 export const DEFAULT_MAX_COLUMNS_WHEN_COLLAPSED = 13;
 
 /**
@@ -137,7 +135,12 @@ export function layoutGraph(
 
   positionNodes(allNodeColumns, layout);
 
-  const bigLabels = createBigLabels(allNodeColumns, collapsed, showNames);
+  const bigLabels = createBigLabels(
+    allNodeColumns,
+    collapsed,
+    showNames,
+    layout,
+  );
   const timings = createTimings(allNodeColumns, collapsed, showDurations);
   const smallLabels = createSmallLabels(allNodeColumns, collapsed);
   const branchLabels = createBranchLabels(allNodeColumns, collapsed);
@@ -312,7 +315,7 @@ function positionNodes(
 
     // Make room for row labels
     if (column.hasBranchLabels) {
-      xp += sequentialStagesLabelOffset;
+      xp += nodeSpacingH;
     }
 
     let maxX = xp;
@@ -348,6 +351,7 @@ function createBigLabels(
   columns: Array<NodeColumn>,
   collapsed: boolean,
   showNames: boolean,
+  layout: LayoutInfo,
 ): Array<NodeLabelInfo> {
   const labels: Array<NodeLabelInfo> = [];
 
@@ -368,7 +372,7 @@ function createBigLabels(
     // bigLabel is located above center of column, but offset if there's branch labels
     let x = column.centerX;
     if (column.hasBranchLabels) {
-      x += Math.floor(sequentialStagesLabelOffset / 2);
+      x += Math.floor(layout.nodeSpacingH / 2);
     }
 
     labels.push({

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/connections.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/connections.tsx
@@ -1,6 +1,5 @@
 import { Component } from "react";
 
-import { sequentialStagesLabelOffset } from "../PipelineGraphLayout.ts";
 import {
   CompositeConnection,
   LayoutInfo,
@@ -117,7 +116,7 @@ export class GraphConnections extends Component {
 
     if (hasBranchLabels) {
       // Shift curve midpoint so that there's room for the labels
-      expandMidPointX -= sequentialStagesLabelOffset;
+      expandMidPointX -= nodeSpacingH;
     }
 
     for (const destNode of destinationNodes.slice(1)) {
@@ -240,7 +239,7 @@ export class GraphConnections extends Component {
 
     if (hasBranchLabels) {
       // Shift curve midpoint so that there's room for the labels
-      expandMidPointX -= sequentialStagesLabelOffset;
+      expandMidPointX -= nodeSpacingH;
     }
 
     for (rightNode of destinationNodes.slice(1)) {

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.tsx
@@ -1,7 +1,6 @@
 import { CSSProperties, memo } from "react";
 
 import LiveTotal from "../../../../common/utils/live-total.tsx";
-import { sequentialStagesLabelOffset } from "../PipelineGraphLayout.ts";
 import { LayoutInfo, NodeLabelInfo } from "../PipelineGraphModel.tsx";
 import { TooltipLabel } from "./convertLabelToTooltip.tsx";
 import { nodeStrokeWidth } from "./StatusIcons.tsx";
@@ -211,7 +210,7 @@ function SequentialContainerLabelImpl({
     lineHeight,
     marginTop: `-${lineHeight / 2}em`,
     position: "absolute" as const,
-    maxWidth: sequentialStagesLabelOffset,
+    maxWidth: layout.nodeSpacingH,
     overflow: "hidden",
     textOverflow: "ellipsis",
     background: "var(--card-background)",


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- For #1155
- For https://github.com/jenkinsci/pipeline-graph-view-plugin/pull/1269

Avoid mixed spacing from branch label offsets (80px) that are slightly smaller than the regular node spacing (140px). This is not so relevant for the current layout where only one level of nesting is supported. It will be important when adding support for many levels of nesting, where two parallel children a/b may have nested parallel blocks a' with and b' without branch labels, that in turn result in following nodes in a/b to no longer be aligned.

80px is also not enough space for making space for the skipped curve of the first child when a branch label is present on the parent.

<details>

80px | 140px
--- | ---
1ef048e6276093bcb0d6094235132ea20201d0cb | f80f10e3474c3563f946c2fb08482f2c0ea262ba
<img width="528" height="558" alt="image" src="https://github.com/user-attachments/assets/94946dde-a021-42fb-9acf-51fabcdea9f1" /> | <img width="582" height="556" alt="image" src="https://github.com/user-attachments/assets/74a6389f-2157-46ec-a625-e2fde6ac3530" />

</details>

As both layouts share the same rendering (connections/nodes/labels), I've opened a PR with the changes already.

### Testing done

The code change is straight forward: replace `sequentialStagesLabelOffset` with `layout.nodeSpacingH` everywhere.

Tested with https://github.com/jenkinsci/pipeline-graph-view-plugin/pull/1269 where  ALL nodes are aligned. I can try to make a demo with just this PRs changes if requested.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
