### PR TITLE
Check if stage is active before using WarningAction result

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/NodeRelationship.java
@@ -111,7 +111,7 @@ public class NodeRelationship {
             return new NodeRunStatus(BlueRun.BlueRunResult.NOT_BUILT, BlueRun.BlueRunState.SKIPPED);
         } else if (PipelineNodeUtil.isPaused(this.end)) {
             return new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.PAUSED);
-        } else if (PipelineNodeUtil.isStage(start)) {
+        } else if (!PipelineNodeUtil.isActive(start) && PipelineNodeUtil.isStage(start)) {
             WarningAction warningAction = start.getPersistentAction(WarningAction.class);
             if (warningAction != null) {
                 return new NodeRunStatus(GenericStatus.fromResult(warningAction.getResult()));
@@ -157,7 +157,7 @@ public class NodeRelationship {
         if (PipelineNodeUtil.isPaused(this.end)) {
             return new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.PAUSED);
         }
-        if (PipelineNodeUtil.isStage(start)) {
+        if (!PipelineNodeUtil.isActive(start) && PipelineNodeUtil.isStage(start)) {
             WarningAction warningAction = start.getPersistentAction(WarningAction.class);
             if (warningAction != null) {
                 return new NodeRunStatus(GenericStatus.fromResult(warningAction.getResult()));

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/ParallelBlockRelationship.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/treescanner/ParallelBlockRelationship.java
@@ -164,9 +164,11 @@ public class ParallelBlockRelationship extends NodeRelationship {
         }
         boolean skippedStage = PipelineNodeUtil.isSkippedStage(branchStartNode);
 
-        WarningAction warningAction = branchStartNode.getPersistentAction(WarningAction.class);
-        if (warningAction != null) {
-            return new NodeRunStatus(GenericStatus.fromResult(warningAction.getResult()), skippedStage);
+        if (!PipelineNodeUtil.isActive(branchStartNode)) {
+            WarningAction warningAction = branchStartNode.getPersistentAction(WarningAction.class);
+            if (warningAction != null) {
+                return new NodeRunStatus(GenericStatus.fromResult(warningAction.getResult()), skippedStage);
+            }
         }
 
         return new NodeRunStatus(this.branchStatuses.get(getBranchName(branchStartNode)), skippedStage);

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineNodeUtil.java
@@ -53,6 +53,10 @@ public class PipelineNodeUtil {
                 : name;
     }
 
+    public static boolean isActive(FlowNode node) {
+        return node != null ? node.isActive() : false;
+    }
+
     public static boolean isStep(FlowNode node) {
         if (node != null) {
             if (node instanceof AtomNode) {

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
@@ -705,4 +705,30 @@ class PipelineGraphApiTest {
         assertThat(stage2.type, equalTo("PARALLEL"));
         assertThat(stage2.name, equalTo("stage 2"));
     }
+
+    @Issue("GH#1296")
+    @Test
+    void runningUnstableStageInProgress() throws Exception {
+        QueueTaskFuture<WorkflowRun> futureRun = TestUtils.createAndRunJobNoWait(
+                j, "githubIssue1296", "gh1296_unstableStageInProgress.jenkinsfile", false);
+        WorkflowRun run = futureRun.waitForStart();
+
+        SemaphoreStep.waitForStart("wait/1", run);
+        PipelineGraphApi api = new PipelineGraphApi(run);
+        List<PipelineStage> stages = api.createTree().stages;
+
+        String stagesStringRunning = TestUtils.collectStagesAsString(
+                stages, (PipelineStage stage) -> String.format("{%s,%s}", stage.name, stage.state));
+        assertThat(stagesStringRunning, equalTo("{unstable-stage,running}"));
+
+        SemaphoreStep.success("wait/1", null);
+        // Wait for Pipeline to end (terminating it means end nodes might not be
+        // created).
+        j.waitForCompletion(run);
+
+        stages = api.createTree().stages;
+        String stagesStringFinished = TestUtils.collectStagesAsString(
+                stages, (PipelineStage stage) -> String.format("{%s,%s}", stage.name, stage.state));
+        assertThat(stagesStringFinished, equalTo("{unstable-stage,unstable}"));
+    }
 }

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh1296_unstableStageInProgress.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/gh1296_unstableStageInProgress.jenkinsfile
@@ -1,0 +1,17 @@
+import hudson.model.Result
+import io.jenkins.plugins.pipelinegraphview.utils.PipelineNodeUtil
+import org.jenkinsci.plugins.workflow.actions.WarningAction
+import org.jenkinsci.plugins.workflow.graph.FlowNode
+
+void setStageResult(Result result) {
+    FlowNode stageNode = getContext(FlowNode.class).getEnclosingBlocks().find { PipelineNodeUtil.isStage(it) }
+    if (stageNode) {
+        stageNode.addOrReplaceAction(new WarningAction(result));
+    }
+}
+
+stage("unstable-stage") {
+    echo("foo")
+    setStageResult(Result.UNSTABLE)
+    semaphore "wait"
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Closes #1296

Follow-up to https://github.com/jenkinsci/pipeline-graph-view-plugin/pull/617 and https://github.com/jenkinsci/pipeline-graph-view-plugin/pull/765

Only use the `Result` of the `WarningAction` associated with a node once that node is no longer active (i.e. a completed stage). 

The `NodeRunStatus(GenericStatus status, boolean skipped)` constructor assumes that the node state is `FINISHED` when given a status of `ABORTED`, `FAILURE`, `UNSTABLE` or `SUCCESS`.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Added the new test `PipelineGraphApiTest#runningUnstableStageInProgress` to demonstrate the issue and confirm the fix.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
