### PR TITLE
Fix alignment of pipeline graph container in multi-pipeline-graph view

### DIFF
--- a/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/styles/main.scss
+++ b/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/styles/main.scss
@@ -5,7 +5,7 @@
 .PWGx-PipelineGraph-container {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   overflow-x: auto;
   margin-bottom: 0px;
 


### PR DESCRIPTION
Fixes #1359.

The `.PWGx-PipelineGraph-container` was using `align-items: center` which centered all flex children horizontally.

Using `align-items: flex-start` instead allowed the pipeline graphs to be left aligned.

<img width="1069" height="826" alt="image" src="https://github.com/user-attachments/assets/a97e2a15-95d4-48b6-9413-663631ba459c" />

### Testing done

Verified fix manually.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
