### PR TITLE
Use nested layout by default

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
@@ -172,7 +172,7 @@ export interface PositionedGraph {
   measuredHeight: number;
 }
 
-export function isFlagEnabled(flag: string) {
+export function isFlagEnabled(flag: string, defaultValue: boolean = false) {
   const isEnabled = (v: string | null) =>
     ["yes", "1", "true", "enabled"].includes(v?.toLowerCase() ?? "");
 
@@ -182,11 +182,12 @@ export function isFlagEnabled(flag: string) {
   } catch {}
   try {
     // LocalStorage access can throw, gracefully access the key.
-    return isEnabled(window.localStorage.getItem(flag));
+    const v = window.localStorage.getItem(flag);
+    if (v !== null) return isEnabled(v);
   } catch {}
-  return false;
+  return defaultValue;
 }
 
-export const nestedLayout = () => isFlagEnabled("nestedLayout");
+export const nestedLayout = () => isFlagEnabled("nestedLayout", true);
 // Optionally turn on debugging for the graph. Once the nested layout is stable, we could use a constant to let tree-shaking remove debug code in production bundles.
 export const debugPipelineGraph = () => isFlagEnabled("debugPipelineGraph");

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewNestedTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewNestedTest.java
@@ -13,7 +13,6 @@ import io.jenkins.plugins.pipelinegraphview.utils.PipelineState;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewNestedTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewNestedTest.java
@@ -24,11 +24,6 @@ class PipelineGraphViewNestedTest {
     // mvn exec:java -e -D exec.mainClass="com.microsoft.playwright.CLI" -Dexec.classpathScope=test -Dexec.args="codegen
     // http://localhost:8080/jenkins
 
-    @BeforeEach
-    void setUp(Page p) {
-        p.context().addInitScript("window.localStorage.setItem('nestedLayout', 'true')");
-    }
-
     @Test
     void smokeTest(Page p, JenkinsConfiguredWithCodeRule j) throws Exception {
         String name = "Integration Tests";

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/PipelineGraphViewTest.java
@@ -13,6 +13,7 @@ import io.jenkins.plugins.pipelinegraphview.utils.PipelineState;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -22,6 +23,11 @@ class PipelineGraphViewTest {
     // Code generation can be generated against local using to give an idea of what commands to use
     // mvn exec:java -e -D exec.mainClass="com.microsoft.playwright.CLI" -Dexec.classpathScope=test -Dexec.args="codegen
     // http://localhost:8080/jenkins
+
+    @BeforeEach
+    void setUp(Page p) {
+        p.context().addInitScript("window.localStorage.setItem('nestedLayout', 'false')");
+    }
 
     @Test
     void smokeTest(Page p, JenkinsConfiguredWithCodeRule j) throws Exception {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

It's been a week without new reports in #1286, time to switch the default to nested layout.

### Testing done

- no query + empty local storage -> nested layout
- `?nestedLayout=1` -> nested layout
- `window.localStorage.setItem('nestedLayout','true')` -> nested layout
- `?nestedLayout=0` -> old layout
- `window.localStorage.setItem('nestedLayout','false')` -> old layout
- `window.localStorage.removeItem('nestedLayout')` -> nested layout

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
