### PR TITLE
Remove unused dependency on Metrics plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,10 +88,6 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>metrics</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pipeline-build-step</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
### Testing done

Verified that there are no remaining Java references to the Metrics plugin (`git grep -i metrics` only returned the dependency in `pom.xml`).

Removed the unused `metrics` dependency from `pom.xml`.

Executed `mvnd clean verify`. The build progressed through compilation and started running tests. A local JVM memory/page file issue caused test execution to stop, but this failure is unrelated to the change in this PR.

This change only removes an unused dependency and does not affect plugin behavior.

### Submitter checklist

* [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x] Ensure that the pull request title represents the desired changelog entry
* [x] Please describe what you did
* [x] Link to relevant issues in GitHub or Jira

Fixes #1343

* [x] Link to relevant pull requests, esp. upstream and downstream changes

Related: #1009

* [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

No additional tests were required because this change only removes an unused dependency.
