### PR TITLE
Make space for counter node when collapsed nodes exceed max columns

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
@@ -64,9 +64,14 @@ export function PipelineGraph({
 
     const apply = (width: number) => {
       if (width <= 0) return;
+      const reservedSpace =
+        fullLayout.nodeSpacingH / 2 + // before start
+        fullLayout.nodeSpacingH * 0.7 + // start node with reduced spacing
+        -fullLayout.nodeSpacingH * 0.3 + // reduced spacing to end node
+        fullLayout.nodeSpacingH / 2; // after end;
       const next = Math.max(
         MIN_COLUMNS_WHEN_COLLAPSED,
-        Math.floor(width / fullLayout.nodeSpacingH) - 2,
+        Math.floor((width - reservedSpace) / fullLayout.nodeSpacingH),
       );
       setMaxColumnsWhenCollapsed((prev) => (prev === next ? prev : next));
     };

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.spec.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.spec.ts
@@ -442,22 +442,22 @@ describe("PipelineGraphLayout", () => {
       it("uses the default threshold of 13 when no override is provided", () => {
         const graph = callLayout(25, true);
 
-        expect(graph.nodes.length).toBe(16);
-        expect(counterFor(graph)?.stages.length).toBe(12);
+        expect(graph.nodes.length).toBe(15);
+        expect(counterFor(graph)?.stages.length).toBe(13);
       });
 
       it("respects an explicit lower maxColumns override", () => {
         const graph = callLayout(25, true, 5);
 
-        expect(graph.nodes.length).toBe(8);
-        expect(counterFor(graph)?.stages.length).toBe(20);
+        expect(graph.nodes.length).toBe(7);
+        expect(counterFor(graph)?.stages.length).toBe(21);
       });
 
       it("respects an explicit higher maxColumns override", () => {
         const graph = callLayout(25, true, 20);
 
-        expect(graph.nodes.length).toBe(23);
-        expect(counterFor(graph)?.stages.length).toBe(5);
+        expect(graph.nodes.length).toBe(22);
+        expect(counterFor(graph)?.stages.length).toBe(6);
       });
 
       it("omits the counter when maxColumns exceeds the stage count", () => {

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.ts
@@ -107,22 +107,21 @@ export function layoutGraph(
 
     const newMiddleNodes = createNodeColumns(middleStages);
 
-    const visibleNodes = newMiddleNodes.slice(0, maxColumnsWhenCollapsed);
-    const hiddenNodes = newMiddleNodes.slice(maxColumnsWhenCollapsed);
+    if (newMiddleNodes.length <= maxColumnsWhenCollapsed) {
+      return [start, ...newMiddleNodes, end];
+    }
 
-    const result = [start, ...visibleNodes];
+    // Make space for the counter node.
+    const breakPoint = maxColumnsWhenCollapsed - 1;
 
-    if (hiddenNodes.length > 0) {
-      counterNode.stages = hiddenNodes.flatMap((node) =>
+    counterNode.stages = newMiddleNodes
+      .slice(breakPoint)
+      .flatMap((node) =>
         node.rows.flatMap((row) =>
           row.flatMap((e) => (e as StageNodeInfo).stage),
         ),
       );
-      result.push(counter);
-    }
-
-    result.push(end);
-    return result;
+    return [start, ...newMiddleNodes.slice(0, breakPoint), counter, end];
   }
 
   const allNodeColumns: Array<NodeColumn> = filterWhenCollapsed([

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.spec.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.spec.tsx
@@ -68,21 +68,21 @@ describe("Counter node with 50+ parallel stages", () => {
       const graph = buildGraphWithManyStages(55, 5);
       const counter = counterFor(graph);
       expect(counter).toBeDefined();
-      expect(counter?.stages.length).toBe(50);
+      expect(counter?.stages.length).toBe(51);
     });
 
     it("collapses 100 stages into a counter node with correct count", () => {
       const graph = buildGraphWithManyStages(100, 5);
       const counter = counterFor(graph);
       expect(counter).toBeDefined();
-      expect(counter?.stages.length).toBe(95);
+      expect(counter?.stages.length).toBe(96);
     });
 
     it("counter node holds all stage references for 60 stages at default threshold", () => {
       const graph = buildGraphWithManyStages(60, 13);
       const counter = counterFor(graph);
       expect(counter).toBeDefined();
-      expect(counter?.stages.length).toBe(47);
+      expect(counter?.stages.length).toBe(48);
       // Each stage should retain its identity
       counter?.stages.forEach((stage) => {
         expect(stage.name).toMatch(/^Stage \d+$/);

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewTest.java
@@ -41,7 +41,7 @@ class PipelineGraphViewTest {
                 .goTo()
                 .hasBuilds(1)
                 .nthBuild(0)
-                .hasStages(5, "Checkout", "Test", "A1", "A2", "Build")
+                .hasStages(4, "Checkout", "Test", "A1", "A2" /* counter */)
                 .goToBuild()
                 .hasStagesInGraph(4, /*A*/ "Checkout", "Test", /*B*/ "Build", "Parallel")
                 .goToPipelineOverview()


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Small tweaks to #1240: Thanks BTW!

- The limit on the stages to display did not factor in that the counter node also needs space. When we detect that a counter node is required, display the stage up to `maxColumnsWhenCollapsed-1` and put the rest into the counter.
- The start/end nodes have reduced spacing, so we do not need the reserve 2x full width, but rather 1.4 full width.

### Testing done

See updated playwright/frontend tests: The number of nodes should be `limit + 2` for start/end.

Demo:

https://github.com/user-attachments/assets/d89e76d8-470c-4ab8-9fe8-b464f4b9bfaf

Notes:
- "before" is main at c15d34c6fd8415a9a5074681c56f38972f459ce7
- "after" is the PR revision
- In "before" it is very common to still see a scrollbar
- The scrollbar in "after" is only briefly shown: during the time of the resize observer firing and the layout being recalculated. 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
