### PR TITLE
Persist layout/collapsed stages by normalized parent job in localStorage

### DIFF
--- a/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/MultiPipelineGraph.tsx
+++ b/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/MultiPipelineGraph.tsx
@@ -15,6 +15,7 @@ export const MultiPipelineGraph = () => {
 
   const rootElement = document.getElementById("multiple-pipeline-root");
   const currentJobPath = rootElement!.dataset.currentJobPath!;
+  const normalizedParentJobPath = rootElement!.dataset.normalizedParentJobPath!;
 
   useEffect(() => {
     if (!poll) {
@@ -64,6 +65,7 @@ export const MultiPipelineGraph = () => {
                 key={run.id}
                 run={run}
                 currentJobPath={currentJobPath}
+                normalizedParentJobPath={normalizedParentJobPath}
               />
             ))}
           </div>

--- a/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/SingleRun.tsx
+++ b/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/SingleRun.tsx
@@ -18,7 +18,11 @@ import {
 import { useCollapsedStages } from "../../../pipeline-graph-view/pipeline-graph/main/support/useCollapsedStages.ts";
 import { RunInfo } from "./MultiPipelineGraphModel.ts";
 
-export default function SingleRun({ run, currentJobPath }: SingleRunProps) {
+export default function SingleRun({
+  run,
+  currentJobPath,
+  normalizedParentJobPath,
+}: SingleRunProps) {
   const currentRunPath = currentJobPath + run.id + "/";
   const { run: runInfo } = useRunPoller({ currentRunPath });
 
@@ -64,7 +68,7 @@ export default function SingleRun({ run, currentJobPath }: SingleRunProps) {
   }
 
   const { effectiveStages, collapsedStageIds, toggleCollapseStage } =
-    useCollapsedStages(currentRunPath, runInfo.stages);
+    useCollapsedStages(normalizedParentJobPath, runInfo.stages);
 
   return (
     <div className="pgv-single-run">
@@ -92,4 +96,5 @@ export default function SingleRun({ run, currentJobPath }: SingleRunProps) {
 interface SingleRunProps {
   run: RunInfo;
   currentJobPath: string;
+  normalizedParentJobPath: string;
 }

--- a/src/main/frontend/pipeline-console-view/app.tsx
+++ b/src/main/frontend/pipeline-console-view/app.tsx
@@ -10,15 +10,18 @@ import { FilterProvider } from "./pipeline-console/main/providers/filter-provide
 import { LayoutPreferencesProvider } from "./pipeline-console/main/providers/user-preference-provider.tsx";
 
 export default function App() {
-  const locale = document.getElementById("console-pipeline-root")!.dataset
-    .userLocale!;
+  const rootElement = document.getElementById("console-pipeline-root")!;
+  const locale = rootElement.dataset.userLocale!;
+  const normalizedParentJobPath = rootElement?.dataset.normalizedParentJobPath!;
   return (
     <UserPermissionsProvider>
       <LocaleProvider locale={locale}>
         <I18NProvider bundles={[ResourceBundleName.messages]}>
           <FilterProvider>
             <UserPreferencesProvider>
-              <LayoutPreferencesProvider>
+              <LayoutPreferencesProvider
+                normalizedParentJobPath={normalizedParentJobPath}
+              >
                 <PipelineConsole />
               </LayoutPreferencesProvider>
             </UserPreferencesProvider>

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.spec.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.spec.tsx
@@ -86,7 +86,7 @@ beforeEach(() => {
   document.body.innerHTML =
     "<header></header>" +
     '<div class="jenkins-app-bar"></div>' +
-    '<div id="console-pipeline-root" data-current-run-path="/jenkins/job/x/1/"></div>' +
+    '<div id="console-pipeline-root" data-current-run-path="/jenkins/job/x/1/" data-normalized-parent-job-path="/jenkins/job/x/"></div>' +
     '<div id="console-pipeline-overflow-root"></div>';
 
   if (!(globalThis as any).IntersectionObserver) {

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -27,6 +27,7 @@ export default function PipelineConsole() {
   const rootElement = document.getElementById("console-pipeline-root");
   const currentRunPath = rootElement?.dataset.currentRunPath!;
   const previousRunPath = rootElement?.dataset.previousRunPath;
+  const normalizedParentJobPath = rootElement?.dataset.normalizedParentJobPath!;
 
   const { stageViewPosition, mainViewVisibility } = useLayoutPreferences();
   const {
@@ -118,7 +119,7 @@ export default function PipelineConsole() {
                 selectedStage={openStage || undefined}
                 stageViewPosition={stageViewPosition}
                 onStageSelect={handleStageSelect}
-                currentRunPath={currentRunPath}
+                normalizedParentJobPath={normalizedParentJobPath}
               />
             ))}
 

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
@@ -29,7 +29,7 @@ export default function Stages({
   stageViewPosition,
   onStageSelect,
   onRunPage,
-  currentRunPath,
+  normalizedParentJobPath,
 }: StagesProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -40,7 +40,7 @@ export default function Stages({
     expandAll,
     hasCollapsibleStages,
     effectiveStages,
-  } = useCollapsedStages(currentRunPath, stages, selectedStage?.id);
+  } = useCollapsedStages(normalizedParentJobPath, stages, selectedStage?.id);
 
   const handleStageSelect = useCallback(
     (nodeId: string) => {
@@ -154,7 +154,7 @@ interface StagesProps {
   stageViewPosition: StageViewPosition;
   onStageSelect?: (nodeId: string) => void;
   onRunPage?: boolean;
-  currentRunPath: string;
+  normalizedParentJobPath: string;
 }
 
 interface ZoomControlsProps {

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/providers/user-preference-provider.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/providers/user-preference-provider.tsx
@@ -54,10 +54,20 @@ const LS_KEYS = {
 };
 
 // HELPER
-const loadFromLocalStorage = <T,>(key: string, fallback: T): T => {
+const loadFromLocalStorage = <T,>(
+  key: string,
+  normalizedParentJobPath: string,
+  fallback: T,
+): T => {
   if (typeof window === "undefined") return fallback;
   try {
-    const value = window.localStorage.getItem(key);
+    let value = window.localStorage.getItem(
+      `${key}/${normalizedParentJobPath}`,
+    );
+    if (value === null) {
+      // Fallback to previous shared key, which also serves as local default form the last job that updated it.
+      value = window.localStorage.getItem(key);
+    }
     if (value !== null) {
       if (typeof fallback === "number") {
         return Number(value) as T;
@@ -70,12 +80,28 @@ const loadFromLocalStorage = <T,>(key: string, fallback: T): T => {
   return fallback;
 };
 
+const storeInLocalStorage = (
+  key: string,
+  normalizedParentJobPath: string,
+  value: string,
+) => {
+  try {
+    window.localStorage.setItem(`${key}/${normalizedParentJobPath}`, value);
+    // Provide default for any other job without a specific value.
+    window.localStorage.setItem(key, value);
+  } catch (e) {
+    console.error(`Error storing localStorage key "${key}"`, e);
+  }
+};
+
 const MOBILE_BREAKPOINT = 700;
 
 // PROVIDER
 export const LayoutPreferencesProvider = ({
+  normalizedParentJobPath,
   children,
 }: {
+  normalizedParentJobPath: string;
   children: ReactNode;
 }) => {
   const [windowWidth, setWindowWidth] = useState<number>(
@@ -84,21 +110,29 @@ export const LayoutPreferencesProvider = ({
 
   const [persistedStageViewPosition, setStageViewPositionState] =
     useState<StageViewPosition>(
-      loadFromLocalStorage(LS_KEYS.stageViewPosition, StageViewPosition.TOP),
+      loadFromLocalStorage(
+        LS_KEYS.stageViewPosition,
+        normalizedParentJobPath,
+        StageViewPosition.TOP,
+      ),
     );
   const [persistedMainViewVisibility, setMainViewVisibilityState] =
     useState<MainViewVisibility>(
-      loadFromLocalStorage(LS_KEYS.mainViewVisibility, MainViewVisibility.BOTH),
+      loadFromLocalStorage(
+        LS_KEYS.mainViewVisibility,
+        normalizedParentJobPath,
+        MainViewVisibility.BOTH,
+      ),
     );
 
   const [treeViewWidth, setTreeViewWidthState] = useState<number>(
-    loadFromLocalStorage(LS_KEYS.treeViewWidth, 300),
+    loadFromLocalStorage(LS_KEYS.treeViewWidth, normalizedParentJobPath, 300),
   );
   const [stageViewWidth, setStageViewWidthState] = useState<number>(
-    loadFromLocalStorage(LS_KEYS.stageViewWidth, 600),
+    loadFromLocalStorage(LS_KEYS.stageViewWidth, normalizedParentJobPath, 600),
   );
   const [stageViewHeight, setStageViewHeightState] = useState<number>(
-    loadFromLocalStorage(LS_KEYS.stageViewHeight, 250),
+    loadFromLocalStorage(LS_KEYS.stageViewHeight, normalizedParentJobPath, 250),
   );
 
   // Handle responsive override
@@ -113,42 +147,47 @@ export const LayoutPreferencesProvider = ({
   // Save to localStorage only when not in mobile mode
   useEffect(() => {
     if (!isMobile) {
-      window.localStorage.setItem(
+      storeInLocalStorage(
         LS_KEYS.stageViewPosition,
+        normalizedParentJobPath,
         persistedStageViewPosition,
       );
     }
-  }, [persistedStageViewPosition, isMobile]);
+  }, [persistedStageViewPosition, isMobile, normalizedParentJobPath]);
 
   useEffect(() => {
     if (!isMobile) {
-      window.localStorage.setItem(
+      storeInLocalStorage(
         LS_KEYS.mainViewVisibility,
+        normalizedParentJobPath,
         persistedMainViewVisibility,
       );
     }
-  }, [persistedMainViewVisibility, isMobile]);
+  }, [persistedMainViewVisibility, isMobile, normalizedParentJobPath]);
 
   useEffect(() => {
-    window.localStorage.setItem(
+    storeInLocalStorage(
       LS_KEYS.treeViewWidth,
+      normalizedParentJobPath,
       treeViewWidth.toString(),
     );
-  }, [treeViewWidth]);
+  }, [treeViewWidth, normalizedParentJobPath]);
 
   useEffect(() => {
-    window.localStorage.setItem(
+    storeInLocalStorage(
       LS_KEYS.stageViewWidth,
+      normalizedParentJobPath,
       stageViewWidth.toString(),
     );
-  }, [stageViewWidth]);
+  }, [stageViewWidth, normalizedParentJobPath]);
 
   useEffect(() => {
-    window.localStorage.setItem(
+    storeInLocalStorage(
       LS_KEYS.stageViewHeight,
+      normalizedParentJobPath,
       stageViewHeight.toString(),
     );
-  }, [stageViewHeight]);
+  }, [stageViewHeight, normalizedParentJobPath]);
 
   // Update window width on resize
   useEffect(() => {

--- a/src/main/frontend/pipeline-graph-view/app.tsx
+++ b/src/main/frontend/pipeline-graph-view/app.tsx
@@ -13,6 +13,7 @@ export default function App() {
   const rootElement = document.getElementById("graph");
   const currentRunPath = rootElement?.dataset.currentRunPath!;
   const previousRunPath = rootElement?.dataset.previousRunPath;
+  const normalizedParentJobPath = rootElement?.dataset.normalizedParentJobPath!;
   const { run, loading } = useRunPoller({
     currentRunPath,
     previousRunPath,
@@ -70,7 +71,7 @@ export default function App() {
           stages={run.stages}
           stageViewPosition={StageViewPosition.TOP}
           onRunPage
-          currentRunPath={currentRunPath}
+          normalizedParentJobPath={normalizedParentJobPath}
         />
       )}
     </UserPreferencesProvider>

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/useCollapsedStages.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/useCollapsedStages.ts
@@ -2,20 +2,11 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Result, StageInfo } from "../PipelineGraphModel.tsx";
 
-const KEY_PREFIX = "pgv.collapsedStages.";
-const EXPIRE_MS = 14 * 24 * 60 * 60 * 1000;
-const MAX_ENTRIES = 1_000;
-
-type StoredCollapsedStages = number[] | { lastUsed: string; ids: number[] };
-
 function loadFromStorage(key: string): Set<number> {
   try {
     const stored = window.localStorage.getItem(key);
     if (stored) {
-      const parsed = JSON.parse(stored) as StoredCollapsedStages;
-      const ids = new Set(Array.isArray(parsed) ? parsed : parsed.ids);
-      saveToStorage(key, ids); // Bump the last used timestamp.
-      return ids;
+      return new Set(JSON.parse(stored) as number[]);
     }
   } catch (err) {
     try {
@@ -32,10 +23,7 @@ function saveToStorage(key: string, ids: Set<number>) {
       window.localStorage.removeItem(key);
       return;
     }
-    window.localStorage.setItem(
-      key,
-      JSON.stringify({ lastUsed: new Date().toISOString(), ids: [...ids] }),
-    );
+    window.localStorage.setItem(key, JSON.stringify([...ids]));
   } catch {
     // ignore
   }
@@ -50,29 +38,10 @@ function garbageCollectLocalStorage() {
     return;
   }
   try {
-    const keys = Object.keys(window.localStorage).filter((key) =>
-      key.startsWith(KEY_PREFIX),
-    );
-    const cutOff = new Date(new Date().getTime() - EXPIRE_MS).toISOString();
-    if (keys.length > MAX_ENTRIES) {
-      // Retain at most MAX_ENTRIES entries in localStorage. Discard the rest.
-      for (const key of keys.splice(0, keys.length - MAX_ENTRIES)) {
-        window.localStorage.removeItem(key);
-      }
-    }
-    for (const key of keys) {
-      const raw = window.localStorage.getItem(key);
-      if (!raw) {
-        window.localStorage.removeItem(key);
-        continue;
-      }
-      const parsed = JSON.parse(raw) as StoredCollapsedStages;
-      if (Array.isArray(parsed)) {
-        // Old schema. We don't know when this record was created. Use the current timestamp. It will expire eventually.
-        saveToStorage(key, new Set(parsed));
-      } else if (parsed.lastUsed < cutOff) {
-        window.localStorage.removeItem(key);
-      }
+    for (const key of Object.keys(window.localStorage)) {
+      // The old key prefix uses a dot as separator.
+      if (!key.startsWith("pgv.collapsedStages.")) continue;
+      window.localStorage.removeItem(key);
     }
   } catch (err) {
     console.warn(
@@ -202,11 +171,11 @@ function findCollapsedAncestors(
 }
 
 export function useCollapsedStages(
-  currentRunPath: string,
+  normalizedParentJobPath: string,
   stages: StageInfo[],
   selectedStageId?: number,
 ) {
-  const storageKey = KEY_PREFIX + currentRunPath;
+  const storageKey = `pgv.collapsedStages/${normalizedParentJobPath}`;
   const [collapsedStageIds, setCollapsedStageIds] = useState<Set<number>>(() =>
     loadFromStorage(storageKey),
   );

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction.java
@@ -401,6 +401,14 @@ public class PipelineConsoleViewAction extends Tab {
         return getBuildNumber(run.getNextBuild());
     }
 
+    public String getNormalizedParentJobPath() {
+        boolean isMultiBranch =
+                run.getParent().getProperty("org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty") != null;
+        return isMultiBranch
+                ? run.getParent().getParent().getUrl()
+                : run.getParent().getUrl();
+    }
+
     @GET
     @WebMethod(name = "tree")
     public void getTree(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction.java
@@ -96,6 +96,12 @@ public class MultiPipelineGraphViewAction implements Action, IconSpec {
         return target.getUrl();
     }
 
+    public String getNormalizedParentJobPath() {
+        boolean isMultiBranch =
+                target.getProperty("org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty") != null;
+        return isMultiBranch ? target.getParent().getUrl() : target.getUrl();
+    }
+
     @Override
     public String getIconFileName() {
         return null;

--- a/src/main/resources/components/temporary-wrapper.jelly
+++ b/src/main/resources/components/temporary-wrapper.jelly
@@ -141,6 +141,7 @@
 
                     <div id="console-pipeline-root" data-current-run-path="${rootURL + '/' + it.buildUrl}"
                          data-previous-run-path="${it.previousBuildUrl != null ? rootURL + '/' + it.previousBuildUrl : null}"
+                         data-normalized-parent-job-path="${it.normalizedParentJobPath}"
                          data-user-locale="${request2.getLocale().toLanguageTag()}"/>
                     <script src="${rootURL}/plugin/pipeline-graph-view/js/build.js" type="module"/>
                     <script src="${rootURL}/plugin/pipeline-graph-view/js/bundles/pipeline-console-view-bundle.js" type="module"/>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/index.jelly
@@ -27,6 +27,7 @@
 
         <div id="console-pipeline-root" data-current-run-path="${rootURL + '/' + it.buildUrl}"
                        data-previous-run-path="${it.previousBuildUrl != null ? rootURL + '/' + it.previousBuildUrl : null}"
+                       data-normalized-parent-job-path="${it.normalizedParentJobPath}"
                        data-user-locale="${request2.getLocale().toLanguageTag()}"/>
         <script src="${rootURL}/plugin/pipeline-graph-view/js/build.js" type="module"/>
         <script src="${rootURL}/plugin/pipeline-graph-view/js/bundles/pipeline-console-view-bundle.js" type="module"/>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/summary.jelly
@@ -5,6 +5,7 @@
     <!-- workaround floatingBox elements overlapping -->
     <div class="clearfix" />
     <div id="graph"
+         data-normalized-parent-job-path="${it.normalizedParentJobPath}"
          data-current-run-path="${rootURL + '/' + it.buildUrl}"
          data-previous-run-path="${it.previousBuildUrl != null ? rootURL + '/' + it.previousBuildUrl : null}" />
     <script src="${rootURL}/plugin/pipeline-graph-view/js/bundles/pipeline-graph-view-bundle.js" type="module"/>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/widget.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/consoleview/PipelineConsoleViewAction/widget.jelly
@@ -3,6 +3,7 @@
 <j:jelly xmlns:j="jelly:core">
     <div class="jenkins-card"
          id="graph"
+         data-normalized-parent-job-path="${it.normalizedParentJobPath}"
          data-current-run-path="${rootURL + '/' + it.url}"
          data-previous-run-path="${it.previousBuild != null ? rootURL + '/' + it.previousBuild.url : null}" />
     <script src="${rootURL}/plugin/pipeline-graph-view/js/bundles/pipeline-graph-view-bundle.js" type="module"/>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction/index.jelly
@@ -30,6 +30,7 @@
 
       <div id="multiple-pipeline-root"
            data-current-job-path="${rootURL + '/' + it.jobUrl}"
+           data-normalized-parent-job-path="${it.normalizedParentJobPath}"
            data-user-locale="${request2.getLocale().toLanguageTag()}"/>
       <script src="${rootURL}/plugin/pipeline-graph-view/js/bundles/multi-pipeline-graph-view-bundle.js" type="module"/>
       <script src="${rootURL}/plugin/pipeline-graph-view/js/build.js" type="module"/>

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction/jobMain.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/multipipelinegraphview/MultiPipelineGraphViewAction/jobMain.jelly
@@ -14,6 +14,7 @@
     <l:card title="${%Stages}" expandable="multi-pipeline-graph" controls="${controls}">
       <div id="multiple-pipeline-root"
            data-current-job-path="${rootURL + '/' + it.jobUrl}"
+           data-normalized-parent-job-path="${it.normalizedParentJobPath}"
            data-user-locale="${request2.getLocale().toLanguageTag()}" />
     </l:card>
     <script src="${rootURL}/plugin/pipeline-graph-view/js/bundles/multi-pipeline-graph-view-bundle.js" type="module"/>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- Closes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/710
- Maybe addresses https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/789 (Opening a build for each pipeline once to collapse desired stages might be fine @stuartrowe ?)

Store local storage entries for layout and collapsed stages by "normalized parent job". That is the job for regular pipelines and the parent job for multi-branch pipelines.

The layout options are still read/stored in the shared keys: Any new job that does not have it's own key will pick any last written value up.

The cleanup in #1320 is likely not needed anymore, so I've reduced it to cleanup the per-build keys only. Limiting the size of the key-space to scale linear with the number of pipelines is likely fine.

Code detail: To avoid depending on the multibranch plugin, I'm checking for the property by name instead of by class.

### Testing done

- create two multi-branch pipelines (`multibranch-one` and `multibranch-twp` below) and build two each branches, open each, see a single key being used for collapsed stages and layout options
- create multiple regular pipelines (`issues/51` and `issues/1155` below), see unique keys per job, switch between builds, see same keys being used
- change layout in any of the builds (call it "foo"), open yet another pipeline, it picks up the last layout, change again, switch back to "foo", it uses the same layout

<img width="632" height="348" alt="image" src="https://github.com/user-attachments/assets/bbc5ae26-55ce-40f9-b88a-1f1985f4faed" />

<img width="632" height="258" alt="image" src="https://github.com/user-attachments/assets/fa7afc93-710a-4d41-bd1d-ee7b9e26865c" />

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
