### PR TITLE
Only fetch pause state on the pipeline overview page

### DIFF
--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -253,4 +253,7 @@ if (cancelSplitButton) {
   });
 }
 
-setTimeout(() => updatePauseElements(true), 0);
+const isPipelineOverview = document.getElementById("console-pipeline-root") !== null;
+if (isPipelineOverview) {
+  setTimeout(() => updatePauseElements(true), 0);
+}

--- a/src/main/webapp/js/build.js
+++ b/src/main/webapp/js/build.js
@@ -253,7 +253,8 @@ if (cancelSplitButton) {
   });
 }
 
-const isPipelineOverview = document.getElementById("console-pipeline-root") !== null;
+const isPipelineOverview =
+  document.getElementById("console-pipeline-root") !== null;
 if (isPipelineOverview) {
   setTimeout(() => updatePauseElements(true), 0);
 }


### PR DESCRIPTION
Fixes #1361.

Check for the `console-pipeline-root` element to determine if currently on the pipeline overview page. Only start the call to `updatePauseElements` when on the pipeline overview page.

### Testing done
Manually verified the fix.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
