### PR TITLE
Add dropdown entries for expanding/collapsing all stage steps

### DIFF
--- a/src/main/frontend/common/components/dropdown.tsx
+++ b/src/main/frontend/common/components/dropdown.tsx
@@ -14,6 +14,28 @@ export default function Dropdown({
   icon,
 }: DropdownProps) {
   const [visible, setVisible] = useState(false);
+  return (
+    <DynamicDropdown
+      visible={visible}
+      setVisible={setVisible}
+      items={items}
+      tooltip={tooltip}
+      disabled={disabled}
+      className={className}
+      icon={icon}
+    />
+  );
+}
+
+export function DynamicDropdown({
+  visible,
+  setVisible,
+  items,
+  tooltip = "More actions",
+  disabled,
+  className,
+  icon,
+}: DynamicDropdownProps) {
   const show = () => setVisible(true);
   const hide = () => setVisible(false);
 
@@ -99,6 +121,11 @@ interface DropdownProps {
   disabled?: boolean;
   className?: string;
   icon?: ReactNode;
+}
+
+interface DynamicDropdownProps extends DropdownProps {
+  visible: boolean;
+  setVisible: (visible: boolean) => void;
 }
 
 interface DropdownItem {

--- a/src/main/frontend/common/components/symbols.tsx
+++ b/src/main/frontend/common/components/symbols.tsx
@@ -55,3 +55,29 @@ export const SETTINGS = (
     />
   </svg>
 );
+
+export const EXPAND = (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+      d="M136 208l120-104 120 104M136 304l120 104 120-104"
+    />
+  </svg>
+);
+
+export const COLLAPSE = (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+      d="M136 104l120 104 120-104M136 408l120-104 120 104"
+    />
+  </svg>
+);

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -39,6 +39,8 @@ export default function PipelineConsole() {
     openStageSteps,
     stepBuffers,
     expandedSteps,
+    expandAllForStage,
+    collapseAllForStage,
     stages,
     handleStageSelect,
     onStepToggle,
@@ -160,6 +162,8 @@ export default function PipelineConsole() {
                   steps={openStageSteps}
                   stepBuffers={stepBuffers}
                   expandedSteps={expandedSteps}
+                  expandAllForStage={expandAllForStage}
+                  collapseAllForStage={collapseAllForStage}
                   onStepToggle={onStepToggle}
                   fetchLogText={fetchLogText}
                   fetchExceptionText={fetchExceptionText}
@@ -173,7 +177,13 @@ export default function PipelineConsole() {
 
       {!loading && isBeforePipelineStart && (
         <>
-          <StageDetails stage={stages[0]} />
+          <StageDetails
+            stage={stages[0]}
+            steps={openStageSteps}
+            expandedSteps={expandedSteps}
+            expandAllForStage={expandAllForStage}
+            collapseAllForStage={collapseAllForStage}
+          />
           <NoStageStepsFallback
             currentRunPath={currentRunPath}
             tailLogs={tailLogs}

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.spec.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.spec.tsx
@@ -58,6 +58,8 @@ describe("StageView", () => {
             onStepToggle={vi.fn()}
             fetchLogText={async () => mockBuffer}
             fetchExceptionText={async () => mockBuffer}
+            expandAllForStage={() => {}}
+            collapseAllForStage={() => {}}
           />
         </FilterProvider>,
       );

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/StageView.tsx
@@ -9,7 +9,13 @@ import StageSteps from "./stage-steps.tsx";
 export default function StageView(props: StageViewProps) {
   return (
     <>
-      <StageDetails stage={props.stage} />
+      <StageDetails
+        stage={props.stage}
+        steps={props.steps}
+        expandedSteps={props.expandedSteps}
+        expandAllForStage={props.expandAllForStage}
+        collapseAllForStage={props.collapseAllForStage}
+      />
       <StageSteps
         stage={props.stage}
         steps={props.steps}
@@ -32,6 +38,8 @@ export interface StageViewProps {
   steps: Array<StepInfo>;
   stepBuffers: Map<string, StepLogBufferInfo>;
   expandedSteps: string[];
+  expandAllForStage: (steps: StepInfo[]) => void;
+  collapseAllForStage: (steps: StepInfo[]) => void;
   onStepToggle: (nodeId: string) => void;
   fetchLogText: (
     stepId: string,

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
@@ -9,6 +9,7 @@ import {
   useTransformEffect,
 } from "react-zoom-pan-pinch";
 
+import { COLLAPSE, EXPAND } from "../../../../common/components/symbols.tsx";
 import Tooltip from "../../../../common/components/tooltip.tsx";
 import {
   I18NContext,
@@ -258,29 +259,7 @@ function ZoomControls({
             className={"jenkins-button jenkins-button--tertiary"}
             onClick={collapsedStageIds.size > 0 ? onExpandAll : onCollapseAll}
           >
-            {collapsedStageIds.size > 0 ? (
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-                <path
-                  fill="none"
-                  stroke="currentColor"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="32"
-                  d="M136 208l120-104 120 104M136 304l120 104 120-104"
-                />
-              </svg>
-            ) : (
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-                <path
-                  fill="none"
-                  stroke="currentColor"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="32"
-                  d="M136 104l120 104 120-104M136 408l120-104 120 104"
-                />
-              </svg>
-            )}
+            {collapsedStageIds.size > 0 ? EXPAND : COLLAPSE}
           </button>
         </Tooltip>
       )}

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.ts
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/hooks/use-steps-poller.ts
@@ -451,6 +451,19 @@ export function useStepsPoller({
     [stopTailingLogs],
   );
 
+  const expandAllForStage = useCallback((steps: StepInfo[]) => {
+    setExpandedSteps((prev) => {
+      return Array.from(new Set(prev.concat(steps.map((step) => step.id))));
+    });
+  }, []);
+
+  const collapseAllForStage = useCallback((steps: StepInfo[]) => {
+    setExpandedSteps((prev) => {
+      const ids = new Set(steps.map((step) => step.id));
+      return prev.filter((id) => !ids.has(id));
+    });
+  }, []);
+
   const openStageSteps = useMemo(() => {
     return steps.filter((step) => step.stageId === openStageId);
   }, [steps, openStageId]);
@@ -471,6 +484,8 @@ export function useStepsPoller({
     scrollToTail,
     startTailingLogs,
     stopTailingLogs,
+    expandAllForStage,
+    collapseAllForStage,
   };
 }
 

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.spec.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.spec.tsx
@@ -12,9 +12,18 @@ import StageDetails from "./stage-details.tsx";
 
 (globalThis as any).TextEncoder = TextEncoder;
 
+const defaultArgs = {
+  steps: [],
+  expandedSteps: [],
+  expandAllForStage: () => {},
+  collapseAllForStage: () => {},
+};
+
 describe("StageDetails", () => {
   it("renders null when stage is null", () => {
-    const { container } = render(<StageDetails stage={null} />);
+    const { container } = render(
+      <StageDetails {...defaultArgs} stage={null} />,
+    );
 
     expect(container.firstChild).toBeNull();
   });
@@ -22,7 +31,7 @@ describe("StageDetails", () => {
   it("renders stage name and status color class", () => {
     render(
       <FilterProvider>
-        <StageDetails stage={mockStage} />
+        <StageDetails {...defaultArgs} stage={mockStage} />
       </FilterProvider>,
     );
 
@@ -37,7 +46,10 @@ describe("StageDetails", () => {
   it("shows running bar if stage is running", () => {
     render(
       <FilterProvider>
-        <StageDetails stage={{ ...mockStage, state: Result.running }} />
+        <StageDetails
+          {...defaultArgs}
+          stage={{ ...mockStage, state: Result.running }}
+        />
       </FilterProvider>,
     );
 
@@ -50,7 +62,10 @@ describe("StageDetails", () => {
   it("does not show pause time if pauseDurationMillis is 0", () => {
     render(
       <FilterProvider>
-        <StageDetails stage={{ ...mockStage, pauseDurationMillis: 0 }} />
+        <StageDetails
+          {...defaultArgs}
+          stage={{ ...mockStage, pauseDurationMillis: 0 }}
+        />
       </FilterProvider>,
     );
 
@@ -60,7 +75,10 @@ describe("StageDetails", () => {
   it("disables dropdown if stage is synthetic", () => {
     render(
       <FilterProvider>
-        <StageDetails stage={{ ...mockStage, synthetic: true }} />
+        <StageDetails
+          {...defaultArgs}
+          stage={{ ...mockStage, synthetic: true }}
+        />
       </FilterProvider>,
     );
 
@@ -71,7 +89,7 @@ describe("StageDetails", () => {
   it("displays total duration", () => {
     render(
       <FilterProvider>
-        <StageDetails stage={{ ...mockStage }} />
+        <StageDetails {...defaultArgs} stage={{ ...mockStage }} />
       </FilterProvider>,
     );
 
@@ -84,6 +102,7 @@ describe("StageDetails", () => {
     render(
       <FilterProvider>
         <StageDetails
+          {...defaultArgs}
           stage={{ ...mockStage, startTimeMillis: Date.now() - 60_000 }}
         />
       </FilterProvider>,
@@ -96,6 +115,7 @@ describe("StageDetails", () => {
     render(
       <FilterProvider>
         <StageDetails
+          {...defaultArgs}
           stage={{
             ...mockStage,
             state: Result.queued,
@@ -115,6 +135,7 @@ describe("StageDetails", () => {
     render(
       <FilterProvider>
         <StageDetails
+          {...defaultArgs}
           stage={{
             ...mockStage,
             state: Result.running,

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.tsx
@@ -1,12 +1,19 @@
 import "./stage-details.scss";
 
-import Dropdown from "../../../common/components/dropdown.tsx";
+import { useState } from "react";
+
+import { DynamicDropdown } from "../../../common/components/dropdown.tsx";
 import {
   resultToColor,
   StageStatusIcon,
 } from "../../../common/components/status-icon.tsx";
-import { DOCUMENT } from "../../../common/components/symbols.tsx";
+import {
+  COLLAPSE,
+  DOCUMENT,
+  EXPAND,
+} from "../../../common/components/symbols.tsx";
 import Tooltip from "../../../common/components/tooltip.tsx";
+import { StepInfo } from "../../../common/RestClient.tsx";
 import LiveTotal from "../../../common/utils/live-total.tsx";
 import { exact, Paused, Started } from "../../../common/utils/timings.tsx";
 import {
@@ -15,7 +22,14 @@ import {
 } from "../../../pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx";
 import StageNodeLink from "./StageNodeLink.tsx";
 
-export default function StageDetails({ stage }: StageDetailsProps) {
+export default function StageDetails({
+  stage,
+  steps,
+  expandedSteps,
+  expandAllForStage,
+  collapseAllForStage,
+}: StageDetailsProps) {
+  const [dropdownVisible, setDropdownVisible] = useState(false);
   if (!stage) {
     return null;
   }
@@ -135,7 +149,9 @@ export default function StageDetails({ stage }: StageDetailsProps) {
         )}
         <StageNodeLink agent={stage.agent} />
         <li>
-          <Dropdown
+          <DynamicDropdown
+            visible={dropdownVisible}
+            setVisible={setDropdownVisible}
             className={"jenkins-button--tertiary"}
             disabled={stage.synthetic && !stage.placeholder}
             items={[
@@ -170,6 +186,40 @@ export default function StageDetails({ stage }: StageDetailsProps) {
                 href: `log?nodeId=${stage.id}`,
                 download: `${stage.name}.txt`,
               },
+              <button
+                key="expand-all-steps"
+                className={"jenkins-dropdown__item"}
+                disabled={!steps.some((s) => !expandedSteps.includes(s.id))}
+                onClick={() => {
+                  expandAllForStage(steps);
+                  setDropdownVisible(false);
+                }}
+              >
+                <div
+                  className="jenkins-dropdown__item__icon"
+                  style={{ rotate: "90deg" }}
+                >
+                  {EXPAND}
+                </div>
+                Expand all steps
+              </button>,
+              <button
+                key="collapse-all-steps"
+                className={"jenkins-dropdown__item"}
+                disabled={!steps.some((s) => expandedSteps.includes(s.id))}
+                onClick={() => {
+                  collapseAllForStage(steps);
+                  setDropdownVisible(false);
+                }}
+              >
+                <div
+                  className="jenkins-dropdown__item__icon"
+                  style={{ rotate: "90deg" }}
+                >
+                  {COLLAPSE}
+                </div>
+                Collapse all steps
+              </button>,
             ]}
           />
         </li>
@@ -180,4 +230,8 @@ export default function StageDetails({ stage }: StageDetailsProps) {
 
 interface StageDetailsProps {
   stage: StageInfo | null;
+  steps: Array<StepInfo>;
+  expandedSteps: string[];
+  expandAllForStage: (steps: StepInfo[]) => void;
+  collapseAllForStage: (steps: StepInfo[]) => void;
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- Closes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/194

This PR is adding dropdown entries on the stage details header for expanding/collapsing all stages.

- Expand all is disabled when all steps are expanded (including when there are none to begin with)
- Collapse all is disabled when any step is expanded (also when there are none to begin with)

I've added an intermediate `DynamicDropdown` for passing the `visible` steps from a parent element and being able to control it from dropdown items. So that I can close the dropdown after clicking one of the buttons.

### Testing done

- View stage with no steps
- View stage with many steps, toggle steps and dropdown buttons


https://github.com/user-attachments/assets/5133db9c-d70f-407c-bed6-7ae4c679a41b

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
