### PR TITLE
Fix excessive /stages/pauseState polling

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,6 +61,7 @@ export default [
     languageOptions: {
       globals: {
         dialog: "readonly",
+        MutationObserver: "readonly",
         notificationBar: "readonly",
       },
     },

--- a/src/main/resources/components/temporary-wrapper.jelly
+++ b/src/main/resources/components/temporary-wrapper.jelly
@@ -28,7 +28,7 @@
                                 <st:bind value="${it}" var="pauseAction${pauseProxyId}"/>
                                 <j:set var="resumeProxyId" value="${h.generateId()}" />
                                 <st:bind value="${it}" var="resumeAction${resumeProxyId}"/>
-                                <div class="jenkins-split-button">
+                                <div id="pgv-cancel-split-button" class="jenkins-split-button">
                                     <button id="pgv-cancel" data-confirm="${%Confirm(it.buildFullDisplayName)}"
                                             data-success-message="${%Build cancelled}"
                                             data-proxy-name="cancelAction${cancelProxyId}"
@@ -76,7 +76,7 @@
                             <l:hasPermission permission="${it.permission}">
                                 <j:set var="rerunProxyId" value="${h.generateId()}" />
                                 <st:bind value="${it}" var="rerunAction${rerunProxyId}"/>
-                                <div class="jenkins-split-button">
+                                <div id="pgv-rerun-split-button" class="jenkins-split-button">
                                     <button id="pgv-rerun"
                                             data-proxy-name="rerunAction${rerunProxyId}"
                                             class="jenkins-button jenkins-!-build-color">

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -170,7 +170,7 @@ document.addEventListener("click", function (event) {
   }
 });
 
-function updatePauseElements() {
+function updatePauseElements(enablePolling = false) {
   const pausedBanner = document.getElementById("pgv-paused-banner");
   const pauseMenuItem = document.getElementById("pgv-pause");
   const resumeMenuItem = document.getElementById("pgv-resume");
@@ -208,12 +208,9 @@ function updatePauseElements() {
             }
           }
 
-          let updateInterval = 5000;
-          // update more frequently when the pause/resume menu items are visible
-          if (pauseMenuItem || resumeMenuItem) {
-            updateInterval = 1000;
+          if (enablePolling) {
+            setTimeout(() => updatePauseElements(true), 1000);
           }
-          setTimeout(updatePauseElements, updateInterval);
         } else {
           pausedBanner.style.display = "none";
           pauseMenuItem.style.display = "none";
@@ -227,4 +224,23 @@ function updatePauseElements() {
     });
 }
 
-updatePauseElements();
+const cancelSplitButton = document.getElementById("pgv-cancel-split-button");
+if (cancelSplitButton) {
+  // Create an observer to update the pause/resume menu items when they become visible
+  new MutationObserver((mutationsList, observer) => {
+    for (const mutation of mutationsList) {
+      if (mutation.type === "childList") {
+        const pauseMenuItem = document.getElementById("pgv-pause");
+        const resumeMenuItem = document.getElementById("pgv-resume");
+        if (pauseMenuItem || resumeMenuItem) {
+          updatePauseElements(false);
+        }
+      }
+    }
+  }).observe(cancelSplitButton, {
+    childList: true,
+    subtree: true,
+  });
+}
+
+updatePauseElements(true);

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -139,11 +139,6 @@ document.addEventListener("click", function (event) {
       const result = response.responseJSON;
       if (result.status === "ok") {
         notificationBar.show(target.dataset.successMessage);
-        // Hide pause, show resume
-        const pauseItem = document.getElementById("pgv-pause");
-        const resumeItem = document.getElementById("pgv-resume");
-        if (pauseItem) pauseItem.style.display = "none";
-        if (resumeItem) resumeItem.style.display = "";
       } else {
         notificationBar.show(result.message, notificationBar.WARNING);
       }
@@ -158,11 +153,6 @@ document.addEventListener("click", function (event) {
       const result = response.responseJSON;
       if (result.status === "ok") {
         notificationBar.show(target.dataset.successMessage);
-        // Hide resume, show pause
-        const pauseItem = document.getElementById("pgv-pause");
-        const resumeItem = document.getElementById("pgv-resume");
-        if (resumeItem) resumeItem.style.display = "none";
-        if (pauseItem) pauseItem.style.display = "";
       } else {
         notificationBar.show(result.message, notificationBar.WARNING);
       }

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -230,11 +230,19 @@ function updatePauseElements(enablePolling = false) {
 
 const cancelSplitButton = document.getElementById("pgv-cancel-split-button");
 if (cancelSplitButton) {
+  let isPauseResumeMenuOpen = false;
+
   const pauseResumeMenuOpenObserver = new MutationObserver(() => {
     const pauseMenuItem = document.getElementById("pgv-pause");
     const resumeMenuItem = document.getElementById("pgv-resume");
-    if (pauseMenuItem || resumeMenuItem) {
+    const menuItemsExist = pauseMenuItem || resumeMenuItem;
+
+    if (menuItemsExist && !isPauseResumeMenuOpen) {
+      isPauseResumeMenuOpen = true;
       setTimeout(() => updatePauseElements(false), 0);
+    }
+    else if (!menuItemsExist && isPauseResumeMenuOpen) {
+      isPauseResumeMenuOpen = false;
     }
   });
 

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -226,21 +226,30 @@ function updatePauseElements(enablePolling = false) {
 
 const cancelSplitButton = document.getElementById("pgv-cancel-split-button");
 if (cancelSplitButton) {
-  // Create an observer to update the pause/resume menu items when they become visible
-  new MutationObserver((mutationsList, observer) => {
-    for (const mutation of mutationsList) {
-      if (mutation.type === "childList") {
-        const pauseMenuItem = document.getElementById("pgv-pause");
-        const resumeMenuItem = document.getElementById("pgv-resume");
-        if (pauseMenuItem || resumeMenuItem) {
-          updatePauseElements(false);
-        }
-      }
+  const pauseResumeMenuOpenObserver = new MutationObserver(() => {
+    const pauseMenuItem = document.getElementById("pgv-pause");
+    const resumeMenuItem = document.getElementById("pgv-resume");
+    if (pauseMenuItem || resumeMenuItem) {
+      setTimeout(() => updatePauseElements(false), 0);
     }
-  }).observe(cancelSplitButton, {
+  });
+
+  pauseResumeMenuOpenObserver.observe(cancelSplitButton, {
     childList: true,
     subtree: true,
   });
+
+  const cancelButtonHiddenObserver = new MutationObserver(() => {
+    if (!cancelSplitButton || cancelSplitButton.style.display === "none") {
+      pauseResumeMenuOpenObserver.disconnect();
+      cancelButtonHiddenObserver.disconnect();
+    }
+  });
+
+  cancelButtonHiddenObserver.observe(cancelSplitButton, {
+    attributes: true,
+    attributeFilter: ["style"],
+  });
 }
 
-updatePauseElements(true);
+setTimeout(() => updatePauseElements(true), 0);

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -230,8 +230,7 @@ if (cancelSplitButton) {
     if (menuItemsExist && !isPauseResumeMenuOpen) {
       isPauseResumeMenuOpen = true;
       setTimeout(() => updatePauseElements(false), 0);
-    }
-    else if (!menuItemsExist && isPauseResumeMenuOpen) {
+    } else if (!menuItemsExist && isPauseResumeMenuOpen) {
       isPauseResumeMenuOpen = false;
     }
   });

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -213,8 +213,12 @@ function updatePauseElements(enablePolling = false) {
           }
         } else {
           pausedBanner.style.display = "none";
-          pauseMenuItem.style.display = "none";
-          resumeMenuItem.style.display = "none";
+          if (pauseMenuItem) {
+            pauseMenuItem.style.display = "none";
+          }
+          if (resumeMenuItem) {
+            resumeMenuItem.style.display = "none";
+          }
         }
       }
       return null;

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -213,7 +213,7 @@ function updatePauseElements() {
           if (pauseMenuItem || resumeMenuItem) {
             updateInterval = 1000;
           }
-          setTimeout(updatePauseElements(), updateInterval);
+          setTimeout(updatePauseElements, updateInterval);
         } else {
           pausedBanner.style.display = "none";
           pauseMenuItem.style.display = "none";


### PR DESCRIPTION
Fixes #1356

Correct bug where `updatePauseElements()` was called and the return value was being passed to `setTimeout` instead of passing a reference to `updatePauseElements` to be used as a callback.

Add a `MutationObserver` to update the visible pause/resume menu item when the overflow menu is opened. This addresses a delay in updating the pause state which could cause the wrong button to be shown. Additional changes to manage the life cycle of the new `MutationObserver` which is disconnected as soon as the parent cancel split button is hidden (when the build stops building).

Additional minor fix to prevent the pause/resume button from swapping to its counterpart as soon as it's clicked.

### Testing done

Local testing to confirm the issue and verify the fix.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
