### PR TITLE
Derive svg element key from node coordinates

### DIFF
--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/connections.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/connections.tsx
@@ -11,7 +11,7 @@ type SVGChildren = Array<any>; // Fixme: Maybe refine this? Not sure what should
 
 // Generate a react key for a connection
 function connectorKey(leftNode: ConnectionEdge, rightNode: ConnectionEdge) {
-  return "c_" + leftNode.key + "_to_" + rightNode.key;
+  return `c_${leftNode.key}_${leftNode.x}_${leftNode.y}_to_${rightNode.key}_${rightNode.x}_${rightNode.y}`;
 }
 
 interface Props {
@@ -538,7 +538,7 @@ export class GraphConnections extends Component {
     const rightTop: ConnectionEdge = {
       x: node.x + node.width!,
       y: node.y,
-      key: `skipped_righ_top_${node.key}`,
+      key: `skipped_right_top_${node.key}`,
       isPlaceholder: true,
       isHidden: true,
     };


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

While testing the last changes, I noticed that collapsing nested stages left stray connections behind. Tweaking the react key of these fixes the issue.

### Testing done

https://github.com/user-attachments/assets/1b28e04d-ada7-4d87-8cf8-c958d3c7cb2c



<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
