### PR TITLE
Use `.jenkins-card` container styling + refine reset control

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -114,13 +114,15 @@ export default function PipelineConsole() {
             (loading ? (
               <Skeleton />
             ) : (
-              <Stages
-                stages={stages}
-                selectedStage={openStage || undefined}
-                stageViewPosition={stageViewPosition}
-                onStageSelect={handleStageSelect}
-                normalizedParentJobPath={normalizedParentJobPath}
-              />
+              <div className={"jenkins-card"}>
+                <Stages
+                  stages={stages}
+                  selectedStage={openStage || undefined}
+                  stageViewPosition={stageViewPosition}
+                  onStageSelect={handleStageSelect}
+                  normalizedParentJobPath={normalizedParentJobPath}
+                />
+              </div>
             ))}
 
           <SplitView storageKey="stages">

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -114,15 +114,13 @@ export default function PipelineConsole() {
             (loading ? (
               <Skeleton />
             ) : (
-              <div className={"jenkins-card"}>
-                <Stages
-                  stages={stages}
-                  selectedStage={openStage || undefined}
-                  stageViewPosition={stageViewPosition}
-                  onStageSelect={handleStageSelect}
-                  normalizedParentJobPath={normalizedParentJobPath}
-                />
-              </div>
+              <Stages
+                stages={stages}
+                selectedStage={openStage || undefined}
+                stageViewPosition={stageViewPosition}
+                onStageSelect={handleStageSelect}
+                normalizedParentJobPath={normalizedParentJobPath}
+              />
             ))}
 
           <SplitView storageKey="stages">

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.scss
@@ -1,8 +1,5 @@
 .pgv-stages-graph {
   position: relative;
-  background: var(--card-background);
-  border: var(--card-border-width) solid var(--card-border-color);
-  border-radius: var(--form-input-border-radius);
   overflow: hidden;
   height: 100%;
 
@@ -25,8 +22,7 @@
     position: fixed;
     inset: 0 !important;
     z-index: 30000;
-    border-radius: 0;
-    border: none;
+    background: var(--card-background);
     height: unset;
     max-height: unset;
 
@@ -92,13 +88,4 @@
   background: color-mix(in srgb, var(--card-background) 80%, transparent);
   border: var(--jenkins-border-width) solid transparent;
   background-clip: padding-box;
-}
-
-// Space for "Stages" overlay
-.pvg-stages-graph--spacing-top {
-  padding-top: 26px;
-}
-// Spacing for "Expand" button
-.pvg-stages-graph--spacing-right {
-  padding-right: 26px;
 }

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
@@ -52,6 +52,7 @@ export default function Stages({
 
   const [initialScale, setInitialScale] = useState(1);
   const [minScale, setMinScale] = useState(0.75);
+  const defaultScale = Math.max(initialScale, 0.5);
 
   return (
     <div
@@ -122,7 +123,7 @@ export default function Stages({
         wheel={{ activationKeys: isExpanded ? [] : ["Control"] }}
       >
         <ZoomControls
-          initialScale={initialScale}
+          defaultScale={defaultScale}
           minScale={minScale}
           collapsedStageIds={collapsedStageIds}
           hasCollapsibleStages={hasCollapsibleStages}
@@ -156,7 +157,7 @@ interface StagesProps {
 }
 
 interface ZoomControlsProps {
-  initialScale: number;
+  defaultScale: number;
   minScale: number;
   collapsedStageIds: Set<number>;
   hasCollapsibleStages: boolean;
@@ -165,7 +166,7 @@ interface ZoomControlsProps {
 }
 
 function ZoomControls({
-  initialScale,
+  defaultScale,
   minScale,
   collapsedStageIds,
   hasCollapsibleStages,
@@ -174,7 +175,7 @@ function ZoomControls({
 }: ZoomControlsProps) {
   const { zoomIn, zoomOut, centerView } = useControls();
   const messages = useContext(I18NContext);
-  const [scale, setScale] = useState(initialScale);
+  const [scale, setScale] = useState(defaultScale);
   const handleTransformEffect = useCallback(
     (ref: ReactZoomPanPinchContextState) => setScale(ref.state.scale),
     [],
@@ -222,8 +223,8 @@ function ZoomControls({
       <Tooltip content={"Reset"}>
         <button
           className={"jenkins-button jenkins-button--tertiary"}
-          onClick={() => centerView(initialScale)}
-          disabled={scale === initialScale}
+          onClick={() => centerView(defaultScale)}
+          disabled={scale === defaultScale}
         >
           <svg className="ionicon" viewBox="0 0 512 512">
             <path

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
@@ -22,6 +22,14 @@ import { useCollapsedStages } from "../../../../pipeline-graph-view/pipeline-gra
 import { StageViewPosition } from "../providers/user-preference-provider.tsx";
 
 const MAX_SCALE = 3;
+const SCALE_TOLERANCE = 0.001;
+const POSITION_TOLERANCE = 1;
+
+interface GraphTransform {
+  scale: number;
+  positionX: number;
+  positionY: number;
+}
 
 export default function Stages({
   stages,
@@ -52,7 +60,11 @@ export default function Stages({
 
   const [initialScale, setInitialScale] = useState(1);
   const [minScale, setMinScale] = useState(0.75);
-  const defaultScale = Math.max(initialScale, 0.5);
+  const [defaultTransform, setDefaultTransform] = useState<GraphTransform>({
+    scale: 1,
+    positionX: 0,
+    positionY: 0,
+  });
 
   return (
     <div
@@ -123,7 +135,7 @@ export default function Stages({
         wheel={{ activationKeys: isExpanded ? [] : ["Control"] }}
       >
         <ZoomControls
-          defaultScale={defaultScale}
+          defaultTransform={defaultTransform}
           minScale={minScale}
           collapsedStageIds={collapsedStageIds}
           hasCollapsibleStages={hasCollapsibleStages}
@@ -139,6 +151,7 @@ export default function Stages({
             onToggleCollapse={toggleCollapseStage}
             setInitialScale={setInitialScale}
             setMinScale={setMinScale}
+            setDefaultTransform={setDefaultTransform}
             {...(onStageSelect && { onStageSelect: handleStageSelect })}
           />
         </TransformComponent>
@@ -157,7 +170,7 @@ interface StagesProps {
 }
 
 interface ZoomControlsProps {
-  defaultScale: number;
+  defaultTransform: GraphTransform;
   minScale: number;
   collapsedStageIds: Set<number>;
   hasCollapsibleStages: boolean;
@@ -166,21 +179,32 @@ interface ZoomControlsProps {
 }
 
 function ZoomControls({
-  defaultScale,
+  defaultTransform,
   minScale,
   collapsedStageIds,
   hasCollapsibleStages,
   onCollapseAll,
   onExpandAll,
 }: ZoomControlsProps) {
-  const { zoomIn, zoomOut, centerView } = useControls();
+  const { zoomIn, zoomOut, setTransform } = useControls();
   const messages = useContext(I18NContext);
-  const [scale, setScale] = useState(defaultScale);
+  const [transform, setTransformState] = useState(defaultTransform);
   const handleTransformEffect = useCallback(
-    (ref: ReactZoomPanPinchContextState) => setScale(ref.state.scale),
+    (ref: ReactZoomPanPinchContextState) =>
+      setTransformState({
+        scale: ref.state.scale,
+        positionX: ref.state.positionX,
+        positionY: ref.state.positionY,
+      }),
     [],
   );
   useTransformEffect(handleTransformEffect);
+  const isAtDefaultTransform =
+    Math.abs(transform.scale - defaultTransform.scale) < SCALE_TOLERANCE &&
+    Math.abs(transform.positionX - defaultTransform.positionX) <
+      POSITION_TOLERANCE &&
+    Math.abs(transform.positionY - defaultTransform.positionY) <
+      POSITION_TOLERANCE;
 
   return (
     <div className="pgv-stages-graph__controls pgw-zoom-controls">
@@ -188,7 +212,7 @@ function ZoomControls({
         <button
           className={"jenkins-button jenkins-button--tertiary"}
           onClick={() => zoomIn()}
-          disabled={scale >= MAX_SCALE}
+          disabled={transform.scale >= MAX_SCALE}
         >
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
             <path
@@ -206,7 +230,7 @@ function ZoomControls({
         <button
           className={"jenkins-button jenkins-button--tertiary"}
           onClick={() => zoomOut()}
-          disabled={scale <= minScale}
+          disabled={transform.scale <= minScale}
         >
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
             <path
@@ -223,8 +247,14 @@ function ZoomControls({
       <Tooltip content={"Reset"}>
         <button
           className={"jenkins-button jenkins-button--tertiary"}
-          onClick={() => centerView(defaultScale)}
-          disabled={scale === defaultScale}
+          onClick={() =>
+            setTransform(
+              defaultTransform.positionX,
+              defaultTransform.positionY,
+              defaultTransform.scale,
+            )
+          }
+          disabled={isAtDefaultTransform}
         >
           <svg className="ionicon" viewBox="0 0 512 512">
             <path

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
@@ -58,8 +58,6 @@ export default function Stages({
       className={classNames("pgv-stages-graph", {
         "pgv-stages-graph--left": stageViewPosition === StageViewPosition.LEFT,
         "pgv-stages-graph--dialog": isExpanded,
-        "pvg-stages-graph--spacing-top": onRunPage,
-        "pvg-stages-graph--spacing-right": !onRunPage && !isExpanded,
       })}
     >
       {onRunPage && (

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
@@ -71,6 +71,7 @@ export default function Stages({
       className={classNames("pgv-stages-graph", {
         "pgv-stages-graph--left": stageViewPosition === StageViewPosition.LEFT,
         "pgv-stages-graph--dialog": isExpanded,
+        "jenkins-card": !onRunPage,
       })}
     >
       {onRunPage && (

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
@@ -42,6 +42,7 @@ interface Viewport {
 }
 
 const VIEWPORT_MARGIN = 300;
+const GRAPH_PADDING = 16;
 
 const MIN_COLUMNS_WHEN_COLLAPSED = 5;
 
@@ -184,11 +185,15 @@ export function PipelineGraph({
       return;
     }
 
-    const initialScale = Math.min(1, transformWidth / measuredWidth);
+    const paddedMeasuredWidth = measuredWidth + GRAPH_PADDING * 2;
+    const paddedMeasuredHeight = measuredHeight + GRAPH_PADDING * 2;
+    const initialScale = Math.min(1, transformWidth / paddedMeasuredWidth);
     const minScale = initialScale * 0.75;
     const autoScale = Math.max(initialScale, 0.5);
-    const centerOffsetX = (transformWidth - measuredWidth * autoScale) / 2;
-    const centerOffsetY = (transformHeight - measuredHeight * autoScale) / 2;
+    const centerOffsetX =
+      (transformWidth - paddedMeasuredWidth * autoScale) / 2;
+    const centerOffsetY =
+      (transformHeight - paddedMeasuredHeight * autoScale) / 2;
     setMinScale(minScale);
     setInitialScale(initialScale);
     setDefaultTransform?.({
@@ -322,6 +327,7 @@ export function PipelineGraph({
   const outerDivStyle: CSSProperties = {
     position: "relative",
     overflow: "visible",
+    margin: GRAPH_PADDING,
   };
   if (debugPipelineGraph()) {
     outerDivStyle.border = "1px dashed red";

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
@@ -55,6 +55,7 @@ export function PipelineGraph({
   onToggleCollapse,
   setMinScale,
   setInitialScale,
+  setDefaultTransform,
 }: Props) {
   const fullLayout = useMemo(() => {
     return {
@@ -185,13 +186,18 @@ export function PipelineGraph({
 
     const initialScale = Math.min(1, transformWidth / measuredWidth);
     const minScale = initialScale * 0.75;
+    const autoScale = Math.max(initialScale, 0.5);
+    const centerOffsetX = (transformWidth - measuredWidth * autoScale) / 2;
+    const centerOffsetY = (transformHeight - measuredHeight * autoScale) / 2;
     setMinScale(minScale);
     setInitialScale(initialScale);
+    setDefaultTransform?.({
+      scale: autoScale,
+      positionX: centerOffsetX,
+      positionY: centerOffsetY,
+    });
     if (fitToWidth) {
       // Don't scale too small by default.
-      const autoScale = Math.max(initialScale, 0.5);
-      const centerOffsetX = (transformWidth - measuredWidth * autoScale) / 2;
-      const centerOffsetY = (transformHeight - measuredHeight * autoScale) / 2;
       if (
         transform.state.scale !== autoScale ||
         transform.state.positionX !== centerOffsetX ||
@@ -209,6 +215,7 @@ export function PipelineGraph({
     measuredHeight,
     setMinScale,
     setInitialScale,
+    setDefaultTransform,
   ]);
 
   // When inside a TransformWrapper, only mount the nodes/labels intersecting
@@ -413,4 +420,9 @@ interface Props {
   onToggleCollapse: (stageId: number) => void;
   setMinScale?: (value: number) => void;
   setInitialScale?: (value: number) => void;
+  setDefaultTransform?: (value: {
+    scale: number;
+    positionX: number;
+    positionY: number;
+  }) => void;
 }

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
@@ -149,12 +149,20 @@ export function PipelineGraph({
   );
 
   const transform = useContext(TransformContext);
-  const [transformWidth, setTransformWidth] = useState<number>(0);
+  const [transformViewport, setTransformViewport] = useState({
+    width: 0,
+    height: 0,
+  });
   useEffect(() => {
     if (!transform?.wrapperComponent) return;
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
-        setTransformWidth(entry.contentRect.width);
+        const { width, height } = entry.contentRect;
+        setTransformViewport((prev) =>
+          prev.width === width && prev.height === height
+            ? prev
+            : { width, height },
+        );
       }
     });
     observer.observe(transform.wrapperComponent);
@@ -164,6 +172,17 @@ export function PipelineGraph({
   const [fitToWidth, setFitToWidth] = useState(true);
   useEffect(() => {
     if (!setMinScale || !setInitialScale || !transform) return;
+    const { width: transformWidth, height: transformHeight } =
+      transformViewport;
+    if (
+      transformWidth <= 0 ||
+      transformHeight <= 0 ||
+      measuredWidth <= 0 ||
+      measuredHeight <= 0
+    ) {
+      return;
+    }
+
     const initialScale = Math.min(1, transformWidth / measuredWidth);
     const minScale = initialScale * 0.75;
     setMinScale(minScale);
@@ -171,20 +190,23 @@ export function PipelineGraph({
     if (fitToWidth) {
       // Don't scale too small by default.
       const autoScale = Math.max(initialScale, 0.5);
-      const centerOffset = Math.max(0, (transformWidth - measuredWidth) / 2);
+      const centerOffsetX = (transformWidth - measuredWidth * autoScale) / 2;
+      const centerOffsetY = (transformHeight - measuredHeight * autoScale) / 2;
       if (
         transform.state.scale !== autoScale ||
-        transform.state.positionX !== centerOffset
+        transform.state.positionX !== centerOffsetX ||
+        transform.state.positionY !== centerOffsetY
       ) {
-        transform.setState(autoScale, centerOffset, 0);
+        transform.setState(autoScale, centerOffsetX, centerOffsetY);
       }
       return transform.onChange(() => setFitToWidth(false));
     }
   }, [
     transform,
-    transformWidth,
+    transformViewport,
     fitToWidth,
     measuredWidth,
+    measuredHeight,
     setMinScale,
     setInitialScale,
   ]);

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
@@ -42,7 +42,7 @@ interface Viewport {
 }
 
 const VIEWPORT_MARGIN = 300;
-const GRAPH_PADDING = 16;
+const GRAPH_PADDING = 20;
 
 const MIN_COLUMNS_WHEN_COLLAPSED = 5;
 
@@ -190,10 +190,14 @@ export function PipelineGraph({
     const initialScale = Math.min(1, transformWidth / paddedMeasuredWidth);
     const minScale = initialScale * 0.75;
     const autoScale = Math.max(initialScale, 0.5);
-    const centerOffsetX =
-      (transformWidth - paddedMeasuredWidth * autoScale) / 2;
-    const centerOffsetY =
-      (transformHeight - paddedMeasuredHeight * autoScale) / 2;
+    const centerOffsetX = Math.max(
+      0,
+      (transformWidth - paddedMeasuredWidth * autoScale) / 2,
+    );
+    const centerOffsetY = Math.max(
+      0,
+      (transformHeight - paddedMeasuredHeight * autoScale) / 2,
+    );
     setMinScale(minScale);
     setInitialScale(initialScale);
     setDefaultTransform?.({


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/1348

* Use `.jenkins-card` container styling
  * So we don't reimplement the same styling/cause issues (identified in https://github.com/jenkinsci/jenkins/pull/26974)
* Refine the reset control/positioning
  * Card is vertically centred by default
  * Reset control now enables if position isn't the centre
  * Some margin added to the graph

### Testing done

* The centering/reset control is largely 🤝 vibe coded 🤝 but in my testing across various complex graphs its working fine

<img width="1603" height="368" alt="Screenshot 2026-06-21 at 17 41 05" src="https://github.com/user-attachments/assets/5fbbf1ab-9963-4b40-a8d0-b286ed8618cd" />

<img width="1603" height="368" alt="Screenshot 2026-06-21 at 17 40 21" src="https://github.com/user-attachments/assets/90135f1d-f81f-4f5c-9b12-783205b0b24c" />

<img width="1603" height="368" alt="Screenshot 2026-06-21 at 17 40 34" src="https://github.com/user-attachments/assets/bc662292-9d6d-4643-8758-dc5bc41a3fa8" />

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
