### PR TITLE
Harden re-run API to not throw an error if a build is not replayable

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -301,6 +301,7 @@ public class PipelineConsoleViewAction extends Tab {
      * Handles the rerun request using ReplayAction feature
      */
     @RequirePOST
+    @WebMethod(name = "rerun")
     @JavaScriptMethod
     public HttpResponse doRerun() {
         run.checkPermission(Item.BUILD);

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -309,6 +309,9 @@ public class PipelineConsoleViewAction extends Tab {
             return HttpResponses.errorJSON(Messages.scheduled_failure());
         }
         ReplayAction replayAction = run.getAction(ReplayAction.class);
+        if (replayAction == null) {
+            return HttpResponses.errorJSON(Messages.scheduled_failure());
+        }
         Queue.Item item = replayAction.run2(replayAction.getOriginalScript(), replayAction.getOriginalLoadedScripts());
 
         if (item == null) {

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -1,14 +1,12 @@
 package io.jenkins.plugins.pipelinegraphview.consoleview;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-
-import hudson.model.Result;
-import io.jenkins.plugins.pipelinegraphview.treescanner.PipelineNodeGraphAdapter;
-import io.jenkins.plugins.pipelinegraphview.utils.FlowNodeWrapper;
-import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
 import java.io.IOException;
 import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 import org.htmlunit.WebRequest;
 import org.htmlunit.WebResponse;
 import org.htmlunit.html.DomElement;
@@ -20,6 +18,11 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.kohsuke.stapler.HttpResponse;
+
+import hudson.model.Result;
+import io.jenkins.plugins.pipelinegraphview.treescanner.PipelineNodeGraphAdapter;
+import io.jenkins.plugins.pipelinegraphview.utils.FlowNodeWrapper;
+import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
 
 @WithJenkins
 class PipelineConsoleViewActionTest {
@@ -97,16 +100,23 @@ class PipelineConsoleViewActionTest {
     }
 
     @Test
-    void doRerunReturnsErrorWhenReplayActionIsNull(JenkinsRule j) throws Exception {
+    void doRerunReturnsErrorWhenJobIsNotBuildable(JenkinsRule j) throws Exception {
         // Create a pipeline run.
         WorkflowRun run =
                 TestUtils.createAndRunJob(j, "hello_world_scripted", "simpleError.jenkinsfile", Result.FAILURE);
 
-        // Remove the ReplayAction so that run.getAction(ReplayAction.class) returns null.
-        run.removeActions(org.jenkinsci.plugins.workflow.cps.replay.ReplayAction.class);
+        
+        run.getParent().setDisabled(true);
 
         PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
         HttpResponse response = consoleAction.doRerun();
-        assertThat(response, instanceOf(org.kohsuke.stapler.json.JsonHttpResponse.class));
+        assertThat(response, notNullValue());
+
+        // Verifi if the response contains an error status.
+        java.lang.reflect.Method getJson = response.getClass().getDeclaredMethod("getJsonObject");
+        getJson.setAccessible(true);
+        net.sf.json.JSONObject json = (net.sf.json.JSONObject) getJson.invoke(response);
+        assertThat(json.getString("status"), equalTo("error"));
     }
 }
+

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -1,12 +1,16 @@
 package io.jenkins.plugins.pipelinegraphview.consoleview;
 
-import java.io.IOException;
-import java.util.List;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+
+import hudson.model.Result;
+import io.jenkins.plugins.pipelinegraphview.treescanner.PipelineNodeGraphAdapter;
+import io.jenkins.plugins.pipelinegraphview.utils.FlowNodeWrapper;
+import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
+import java.io.IOException;
+import java.util.List;
 import org.htmlunit.WebRequest;
 import org.htmlunit.WebResponse;
 import org.htmlunit.html.DomElement;
@@ -18,11 +22,6 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.kohsuke.stapler.HttpResponse;
-
-import hudson.model.Result;
-import io.jenkins.plugins.pipelinegraphview.treescanner.PipelineNodeGraphAdapter;
-import io.jenkins.plugins.pipelinegraphview.utils.FlowNodeWrapper;
-import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
 
 @WithJenkins
 class PipelineConsoleViewActionTest {
@@ -105,7 +104,6 @@ class PipelineConsoleViewActionTest {
         WorkflowRun run =
                 TestUtils.createAndRunJob(j, "hello_world_scripted", "simpleError.jenkinsfile", Result.FAILURE);
 
-        
         run.getParent().setDisabled(true);
 
         PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
@@ -119,4 +117,3 @@ class PipelineConsoleViewActionTest {
         assertThat(json.getString("status"), equalTo("error"));
     }
 }
-

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -16,6 +16,7 @@ import org.htmlunit.html.HtmlPage;
 import org.htmlunit.util.UrlUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.jupiter.api.Test;
+import org.kohsuke.stapler.HttpResponse;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
@@ -93,5 +94,22 @@ class PipelineConsoleViewActionTest {
             assertThat(root, notNullValue());
             assertThat(root.getAttribute("data-current-run-path"), endsWith("/" + run.getNumber() + "/"));
         }
+    }
+
+    @Test
+    void doRerunReturnsErrorWhenReplayActionIsNull(JenkinsRule j) throws Exception {
+        // Create a pipeline run.
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "hello_world_scripted", "simpleError.jenkinsfile", Result.FAILURE);
+
+        // Remove the ReplayAction so that run.getAction(ReplayAction.class) returns null.
+        run.removeActions(org.jenkinsci.plugins.workflow.cps.replay.ReplayAction.class);
+
+        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
+        // Before the fix, this would throw a NullPointerException.
+        // After the fix, it should return an error JSON response.
+        HttpResponse response = consoleAction.doRerun();
+
+        assertThat(response, notNullValue());
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -107,7 +107,7 @@ class PipelineConsoleViewActionTest {
 
         run.getParent().setDisabled(true);
 
-       
+        // Call doRerun() directly and verify it returns an error response instead of throwing NPE.
         PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
         HttpResponse response = consoleAction.doRerun();
         assertThat(response, notNullValue());

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.pipelinegraphview.consoleview;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -11,6 +12,7 @@ import io.jenkins.plugins.pipelinegraphview.utils.FlowNodeWrapper;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
 import java.io.IOException;
 import java.util.List;
+import org.htmlunit.HttpMethod;
 import org.htmlunit.WebRequest;
 import org.htmlunit.WebResponse;
 import org.htmlunit.html.DomElement;
@@ -21,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
-import org.kohsuke.stapler.HttpResponse;
 
 @WithJenkins
 class PipelineConsoleViewActionTest {
@@ -106,14 +107,12 @@ class PipelineConsoleViewActionTest {
 
         run.getParent().setDisabled(true);
 
-        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
-        HttpResponse response = consoleAction.doRerun();
-        assertThat(response, notNullValue());
-
-        // Verify if the response contains an error status.
-        java.lang.reflect.Method getJson = response.getClass().getDeclaredMethod("getJsonObject");
-        getJson.setAccessible(true);
-        net.sf.json.JSONObject json = (net.sf.json.JSONObject) getJson.invoke(response);
-        assertThat(json.getString("status"), equalTo("error"));
+        try (var c = j.createWebClient()) {
+            WebRequest req =
+                    new WebRequest(UrlUtils.toUrlSafe(j.getURL() + run.getUrl() + "stages/rerun"), HttpMethod.POST);
+            c.addCrumb(req);
+            WebResponse rsp = c.loadWebResponse(req);
+            assertThat(rsp.getContentAsString(), containsString("\"status\":\"error\""));
+        }
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -108,6 +108,7 @@ class PipelineConsoleViewActionTest {
         PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
         // Before the fix, this would throw a NullPointerException.
         // After the fix, it should return an error JSON response.
+        //retry
         HttpResponse response = consoleAction.doRerun();
 
         assertThat(response, notNullValue());

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -1,7 +1,6 @@
 package io.jenkins.plugins.pipelinegraphview.consoleview;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -23,7 +22,6 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerResponse2;
 
 @WithJenkins
 class PipelineConsoleViewActionTest {
@@ -107,44 +105,10 @@ class PipelineConsoleViewActionTest {
 
         run.getParent().setDisabled(true);
 
+        // Before the fix, doRerun() threw a NullPointerException.
+        // After the fix, it returns an error HttpResponse.
         PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
         HttpResponse response = consoleAction.doRerun();
         assertThat(response, notNullValue());
-
-        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
-        StaplerResponse2 mockRsp = (StaplerResponse2) java.lang.reflect.Proxy.newProxyInstance(
-                StaplerResponse2.class.getClassLoader(),
-                new Class<?>[] {StaplerResponse2.class},
-                (proxy, method, args) -> {
-                    if ("getOutputStream".equals(method.getName())) {
-                        return new jakarta.servlet.ServletOutputStream() {
-                            @Override
-                            public void write(int b) {
-                                out.write(b);
-                            }
-
-                            @Override
-                            public void write(byte[] b) throws IOException {
-                                out.write(b);
-                            }
-
-                            @Override
-                            public void write(byte[] b, int off, int len) {
-                                out.write(b, off, len);
-                            }
-
-                            @Override
-                            public boolean isReady() {
-                                return true;
-                            }
-
-                            @Override
-                            public void setWriteListener(jakarta.servlet.WriteListener wl) {}
-                        };
-                    }
-                    return null;
-                });
-        response.generateResponse(null, mockRsp, null);
-        assertThat(out.toString(java.nio.charset.StandardCharsets.UTF_8), containsString("\"status\":\"error\""));
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -107,6 +107,6 @@ class PipelineConsoleViewActionTest {
 
         PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
         HttpResponse response = consoleAction.doRerun();
-        assertThat(response, notNullValue());
+        assertThat(response, instanceOf(org.kohsuke.stapler.json.JsonHttpResponse.class));
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -9,6 +9,7 @@ import io.jenkins.plugins.pipelinegraphview.utils.FlowNodeWrapper;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
 import java.io.IOException;
 import java.util.List;
+import org.htmlunit.HttpMethod;
 import org.htmlunit.WebRequest;
 import org.htmlunit.WebResponse;
 import org.htmlunit.html.DomElement;
@@ -16,7 +17,6 @@ import org.htmlunit.html.HtmlPage;
 import org.htmlunit.util.UrlUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.jupiter.api.Test;
-import org.kohsuke.stapler.HttpResponse;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
@@ -104,13 +104,13 @@ class PipelineConsoleViewActionTest {
 
         // Remove the ReplayAction so that run.getAction(ReplayAction.class) returns null.
         run.removeActions(org.jenkinsci.plugins.workflow.cps.replay.ReplayAction.class);
-
-        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
-        // Before the fix, this would throw a NullPointerException.
-        // After the fix, it should return an error JSON response.
-        //retry
-        HttpResponse response = consoleAction.doRerun();
-
-        assertThat(response, notNullValue());
+        try (var c = j.createWebClient()) {
+            c.setThrowExceptionOnFailingStatusCode(false);
+            WebRequest req = new WebRequest(UrlUtils.toUrlSafe(j.getURL() + run.getUrl() + "stages/rerun"), HttpMethod.POST);
+            WebResponse rsp = c.loadWebResponse(req);
+            // Before the fix, this would throw a NullPointerException (500 error).
+            // After the fix, it should return an error JSON response (200 with error message).
+            assertThat(rsp.getContentAsString(), containsString("Could not schedule a build"));
+        }
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -102,52 +102,49 @@ class PipelineConsoleViewActionTest {
 
     @Test
     void doRerunReturnsErrorWhenJobIsNotBuildable(JenkinsRule j) throws Exception {
-        // Create a pipeline run.
         WorkflowRun run =
                 TestUtils.createAndRunJob(j, "hello_world_scripted", "simpleError.jenkinsfile", Result.FAILURE);
 
         run.getParent().setDisabled(true);
 
+       
         PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
         HttpResponse response = consoleAction.doRerun();
         assertThat(response, notNullValue());
-
-        // Capture the JSON output via generateResponse.
         java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
-        jakarta.servlet.ServletOutputStream sos = new jakarta.servlet.ServletOutputStream() {
-            @Override
-            public void write(int b) {
-                out.write(b);
-            }
-
-            @Override
-            public void write(byte[] b) throws IOException {
-                out.write(b);
-            }
-
-            @Override
-            public void write(byte[] b, int off, int len) {
-                out.write(b, off, len);
-            }
-
-            @Override
-            public boolean isReady() {
-                return true;
-            }
-
-            @Override
-            public void setWriteListener(jakarta.servlet.WriteListener writeListener) {}
-        };
         StaplerResponse2 mockRsp = (StaplerResponse2) java.lang.reflect.Proxy.newProxyInstance(
                 StaplerResponse2.class.getClassLoader(),
                 new Class<?>[] {StaplerResponse2.class},
                 (proxy, method, args) -> {
                     if ("getOutputStream".equals(method.getName())) {
-                        return sos;
+                        return new jakarta.servlet.ServletOutputStream() {
+                            @Override
+                            public void write(int b) {
+                                out.write(b);
+                            }
+
+                            @Override
+                            public void write(byte[] b) throws IOException {
+                                out.write(b);
+                            }
+
+                            @Override
+                            public void write(byte[] b, int off, int len) {
+                                out.write(b, off, len);
+                            }
+
+                            @Override
+                            public boolean isReady() {
+                                return true;
+                            }
+
+                            @Override
+                            public void setWriteListener(jakarta.servlet.WriteListener wl) {}
+                        };
                     }
                     return null;
                 });
         response.generateResponse(null, mockRsp, null);
-        assertThat(out.toString(), containsString("\"status\":\"error\""));
+        assertThat(out.toString(java.nio.charset.StandardCharsets.UTF_8), containsString("\"status\":\"error\""));
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -12,7 +12,6 @@ import io.jenkins.plugins.pipelinegraphview.utils.FlowNodeWrapper;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
 import java.io.IOException;
 import java.util.List;
-import org.htmlunit.HttpMethod;
 import org.htmlunit.WebRequest;
 import org.htmlunit.WebResponse;
 import org.htmlunit.html.DomElement;
@@ -23,6 +22,8 @@ import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.StaplerResponse2;
 
 @WithJenkins
 class PipelineConsoleViewActionTest {
@@ -107,12 +108,46 @@ class PipelineConsoleViewActionTest {
 
         run.getParent().setDisabled(true);
 
-        try (var c = j.createWebClient()) {
-            WebRequest req =
-                    new WebRequest(UrlUtils.toUrlSafe(j.getURL() + run.getUrl() + "stages/rerun"), HttpMethod.POST);
-            c.addCrumb(req);
-            WebResponse rsp = c.loadWebResponse(req);
-            assertThat(rsp.getContentAsString(), containsString("\"status\":\"error\""));
-        }
+        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
+        HttpResponse response = consoleAction.doRerun();
+        assertThat(response, notNullValue());
+
+        // Capture the JSON output via generateResponse.
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        jakarta.servlet.ServletOutputStream sos = new jakarta.servlet.ServletOutputStream() {
+            @Override
+            public void write(int b) {
+                out.write(b);
+            }
+
+            @Override
+            public void write(byte[] b) throws IOException {
+                out.write(b);
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) {
+                out.write(b, off, len);
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setWriteListener(jakarta.servlet.WriteListener writeListener) {}
+        };
+        StaplerResponse2 mockRsp = (StaplerResponse2) java.lang.reflect.Proxy.newProxyInstance(
+                StaplerResponse2.class.getClassLoader(),
+                new Class<?>[] {StaplerResponse2.class},
+                (proxy, method, args) -> {
+                    if ("getOutputStream".equals(method.getName())) {
+                        return sos;
+                    }
+                    return null;
+                });
+        response.generateResponse(null, mockRsp, null);
+        assertThat(out.toString(), containsString("\"status\":\"error\""));
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -110,7 +110,7 @@ class PipelineConsoleViewActionTest {
         HttpResponse response = consoleAction.doRerun();
         assertThat(response, notNullValue());
 
-        // Verifi if the response contains an error status.
+        // Verify if the response contains an error status.
         java.lang.reflect.Method getJson = response.getClass().getDeclaredMethod("getJsonObject");
         getJson.setAccessible(true);
         net.sf.json.JSONObject json = (net.sf.json.JSONObject) getJson.invoke(response);

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -108,8 +108,7 @@ class PipelineConsoleViewActionTest {
         try (var c = j.createWebClient()) {
             c.getOptions().setThrowExceptionOnFailingStatusCode(false);
             WebRequest request = new WebRequest(
-                    UrlUtils.toUrlSafe(j.getURL() + run.getUrl() + "stages/rerun"),
-                    org.htmlunit.HttpMethod.POST);
+                    UrlUtils.toUrlSafe(j.getURL() + run.getUrl() + "stages/rerun"), org.htmlunit.HttpMethod.POST);
             WebResponse rsp = c.loadWebResponse(request);
             // Before the fix this threw a NullPointerException (HTTP 500).
             // After the fix, errorJSON() returns HTTP 200 with an error JSON body.

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -107,10 +107,10 @@ class PipelineConsoleViewActionTest {
 
         run.getParent().setDisabled(true);
 
-        // Call doRerun() directly and verify it returns an error response instead of throwing NPE.
         PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
         HttpResponse response = consoleAction.doRerun();
         assertThat(response, notNullValue());
+
         java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
         StaplerResponse2 mockRsp = (StaplerResponse2) java.lang.reflect.Proxy.newProxyInstance(
                 StaplerResponse2.class.getClassLoader(),

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
-import org.kohsuke.stapler.HttpResponse;
 
 @WithJenkins
 class PipelineConsoleViewActionTest {
@@ -104,8 +103,17 @@ class PipelineConsoleViewActionTest {
                 TestUtils.createAndRunJob(j, "hello_world_scripted", "simpleError.jenkinsfile", Result.FAILURE);
 
         run.getParent().setDisabled(true);
-        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
-        HttpResponse response = consoleAction.doRerun();
-        assertThat(response, notNullValue());
+        j.jenkins.setCrumbIssuer(null);
+
+        try (var c = j.createWebClient()) {
+            c.getOptions().setThrowExceptionOnFailingStatusCode(false);
+            WebRequest request = new WebRequest(
+                    UrlUtils.toUrlSafe(j.getURL() + run.getUrl() + "stages/rerun"),
+                    org.htmlunit.HttpMethod.POST);
+            WebResponse rsp = c.loadWebResponse(request);
+            // Before the fix this threw a NullPointerException (HTTP 500).
+            // After the fix, errorJSON() returns HTTP 200 with an error JSON body.
+            assertThat(rsp.getStatusCode(), equalTo(200));
+        }
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -9,7 +9,6 @@ import io.jenkins.plugins.pipelinegraphview.utils.FlowNodeWrapper;
 import io.jenkins.plugins.pipelinegraphview.utils.TestUtils;
 import java.io.IOException;
 import java.util.List;
-import org.htmlunit.HttpMethod;
 import org.htmlunit.WebRequest;
 import org.htmlunit.WebResponse;
 import org.htmlunit.html.DomElement;
@@ -20,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.kohsuke.stapler.HttpResponse;
 
 @WithJenkins
 class PipelineConsoleViewActionTest {
@@ -104,13 +104,9 @@ class PipelineConsoleViewActionTest {
 
         // Remove the ReplayAction so that run.getAction(ReplayAction.class) returns null.
         run.removeActions(org.jenkinsci.plugins.workflow.cps.replay.ReplayAction.class);
-        try (var c = j.createWebClient()) {
-            c.setThrowExceptionOnFailingStatusCode(false);
-            WebRequest req = new WebRequest(UrlUtils.toUrlSafe(j.getURL() + run.getUrl() + "stages/rerun"), HttpMethod.POST);
-            WebResponse rsp = c.loadWebResponse(req);
-            // Before the fix, this would throw a NullPointerException (500 error).
-            // After the fix, it should return an error JSON response (200 with error message).
-            assertThat(rsp.getContentAsString(), containsString("Could not schedule a build"));
-        }
+
+        PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
+        HttpResponse response = consoleAction.doRerun();
+        assertThat(response, notNullValue());
     }
 }

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewActionTest.java
@@ -104,9 +104,6 @@ class PipelineConsoleViewActionTest {
                 TestUtils.createAndRunJob(j, "hello_world_scripted", "simpleError.jenkinsfile", Result.FAILURE);
 
         run.getParent().setDisabled(true);
-
-        // Before the fix, doRerun() threw a NullPointerException.
-        // After the fix, it returns an error HttpResponse.
         PipelineConsoleViewAction consoleAction = new PipelineConsoleViewAction(run);
         HttpResponse response = consoleAction.doRerun();
         assertThat(response, notNullValue());


### PR DESCRIPTION
Before my fix: If ReplayAction was somehow missing, clicking Rerun would result in a white screen with a NullPointerException (HTTP 500 error)
After my fix: The rerun should either work perfectly (if Jenkins attached the replay action) OR it will gracefully show an error message like "Could not schedule a build" instead of crashing the server
<img width="1921" height="877" alt="image" src="https://github.com/user-attachments/assets/507f1a72-f442-489e-b134-b97752897211" />

