### PR TITLE
Fix rendering of skipped connections across layers

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.ts
@@ -1,6 +1,7 @@
 import { LocalizedMessageKey, Messages } from "../../../common/i18n/index.ts";
 import {
   CompositeConnection,
+  ConnectionEdge,
   CounterNodeInfo,
   LayoutInfo,
   NodeColumn,
@@ -491,11 +492,14 @@ function createConnections(
   const connections: Array<CompositeConnection> = [];
 
   let sourceNodes: Array<NodeInfo> = [];
-  let skippedNodes: Array<NodeInfo> = [];
+  let skippedNodes: Array<ConnectionEdge> = [];
 
   for (const column of columns) {
     if (!collapsed && column.topStage?.state === Result.skipped) {
-      skippedNodes.push(column.rows[0][0]);
+      skippedNodes.push({
+        ...column.rows[0][0],
+        isSkipped: true,
+      });
       continue;
     }
 

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
@@ -108,10 +108,22 @@ export interface NodeColumn {
   startX: number; // Where to put the branch labels, or if none, the center of the left-most node(s)
 }
 
+export interface ConnectionEdge {
+  x: number;
+  y: number;
+  key: string;
+  type: NodeInfo["type"];
+  firstChildIsSkipped?: boolean;
+  isHidden?: boolean;
+  isParallel?: boolean;
+  isPlaceholder?: boolean;
+  isSkipped?: boolean;
+}
+
 export interface CompositeConnection {
-  sourceNodes: Array<NodeInfo>;
-  destinationNodes: Array<NodeInfo>;
-  skippedNodes: Array<NodeInfo>;
+  sourceNodes: Array<ConnectionEdge>;
+  destinationNodes: Array<ConnectionEdge>;
+  skippedNodes: Array<ConnectionEdge>;
   hasBranchLabels: boolean;
 }
 

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/connections.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/connections.tsx
@@ -1,16 +1,16 @@
-import { Component } from "react";
+import { Component, SVGAttributes } from "react";
 
 import {
   CompositeConnection,
+  ConnectionEdge,
   LayoutInfo,
-  NodeInfo,
 } from "../PipelineGraphModel.tsx";
 import { nodeStrokeWidth } from "../support/StatusIcons.tsx";
 
 type SVGChildren = Array<any>; // Fixme: Maybe refine this? Not sure what should go here, we have working code I can't make typecheck
 
 // Generate a react key for a connection
-function connectorKey(leftNode: NodeInfo, rightNode: NodeInfo) {
+function connectorKey(leftNode: ConnectionEdge, rightNode: ConnectionEdge) {
   return "c_" + leftNode.key + "_to_" + rightNode.key;
 }
 
@@ -21,6 +21,15 @@ interface Props {
 
 export class GraphConnections extends Component {
   declare props: Props;
+
+  getConnectorStroke(isSkipped?: boolean): SVGAttributes<any> {
+    return {
+      className: isSkipped
+        ? "PWGx-pipeline-connector-skipped"
+        : "PWGx-pipeline-connector",
+      strokeWidth: this.props.layout.connectorStrokeWidth,
+    };
+  }
 
   /**
    * Generate SVG for a composite connection, which may be to/from many nodes.
@@ -60,27 +69,19 @@ export class GraphConnections extends Component {
    * Adds all the SVG components to the elements list.
    */
   private renderBasicConnections(
-    sourceNodes: Array<NodeInfo>,
-    destinationNodes: Array<NodeInfo>,
+    sourceNodes: Array<ConnectionEdge>,
+    destinationNodes: Array<ConnectionEdge>,
     svgElements: SVGChildren,
     hasBranchLabels: boolean,
   ) {
-    const { connectorStrokeWidth, nodeSpacingH } = this.props.layout;
+    const { nodeSpacingH } = this.props.layout;
     const halfSpacingH = nodeSpacingH / 2;
-
-    // Stroke props common to straight / curved connections
-    const connectorStroke = {
-      className: "PWGx-pipeline-connector",
-      strokeWidth: connectorStrokeWidth,
-    };
 
     this.renderHorizontalConnection(
       sourceNodes[0],
       destinationNodes[0],
-      connectorStroke,
       svgElements,
     );
-
     if (sourceNodes.length === 1 && destinationNodes.length === 1) {
       return; // No curves needed.
     }
@@ -129,62 +130,48 @@ export class GraphConnections extends Component {
     }
   }
 
+  getNodeRadius(node: ConnectionEdge, edge: "left" | "right") {
+    const { nodeRadius, terminalRadius, nodeSpacingH } = this.props.layout;
+    if (node.isPlaceholder) {
+      if (node.isHidden) return 0;
+      return terminalRadius;
+    }
+    if (node.isParallel && node.firstChildIsSkipped) {
+      // Turn half of the regular connecting line into a skipped line.
+      if (edge === "right") return nodeSpacingH / 2;
+      if (edge === "left") return -nodeSpacingH / 2;
+    }
+    if (node.isHidden) return 0;
+    return nodeRadius;
+  }
+
   /**
    * Renders a more complex connection, that "skips" one or more nodes
    *
    * Adds all the SVG components to the elements list.
    */
   private renderSkippingConnections(
-    sourceNodes: Array<NodeInfo>,
-    destinationNodes: Array<NodeInfo>,
-    skippedNodes: Array<NodeInfo>,
+    sourceNodes: Array<ConnectionEdge>,
+    destinationNodes: Array<ConnectionEdge>,
+    skippedNodes: Array<ConnectionEdge>,
     svgElements: SVGChildren,
     hasBranchLabels: boolean,
   ) {
-    const {
-      connectorStrokeWidth,
-      nodeRadius,
-      terminalRadius,
-      curveRadius,
-      nodeSpacingV,
-      nodeSpacingH,
-    } = this.props.layout;
+    const { curveRadius, nodeSpacingV, nodeSpacingH } = this.props.layout;
 
     const halfSpacingH = nodeSpacingH / 2;
-
-    // Stroke props common to straight / curved connections
-    const connectorStroke = {
-      className: "PWGx-pipeline-connector",
-      strokeWidth: connectorStrokeWidth,
-    };
-
-    const skipConnectorStroke = {
-      className: "PWGx-pipeline-connector-skipped",
-      strokeWidth: connectorStrokeWidth,
-    };
 
     const lastSkippedNode = skippedNodes[skippedNodes.length - 1];
     let leftNode, rightNode;
 
     //--------------------------------------------------------------------------
-    //  Draw the "ghost" connections to/from/between skipped nodes
+    //  Draw the "ghost" connections between skipped nodes
 
-    leftNode = sourceNodes[0];
-    for (rightNode of skippedNodes) {
-      this.renderHorizontalConnection(
-        leftNode,
-        rightNode,
-        skipConnectorStroke,
-        svgElements,
-      );
+    leftNode = skippedNodes[0];
+    for (rightNode of skippedNodes.slice(1)) {
+      this.renderHorizontalConnection(leftNode, rightNode, svgElements);
       leftNode = rightNode;
     }
-    this.renderHorizontalConnection(
-      leftNode,
-      destinationNodes[0],
-      skipConnectorStroke,
-      svgElements,
-    );
 
     //--------------------------------------------------------------------------
     //  Work out the extents of source and dest space
@@ -211,9 +198,7 @@ export class GraphConnections extends Component {
 
     for (leftNode of sourceNodes.slice(1)) {
       const midPointX = Math.round(rightmostSource + halfSpacingH);
-      const leftNodeRadius = leftNode.isPlaceholder
-        ? terminalRadius
-        : nodeRadius;
+      const leftNodeRadius = this.getNodeRadius(leftNode, "left");
       const key = connectorKey(leftNode, rightNode);
 
       const x1 = leftNode.x + leftNodeRadius - nodeStrokeWidth / 2;
@@ -226,7 +211,12 @@ export class GraphConnections extends Component {
         this.svgBranchCurve(x1, y1, x2, y2, midPointX, curveRadius);
 
       svgElements.push(
-        <path {...connectorStroke} key={key} d={pathData} fill="none" />,
+        <path
+          {...this.getConnectorStroke(leftNode.isSkipped)}
+          key={key}
+          d={pathData}
+          fill="none"
+        />,
       );
     }
 
@@ -243,9 +233,7 @@ export class GraphConnections extends Component {
     }
 
     for (rightNode of destinationNodes.slice(1)) {
-      const rightNodeRadius = rightNode.isPlaceholder
-        ? terminalRadius
-        : nodeRadius;
+      const rightNodeRadius = this.getNodeRadius(rightNode, "right");
       const key = connectorKey(leftNode, rightNode);
 
       const x1 = expandMidPointX;
@@ -258,7 +246,12 @@ export class GraphConnections extends Component {
         this.svgBranchCurve(x1, y1, x2, y2, expandMidPointX, curveRadius);
 
       svgElements.push(
-        <path {...connectorStroke} key={key} d={pathData} fill="none" />,
+        <path
+          {...this.getConnectorStroke(rightNode.isSkipped)}
+          key={key}
+          d={pathData}
+          fill="none"
+        />,
       );
     }
 
@@ -268,10 +261,8 @@ export class GraphConnections extends Component {
     leftNode = sourceNodes[0];
     rightNode = destinationNodes[0];
 
-    const leftNodeRadius = leftNode.isPlaceholder ? terminalRadius : nodeRadius;
-    const rightNodeRadius = rightNode.isPlaceholder
-      ? terminalRadius
-      : nodeRadius;
+    const leftNodeRadius = this.getNodeRadius(leftNode, "left");
+    const rightNodeRadius = this.getNodeRadius(rightNode, "right");
     const key = connectorKey(leftNode, rightNode);
 
     const skipHeight = nodeSpacingV * 0.5;
@@ -328,19 +319,74 @@ export class GraphConnections extends Component {
     const p8x = rightNode.x - rightNodeRadius + nodeStrokeWidth / 2;
     const p8y = rightNode.y;
 
+    // Source side half of the 1st horizontal
+    svgElements.push(
+      <line
+        {...this.getConnectorStroke(leftNode.isSkipped)}
+        key={key + "_source"}
+        x1={p1x}
+        y1={p1y}
+        x2={p2x}
+        y2={p2y}
+        fill="none"
+      />,
+    );
+    // Skipped side half of the 1st horizontal
+    svgElements.push(
+      <line
+        {...this.getConnectorStroke(skippedNodes[0].isSkipped)}
+        key={key + "_skipped_left"}
+        x1={p2x}
+        y1={p2y}
+        x2={skippedNodes[0].x}
+        y2={skippedNodes[0].y}
+        fill="none"
+      />,
+    );
+
     const pathData =
-      `M ${p1x} ${p1y}` +
-      `L ${p2x} ${p2y}` + // 1st horizontal
+      `M ${p2x} ${p2y}` +
       `C ${c1x} ${c1y} ${c2x} ${c2y} ${p3x} ${p3y}` + // Curve down (upper)
       `C ${c3x} ${c3y} ${c4x} ${c4y} ${p4x} ${p4y}` + // Curve down (lower)
       `L ${p5x} ${p5y}` + // 2nd horizontal
       `C ${c5x} ${c5y} ${c6x} ${c6y} ${p6x} ${p6y}` + // Curve up (lower)
       `C ${c7x} ${c7y} ${c8x} ${c8y} ${p7x} ${p7y}` + // Curve up (upper)
-      `L ${p8x} ${p8y}` + // Last horizontal
       "";
 
+    // Skipped curve
     svgElements.push(
-      <path {...connectorStroke} key={key} d={pathData} fill="none" />,
+      <path
+        {...this.getConnectorStroke(false)}
+        key={key + "_skipped_curve"}
+        d={pathData}
+        fill="none"
+      />,
+    );
+
+    // Skipped side of the last horizontal
+    svgElements.push(
+      <line
+        {...this.getConnectorStroke(lastSkippedNode.isSkipped)}
+        key={key + "_skipped_right"}
+        x1={lastSkippedNode.x}
+        y1={lastSkippedNode.y}
+        x2={p7x}
+        y2={p7y}
+        fill="none"
+      />,
+    );
+
+    // Destination side of the last horizontal
+    svgElements.push(
+      <line
+        {...this.getConnectorStroke(rightNode.isSkipped)}
+        key={key + "_destination"}
+        x1={p7x}
+        y1={p7y}
+        x2={p8x}
+        y2={p8y}
+        fill="none"
+      />,
     );
   }
 
@@ -350,16 +396,12 @@ export class GraphConnections extends Component {
    * Adds all the SVG components to the elements list.
    */
   private renderHorizontalConnection(
-    leftNode: NodeInfo,
-    rightNode: NodeInfo,
-    connectorStroke: Object,
+    leftNode: ConnectionEdge,
+    rightNode: ConnectionEdge,
     svgElements: SVGChildren,
   ) {
-    const { nodeRadius, terminalRadius } = this.props.layout;
-    const leftNodeRadius = leftNode.isPlaceholder ? terminalRadius : nodeRadius;
-    const rightNodeRadius = rightNode.isPlaceholder
-      ? terminalRadius
-      : nodeRadius;
+    const leftNodeRadius = this.getNodeRadius(leftNode, "left");
+    const rightNodeRadius = this.getNodeRadius(rightNode, "right");
 
     const key = connectorKey(leftNode, rightNode);
 
@@ -368,7 +410,14 @@ export class GraphConnections extends Component {
     const y = leftNode.y;
 
     svgElements.push(
-      <line {...connectorStroke} key={key} x1={x1} y1={y} x2={x2} y2={y} />,
+      <line
+        {...this.getConnectorStroke(leftNode.isSkipped || rightNode.isSkipped)}
+        key={key}
+        x1={x1}
+        y1={y}
+        x2={x2}
+        y2={y}
+      />,
     );
   }
 
@@ -378,17 +427,14 @@ export class GraphConnections extends Component {
    * Adds all the SVG components to the elements list.
    */
   private renderBasicCurvedConnection(
-    leftNode: NodeInfo,
-    rightNode: NodeInfo,
+    leftNode: ConnectionEdge,
+    rightNode: ConnectionEdge,
     midPointX: number,
     svgElements: SVGChildren,
   ) {
-    const { nodeRadius, terminalRadius, curveRadius, connectorStrokeWidth } =
-      this.props.layout;
-    const leftNodeRadius = leftNode.isPlaceholder ? terminalRadius : nodeRadius;
-    const rightNodeRadius = rightNode.isPlaceholder
-      ? terminalRadius
-      : nodeRadius;
+    const { curveRadius } = this.props.layout;
+    const leftNodeRadius = this.getNodeRadius(leftNode, "left");
+    const rightNodeRadius = this.getNodeRadius(rightNode, "right");
 
     const key = connectorKey(leftNode, rightNode);
 
@@ -400,12 +446,6 @@ export class GraphConnections extends Component {
     const rightPos = {
       x: rightNode.x - rightNodeRadius + nodeStrokeWidth / 2,
       y: rightNode.y,
-    };
-
-    // Stroke props common to straight / curved connections
-    const connectorStroke = {
-      className: "PWGx-pipeline-connector",
-      strokeWidth: connectorStrokeWidth,
     };
 
     const pathData =
@@ -420,7 +460,12 @@ export class GraphConnections extends Component {
       );
 
     svgElements.push(
-      <path {...connectorStroke} key={key} d={pathData} fill="none" />,
+      <path
+        {...this.getConnectorStroke(leftNode.isSkipped || rightNode.isSkipped)}
+        key={key}
+        d={pathData}
+        fill="none"
+      />,
     );
   }
 

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/styles/PipelineGraphWidget.scss
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/styles/PipelineGraphWidget.scss
@@ -123,7 +123,8 @@
 
 .PWGx-pipeline-connector-skipped {
   stroke: variables.$graph-connector-grey;
-  stroke-opacity: 0.25;
+  stroke-opacity: 0.75;
+  stroke-dasharray: 4 4;
 }
 
 .PWGx-pipeline-small-label {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- For #1155
- For https://github.com/jenkinsci/pipeline-graph-view-plugin/pull/1269

This PR is fixing the rendering of skipped connections when they are not resembling nodes that are skipped on the top-level.
Notably it is fixing the "double rendering" of connections that shadow the "skipped" ones.

I've taken the liberty to change the rendering of skipped connections for a rather hard to read 0.25 opacity gray to a 0.75 opacity gray with a dashed stroke.

Additional code changes:
- `getNodeRadius`: deduplicate radius calculation (also include the new flags from #1269 here)
- `getConnectorStroke`: deduplicate stroke properties definition

### Testing done

##### before "bugs"

In nested branches, the leading connection would not be marked as skipped.

<img width="408" height="136" alt="image" src="https://github.com/user-attachments/assets/390f57d9-f21b-45eb-9e63-3dd580cc4a38" />

In nested branches, where the skipped node is the only one, the connections are not marked as skipped

<img width="476" height="108" alt="image" src="https://github.com/user-attachments/assets/ea8dfb82-71aa-42ec-a4e4-17a10977ca6d" />

##### after with https://github.com/jenkinsci/pipeline-graph-view-plugin/pull/1269

<img width="360" height="110" alt="image" src="https://github.com/user-attachments/assets/c01d9a69-842a-45f2-925f-6cf04e7054e0" />

<img width="464" height="108" alt="image" src="https://github.com/user-attachments/assets/51bde877-3253-4f53-b5a1-8d7553fd5cfd" />


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
