### PR TITLE
Show NoStageStepsFallback when completing early

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.spec.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.spec.tsx
@@ -160,6 +160,47 @@ describe("PipelineConsole — queued placeholder fallback", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders StageDetails + NoStageStepsFallback when completed early", async () => {
+    (useStepsPoller as any).mockReturnValue({
+      complete: true,
+      tailLogs: false,
+      scrollToTail: () => {},
+      startTailingLogs: () => {},
+      stopTailingLogs: () => {},
+      openStage: { ...placeholderStage, state: Result.aborted },
+      openStageSteps: [],
+      stepBuffers: new Map(),
+      expandedSteps: [],
+      stages: [{ ...placeholderStage, state: Result.aborted }],
+      handleStageSelect: () => {},
+      onStepToggle: () => {},
+      fetchLogText: async () => ({ lines: [], startByte: 0, endByte: 0 }),
+      fetchExceptionText: async () => ({ lines: [], startByte: 0, endByte: 0 }),
+      loading: false,
+    });
+
+    await act(async () => {
+      render(
+        <FilterProvider>
+          <PipelineConsole />
+        </FilterProvider>,
+      );
+    });
+
+    expect(
+      screen.getAllByText(/Waiting for next available executor on/).length,
+    ).toBeGreaterThan(0);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Obtained Jenkinsfile from git/),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText(/Still waiting to schedule task/),
+    ).toBeInTheDocument();
+  });
+
   it("renders the structured graph when the placeholder is no longer queued", async () => {
     (useStepsPoller as any).mockReturnValue({
       complete: false,

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -50,9 +50,10 @@ export default function PipelineConsole() {
   const isOnlyPlaceholderNode = stages.length === 1 && stages[0].placeholder;
   const isBeforePipelineStart =
     isOnlyPlaceholderNode &&
+    // We are waiting for the pipeline to start...
     (stages[0].state === Result.queued ||
-      stages[0].state === Result.failure ||
-      stages[0].state === Result.aborted);
+      // Stopped early. We will never reach the actual pipeline start.
+      complete);
   const showSplitView =
     loading || (!loading && stages.length > 0 && !isBeforePipelineStart);
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- Closes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/1203

Rather than adding `not_built` to the pile of potential results that show the no-stages ui, I'm going to check whether the run is `complete`. That should cover them all.

### Testing done

See added test

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
