### PR TITLE
Garbage collect collapsed stages entries in localStorage

### DIFF
--- a/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/SingleRun.tsx
+++ b/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/SingleRun.tsx
@@ -64,7 +64,7 @@ export default function SingleRun({ run, currentJobPath }: SingleRunProps) {
   }
 
   const { effectiveStages, collapsedStageIds, toggleCollapseStage } =
-    useCollapsedStages("pgv.collapsedStages." + currentRunPath, runInfo.stages);
+    useCollapsedStages(currentRunPath, runInfo.stages);
 
   return (
     <div className="pgv-single-run">

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
@@ -39,11 +39,7 @@ export default function Stages({
     expandAll,
     hasCollapsibleStages,
     effectiveStages,
-  } = useCollapsedStages(
-    "pgv.collapsedStages." + currentRunPath,
-    stages,
-    selectedStage?.id,
-  );
+  } = useCollapsedStages(currentRunPath, stages, selectedStage?.id);
 
   const handleStageSelect = useCallback(
     (nodeId: string) => {

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/useCollapsedStages.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/useCollapsedStages.ts
@@ -2,23 +2,83 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Result, StageInfo } from "../PipelineGraphModel.tsx";
 
+const KEY_PREFIX = "pgv.collapsedStages.";
+const EXPIRE_MS = 14 * 24 * 60 * 60 * 1000;
+const MAX_ENTRIES = 1_000;
+
+type StoredCollapsedStages = number[] | { lastUsed: string; ids: number[] };
+
 function loadFromStorage(key: string): Set<number> {
   try {
     const stored = window.localStorage.getItem(key);
     if (stored) {
-      return new Set(JSON.parse(stored) as number[]);
+      const parsed = JSON.parse(stored) as StoredCollapsedStages;
+      const ids = new Set(Array.isArray(parsed) ? parsed : parsed.ids);
+      saveToStorage(key, ids); // Bump the last used timestamp.
+      return ids;
     }
-  } catch {
-    // ignore
+  } catch (err) {
+    try {
+      // Bad record. Perform best-effort cleanup.
+      window.localStorage.removeItem(key);
+    } catch {}
   }
   return new Set();
 }
 
 function saveToStorage(key: string, ids: Set<number>) {
   try {
-    window.localStorage.setItem(key, JSON.stringify([...ids]));
+    if (ids.size === 0) {
+      window.localStorage.removeItem(key);
+      return;
+    }
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({ lastUsed: new Date().toISOString(), ids: [...ids] }),
+    );
   } catch {
     // ignore
+  }
+}
+
+function garbageCollectLocalStorage() {
+  try {
+    window.localStorage.key(0);
+  } catch {
+    // Local storage access failed, likely due to browser restrictions (expected).
+    // Perform this check here so that we can log unexpected errors below.
+    return;
+  }
+  try {
+    const keys = Object.keys(window.localStorage).filter((key) =>
+      key.startsWith(KEY_PREFIX),
+    );
+    const cutOff = new Date(new Date().getTime() - EXPIRE_MS).toISOString();
+    if (keys.length > MAX_ENTRIES) {
+      // Retain at most MAX_ENTRIES entries in localStorage. Discard the rest.
+      for (const key of keys.splice(0, keys.length - MAX_ENTRIES)) {
+        window.localStorage.removeItem(key);
+      }
+    }
+    for (const key of keys) {
+      const raw = window.localStorage.getItem(key);
+      if (!raw) {
+        window.localStorage.removeItem(key);
+        continue;
+      }
+      const parsed = JSON.parse(raw) as StoredCollapsedStages;
+      if (Array.isArray(parsed)) {
+        // Old schema. We don't know when this record was created. Use the current timestamp. It will expire eventually.
+        saveToStorage(key, new Set(parsed));
+      } else if (parsed.lastUsed < cutOff) {
+        window.localStorage.removeItem(key);
+      }
+    }
+  } catch (err) {
+    console.warn(
+      "Error during garbage collection for collapsed stages in localStorage:",
+      err,
+    );
   }
 }
 
@@ -142,13 +202,18 @@ function findCollapsedAncestors(
 }
 
 export function useCollapsedStages(
-  storageKey: string,
+  currentRunPath: string,
   stages: StageInfo[],
   selectedStageId?: number,
 ) {
+  const storageKey = KEY_PREFIX + currentRunPath;
   const [collapsedStageIds, setCollapsedStageIds] = useState<Set<number>>(() =>
     loadFromStorage(storageKey),
   );
+
+  useEffect(() => {
+    garbageCollectLocalStorage();
+  }, []);
 
   const toggleCollapseStage = useCallback(
     (stageId: number) => {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

We are accumulating a lot of cruft from collapsed stages in local storage. This PR is adding a little garbage collection routine:
- retain at most 1k entries
- retain entries for up-to two weeks
- Refresh a `lastUsed` timestamp on read and write access

Additionally, do not store empty collapsed lists.

cc @adityajalkhare 

### Testing done

- Store list of ids in local storage, reload page and see stages collapsed, local storage entry migrated
- Reload page, lastUsed timestamp bumped
- Expand all stages, local storage entry removed
- Back date another entry, reload the page: 1 day ->  retained; 1 month -> removed.
- set `MAX_ENTRIES=3`, collapse stages on four builds, reload the page, see 3 entries

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
