### PR TITLE
Refine graph spacing and adjust graph height

### DIFF
--- a/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/SingleRun.tsx
+++ b/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/SingleRun.tsx
@@ -61,8 +61,6 @@ export default function SingleRun({
       // Do not reserve space for small label.
       layout.nodeSpacingV -= layout.labelOffsetV + 15;
     }
-    // Do not reserve space for big label on next row.
-    layout.nodeSpacingV -= layout.labelOffsetV;
 
     return layout;
   }

--- a/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/SingleRun.tsx
+++ b/src/main/frontend/multi-pipeline-graph-view/multi-pipeline-graph/main/SingleRun.tsx
@@ -1,6 +1,6 @@
 import "./single-run.scss";
 
-import { useContext } from "react";
+import { useContext, useMemo } from "react";
 
 import StatusIcon from "../../../common/components/status-icon.tsx";
 import {
@@ -44,8 +44,10 @@ export default function SingleRun({
 
   const { showNames, showDurations } = useUserPreferences();
 
-  function getLayout() {
-    const layout: LayoutInfo = { ...defaultLayout };
+  const layout: LayoutInfo = useMemo(() => {
+    const layout: LayoutInfo = {
+      ...defaultLayout,
+    };
 
     if (!showNames && !showDurations) {
       layout.nodeSpacingH = 45;
@@ -63,7 +65,7 @@ export default function SingleRun({
     }
 
     return layout;
-  }
+  }, [showDurations, showNames]);
 
   const { effectiveStages, collapsedStageIds, toggleCollapseStage } =
     useCollapsedStages(normalizedParentJobPath, runInfo.stages);
@@ -82,7 +84,7 @@ export default function SingleRun({
       </div>
       <PipelineGraph
         stages={effectiveStages}
-        layout={getLayout()}
+        layout={layout}
         collapsed
         collapsedStageIds={collapsedStageIds}
         onToggleCollapse={toggleCollapseStage}

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -39,7 +39,12 @@ export default function PipelineConsole() {
   const previousRunPath = rootElement?.dataset.previousRunPath;
   const normalizedParentJobPath = rootElement?.dataset.normalizedParentJobPath!;
 
-  const { stageViewPosition, mainViewVisibility } = useLayoutPreferences();
+  const {
+    stageViewPosition,
+    mainViewVisibility,
+    setAutoStageViewHeight,
+    setDefaultStageViewHeight,
+  } = useLayoutPreferences();
   const {
     complete,
     tailLogs,
@@ -131,6 +136,8 @@ export default function PipelineConsole() {
                 stageViewPosition={stageViewPosition}
                 onStageSelect={handleStageSelect}
                 normalizedParentJobPath={normalizedParentJobPath}
+                setAutoStageViewHeight={setAutoStageViewHeight}
+                setDefaultStageViewHeight={setDefaultStageViewHeight}
               />
             ))}
 

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/PipelineConsole.tsx
@@ -10,7 +10,10 @@ import {
   SETTINGS,
 } from "../../../common/components/symbols.tsx";
 import { useUserPermissions } from "../../../common/user/user-permission-provider.tsx";
-import { Result } from "../../../pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx";
+import {
+  LayoutInfo,
+  Result,
+} from "../../../pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx";
 import Skeleton from "./components/skeleton.tsx";
 import Stages from "./components/stages.tsx";
 import StagesCustomization from "./components/stages-customization.tsx";
@@ -22,6 +25,13 @@ import ScrollToTopBottom from "./scroll-to-top-bottom.tsx";
 import SplitView from "./split-view.tsx";
 import StageDetails from "./stage-details.tsx";
 import StageView from "./StageView.tsx";
+
+const stagesLayout: Partial<LayoutInfo> = {
+  graphSpacingTop: 34, // spacing for expand button
+  graphSpacingRight: 18, // spacing for expand button
+  graphSpacingBottom: 18, // spacing for zoom buttons
+  graphSpacingLeft: 18, // align with right spacing
+};
 
 export default function PipelineConsole() {
   const rootElement = document.getElementById("console-pipeline-root");
@@ -115,6 +125,7 @@ export default function PipelineConsole() {
               <Skeleton />
             ) : (
               <Stages
+                layout={stagesLayout}
                 stages={stages}
                 selectedStage={openStage || undefined}
                 stageViewPosition={stageViewPosition}

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
@@ -17,7 +17,10 @@ import {
 } from "../../../../common/i18n/index.ts";
 import { classNames } from "../../../../common/utils/classnames.ts";
 import { PipelineGraph } from "../../../../pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx";
-import { StageInfo } from "../../../../pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx";
+import {
+  LayoutInfo,
+  StageInfo,
+} from "../../../../pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx";
 import { useCollapsedStages } from "../../../../pipeline-graph-view/pipeline-graph/main/support/useCollapsedStages.ts";
 import { StageViewPosition } from "../providers/user-preference-provider.tsx";
 
@@ -32,6 +35,7 @@ interface GraphTransform {
 }
 
 export default function Stages({
+  layout,
   stages,
   selectedStage,
   stageViewPosition,
@@ -146,6 +150,7 @@ export default function Stages({
 
         <TransformComponent wrapperStyle={{ width: "100%", height: "100%" }}>
           <PipelineGraph
+            layout={layout}
             stages={effectiveStages}
             selectedStage={selectedStage}
             collapsedStageIds={collapsedStageIds}
@@ -162,6 +167,7 @@ export default function Stages({
 }
 
 interface StagesProps {
+  layout: Partial<LayoutInfo>;
   stages: StageInfo[];
   selectedStage?: StageInfo;
   stageViewPosition: StageViewPosition;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/components/stages.tsx
@@ -1,6 +1,12 @@
 import "./stages.scss";
 
-import { useCallback, useContext, useState } from "react";
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
 import {
   ReactZoomPanPinchContextState,
   TransformComponent,
@@ -42,6 +48,8 @@ export default function Stages({
   onStageSelect,
   onRunPage,
   normalizedParentJobPath,
+  setAutoStageViewHeight,
+  setDefaultStageViewHeight,
 }: StagesProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -62,6 +70,7 @@ export default function Stages({
     [onStageSelect],
   );
 
+  const [centerGraph, setCenterGraph] = useState(true);
   const [initialScale, setInitialScale] = useState(1);
   const [minScale, setMinScale] = useState(0.75);
   const [defaultTransform, setDefaultTransform] = useState<GraphTransform>({
@@ -146,6 +155,7 @@ export default function Stages({
           hasCollapsibleStages={hasCollapsibleStages}
           onCollapseAll={collapseAll}
           onExpandAll={expandAll}
+          setCenterGraph={setCenterGraph}
         />
 
         <TransformComponent wrapperStyle={{ width: "100%", height: "100%" }}>
@@ -158,6 +168,10 @@ export default function Stages({
             setInitialScale={setInitialScale}
             setMinScale={setMinScale}
             setDefaultTransform={setDefaultTransform}
+            setAutoStageViewHeight={setAutoStageViewHeight}
+            setDefaultStageViewHeight={setDefaultStageViewHeight}
+            centerGraph={centerGraph}
+            setCenterGraph={setCenterGraph}
             {...(onStageSelect && { onStageSelect: handleStageSelect })}
           />
         </TransformComponent>
@@ -174,6 +188,8 @@ interface StagesProps {
   onStageSelect?: (nodeId: string) => void;
   onRunPage?: boolean;
   normalizedParentJobPath: string;
+  setAutoStageViewHeight: Dispatch<SetStateAction<number>>;
+  setDefaultStageViewHeight: Dispatch<SetStateAction<number>>;
 }
 
 interface ZoomControlsProps {
@@ -183,6 +199,7 @@ interface ZoomControlsProps {
   hasCollapsibleStages: boolean;
   onCollapseAll: () => void;
   onExpandAll: () => void;
+  setCenterGraph: Dispatch<SetStateAction<boolean>>;
 }
 
 function ZoomControls({
@@ -192,8 +209,9 @@ function ZoomControls({
   hasCollapsibleStages,
   onCollapseAll,
   onExpandAll,
+  setCenterGraph,
 }: ZoomControlsProps) {
-  const { zoomIn, zoomOut, setTransform } = useControls();
+  const { zoomIn, zoomOut } = useControls();
   const messages = useContext(I18NContext);
   const [transform, setTransformState] = useState(defaultTransform);
   const handleTransformEffect = useCallback(
@@ -254,13 +272,7 @@ function ZoomControls({
       <Tooltip content={"Reset"}>
         <button
           className={"jenkins-button jenkins-button--tertiary"}
-          onClick={() =>
-            setTransform(
-              defaultTransform.positionX,
-              defaultTransform.positionY,
-              defaultTransform.scale,
-            )
-          }
+          onClick={() => setCenterGraph(true)}
           disabled={isAtDefaultTransform}
         >
           <svg className="ionicon" viewBox="0 0 512 512">

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/providers/user-preference-provider.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/providers/user-preference-provider.tsx
@@ -1,6 +1,8 @@
 import {
   createContext,
+  Dispatch,
   ReactNode,
+  SetStateAction,
   useContext,
   useEffect,
   useState,
@@ -25,11 +27,14 @@ interface LayoutPreferences {
   treeViewWidth: number;
   stageViewWidth: number;
   stageViewHeight: number;
+  defaultStageViewHeight: number;
+  setDefaultStageViewHeight: Dispatch<SetStateAction<number>>;
   setStageViewPosition: (position: StageViewPosition) => void;
   setMainViewVisibility: (visibility: MainViewVisibility) => void;
-  setTreeViewWidth: (width: number) => void;
-  setStageViewWidth: (width: number) => void;
-  setStageViewHeight: (height: number) => void;
+  setTreeViewWidth: Dispatch<SetStateAction<number>>;
+  setStageViewWidth: Dispatch<SetStateAction<number>>;
+  setPersistedStageViewHeight: Dispatch<SetStateAction<number>>;
+  setAutoStageViewHeight: Dispatch<SetStateAction<number>>;
   /**
    * Returns true if the current window width is less than the mobile breakpoint.
    * Used for disabling customization options in favor of a mobile-friendly layout.
@@ -58,13 +63,14 @@ const loadFromLocalStorage = <T,>(
   key: string,
   normalizedParentJobPath: string,
   fallback: T,
+  useOldKey: boolean = true,
 ): T => {
   if (typeof window === "undefined") return fallback;
   try {
     let value = window.localStorage.getItem(
       `${key}/${normalizedParentJobPath}`,
     );
-    if (value === null) {
+    if (value === null && useOldKey) {
       // Fallback to previous shared key, which also serves as local default form the last job that updated it.
       value = window.localStorage.getItem(key);
     }
@@ -91,6 +97,17 @@ const storeInLocalStorage = (
     window.localStorage.setItem(key, value);
   } catch (e) {
     console.error(`Error storing localStorage key "${key}"`, e);
+  }
+};
+
+const removeFromLocalStorage = (
+  key: string,
+  normalizedParentJobPath: string,
+) => {
+  try {
+    window.localStorage.removeItem(`${key}/${normalizedParentJobPath}`);
+  } catch (e) {
+    console.error(`Error removing localStorage key "${key}"`, e);
   }
 };
 
@@ -125,15 +142,27 @@ export const LayoutPreferencesProvider = ({
       ),
     );
 
-  const [treeViewWidth, setTreeViewWidthState] = useState<number>(
+  const [treeViewWidth, setTreeViewWidth] = useState<number>(
     loadFromLocalStorage(LS_KEYS.treeViewWidth, normalizedParentJobPath, 300),
   );
-  const [stageViewWidth, setStageViewWidthState] = useState<number>(
+  const [stageViewWidth, setStageViewWidth] = useState<number>(
     loadFromLocalStorage(LS_KEYS.stageViewWidth, normalizedParentJobPath, 600),
   );
-  const [stageViewHeight, setStageViewHeightState] = useState<number>(
-    loadFromLocalStorage(LS_KEYS.stageViewHeight, normalizedParentJobPath, 250),
-  );
+  const [persistedStageViewHeight, setPersistedStageViewHeight] =
+    useState<number>(
+      loadFromLocalStorage(
+        LS_KEYS.stageViewHeight,
+        normalizedParentJobPath,
+        0,
+        // Default to auto stage height instead of using old keys.
+        false,
+      ),
+    );
+  const [autoStageViewHeight, setAutoStageViewHeight] = useState(0);
+  const [defaultStageViewHeight, setDefaultStageViewHeight] =
+    useState<number>(250);
+  const stageViewHeight =
+    persistedStageViewHeight || autoStageViewHeight || defaultStageViewHeight;
 
   // Handle responsive override
   const isMobile = windowWidth < MOBILE_BREAKPOINT;
@@ -182,12 +211,17 @@ export const LayoutPreferencesProvider = ({
   }, [stageViewWidth, normalizedParentJobPath]);
 
   useEffect(() => {
+    if (persistedStageViewHeight === 0) {
+      // Backwards compatibility: Do not store 0. We default to 0 when loading, so this is fine.
+      removeFromLocalStorage(LS_KEYS.stageViewHeight, normalizedParentJobPath);
+      return;
+    }
     storeInLocalStorage(
       LS_KEYS.stageViewHeight,
       normalizedParentJobPath,
-      stageViewHeight.toString(),
+      persistedStageViewHeight.toString(),
     );
-  }, [stageViewHeight, normalizedParentJobPath]);
+  }, [persistedStageViewHeight, normalizedParentJobPath]);
 
   // Update window width on resize
   useEffect(() => {
@@ -200,10 +234,6 @@ export const LayoutPreferencesProvider = ({
     setStageViewPositionState(position);
   const setMainViewVisibility = (visibility: MainViewVisibility) =>
     setMainViewVisibilityState(visibility);
-  const setTreeViewWidth = (width: number) => setTreeViewWidthState(width);
-  const setStageViewWidth = (width: number) => setStageViewWidthState(width);
-  const setStageViewHeight = (height: number) =>
-    setStageViewHeightState(height);
 
   return (
     <LayoutPreferencesContext.Provider
@@ -213,11 +243,14 @@ export const LayoutPreferencesProvider = ({
         treeViewWidth,
         stageViewWidth,
         stageViewHeight,
+        defaultStageViewHeight,
+        setDefaultStageViewHeight,
         setStageViewPosition,
         setMainViewVisibility,
         setTreeViewWidth,
         setStageViewWidth,
-        setStageViewHeight,
+        setAutoStageViewHeight,
+        setPersistedStageViewHeight,
         isMobile,
       }}
     >

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/split-view.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/split-view.tsx
@@ -10,13 +10,15 @@ import {
 } from "react";
 
 import { classNames } from "../../../common/utils/classnames.ts";
+import { defaultLayout } from "../../../pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx";
 import { useLayoutPreferences } from "./providers/user-preference-provider.tsx";
 
 export default function SplitView(props: SplitViewNewProps) {
   const {
     setTreeViewWidth,
     setStageViewWidth,
-    setStageViewHeight,
+    setPersistedStageViewHeight,
+    defaultStageViewHeight,
     treeViewWidth,
     stageViewWidth,
     stageViewHeight,
@@ -55,9 +57,17 @@ export default function SplitView(props: SplitViewNewProps) {
         ? e.clientY - getContainerOffset()
         : e.clientX - getContainerOffset();
 
+    const maxZoom = 3;
     const clampedSize = Math.max(
-      direction === "vertical" ? 100 : 200,
-      Math.min(newSize, 1500),
+      direction === "vertical"
+        ? Math.min(defaultStageViewHeight, defaultLayout.nodeSpacingH)
+        : 200,
+      Math.min(
+        newSize,
+        storageKey === "graph" && direction === "vertical"
+          ? defaultStageViewHeight * maxZoom
+          : 1500,
+      ),
     );
 
     // Update context sizes
@@ -65,7 +75,7 @@ export default function SplitView(props: SplitViewNewProps) {
       setTreeViewWidth(clampedSize);
     } else if (storageKey === "graph") {
       if (direction === "vertical") {
-        setStageViewHeight(clampedSize);
+        setPersistedStageViewHeight(clampedSize);
       } else {
         setStageViewWidth(clampedSize);
       }
@@ -77,7 +87,7 @@ export default function SplitView(props: SplitViewNewProps) {
       setTreeViewWidth(300);
     } else if (storageKey === "graph") {
       if (direction === "vertical") {
-        setStageViewHeight(250);
+        setPersistedStageViewHeight(0);
       } else {
         setStageViewWidth(600);
       }

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/split-view.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/split-view.tsx
@@ -25,29 +25,17 @@ export default function SplitView(props: SplitViewNewProps) {
   const { direction = "horizontal", storageKey } = props;
   const [isDragging, setIsDragging] = useState(false);
 
-  const isVertical = direction === "vertical";
-
-  const initialSize = (() => {
+  const panelSize = (() => {
     if (storageKey === "stages") return treeViewWidth;
     if (storageKey === "graph") {
-      return isVertical ? stageViewHeight : stageViewWidth;
+      if (direction === "vertical") {
+        return stageViewHeight;
+      } else {
+        return stageViewWidth;
+      }
     }
     return 300; // fallback
   })();
-
-  useEffect(() => {
-    const newSize = (() => {
-      if (storageKey === "stages") return treeViewWidth;
-      if (storageKey === "graph") {
-        return direction === "vertical" ? stageViewHeight : stageViewWidth;
-      }
-      return 300;
-    })();
-
-    setPanelSize(newSize);
-  }, [direction, treeViewWidth, stageViewWidth, stageViewHeight, storageKey]);
-
-  const [panelSize, setPanelSize] = useState<number>(initialSize);
 
   const dividerRef = useRef<HTMLDivElement>(null);
 
@@ -71,7 +59,6 @@ export default function SplitView(props: SplitViewNewProps) {
       direction === "vertical" ? 100 : 200,
       Math.min(newSize, 1500),
     );
-    setPanelSize(clampedSize);
 
     // Update context sizes
     if (storageKey === "stages") {
@@ -86,21 +73,13 @@ export default function SplitView(props: SplitViewNewProps) {
   };
 
   const handleDoubleClick = () => {
-    const resetSize = (() => {
-      if (storageKey === "stages") return 300;
-      if (storageKey === "graph") return isVertical ? 250 : 600;
-      return 300;
-    })();
-
-    setPanelSize(resetSize);
-
     if (storageKey === "stages") {
-      setTreeViewWidth(resetSize);
+      setTreeViewWidth(300);
     } else if (storageKey === "graph") {
       if (direction === "vertical") {
-        setStageViewHeight(resetSize);
+        setStageViewHeight(250);
       } else {
-        setStageViewWidth(resetSize);
+        setStageViewWidth(600);
       }
     }
   };

--- a/src/main/frontend/pipeline-graph-view/app.tsx
+++ b/src/main/frontend/pipeline-graph-view/app.tsx
@@ -2,6 +2,8 @@ import "./app.scss";
 import "./pipeline-graph/styles/main.scss";
 import "../pipeline-console-view/pipeline-console/main/console-log-card.scss";
 
+import { useState } from "react";
+
 import useRunPoller from "../common/tree-api.ts";
 import { UserPreferencesProvider } from "../common/user/user-preferences-provider.tsx";
 import Stages from "../pipeline-console-view/pipeline-console/main/components/stages.tsx";
@@ -28,6 +30,10 @@ export default function App() {
     currentRunPath,
     previousRunPath,
   });
+
+  const [autoStageViewHeight, setAutoStageViewHeight] = useState(0);
+  const [defaultStageViewHeight, setDefaultStageViewHeight] = useState(0);
+  const height = autoStageViewHeight || defaultStageViewHeight;
 
   const onlyQueuedPlaceholder =
     run.stages.length === 1 &&
@@ -77,13 +83,17 @@ export default function App() {
       )}
 
       {run.stages.length > 0 && !onlyQueuedPlaceholder && (
-        <Stages
-          layout={buildLayout}
-          stages={run.stages}
-          stageViewPosition={StageViewPosition.TOP}
-          onRunPage
-          normalizedParentJobPath={normalizedParentJobPath}
-        />
+        <div style={height ? { height } : {}}>
+          <Stages
+            layout={buildLayout}
+            stages={run.stages}
+            stageViewPosition={StageViewPosition.TOP}
+            onRunPage
+            normalizedParentJobPath={normalizedParentJobPath}
+            setAutoStageViewHeight={setAutoStageViewHeight}
+            setDefaultStageViewHeight={setDefaultStageViewHeight}
+          />
+        </div>
       )}
     </UserPreferencesProvider>
   );

--- a/src/main/frontend/pipeline-graph-view/app.tsx
+++ b/src/main/frontend/pipeline-graph-view/app.tsx
@@ -7,7 +7,17 @@ import { UserPreferencesProvider } from "../common/user/user-preferences-provide
 import Stages from "../pipeline-console-view/pipeline-console/main/components/stages.tsx";
 import { NoStageStepsFallback } from "../pipeline-console-view/pipeline-console/main/NoStageStepsFallback.tsx";
 import { StageViewPosition } from "../pipeline-console-view/pipeline-console/main/providers/user-preference-provider.tsx";
-import { Result } from "./pipeline-graph/main/PipelineGraphModel.tsx";
+import {
+  LayoutInfo,
+  Result,
+} from "./pipeline-graph/main/PipelineGraphModel.tsx";
+
+const buildLayout: Partial<LayoutInfo> = {
+  graphSpacingTop: 3 + 1 + 32, // spacing for "Stages" button (top+border+a)
+  graphSpacingRight: 18, // spacing for expand button
+  graphSpacingBottom: 18, // spacing for zoom buttons
+  graphSpacingLeft: 18, // align with right spacing
+};
 
 export default function App() {
   const rootElement = document.getElementById("graph");
@@ -68,6 +78,7 @@ export default function App() {
 
       {run.stages.length > 0 && !onlyQueuedPlaceholder && (
         <Stages
+          layout={buildLayout}
           stages={run.stages}
           stageViewPosition={StageViewPosition.TOP}
           onRunPage

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/NestedPipelineGraphLayout.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/NestedPipelineGraphLayout.ts
@@ -253,6 +253,7 @@ function buildGraphNested(
       firstChildIsSkipped,
     };
     buildGraphNested(childNode, stage.children, layout, isLast);
+    if (isParallel && idx > 0) childNode.shiftY += layout.labelOffsetV;
     if (hasBigLabel) childNode.shiftY += layout.labelOffsetV;
     childNode.allChildrenSkipped =
       childNode.hasParallel && !childNode.children.some((c) => !c.isSkipped);
@@ -521,7 +522,7 @@ function baseGraphNode(layout: LayoutInfo, hasBigLabel?: boolean) {
     shiftX: 0,
     shiftY: 0,
     width: layout.nodeSpacingH,
-    height: layout.nodeSpacingV,
+    height: layout.nodeSpacingV - layout.labelOffsetV,
     ...(hasBigLabel ? { shiftY: layout.labelOffsetV, hasBigLabel: true } : {}),
   };
 }

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/NestedPipelineGraphLayout.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/NestedPipelineGraphLayout.ts
@@ -69,7 +69,7 @@ export function nestedGraphLayout(
     key: "end-node",
     id: -3,
   });
-  root.y = root.shiftY + layout.nodeRadius + 4;
+  root.y = root.shiftY + layout.nodeRadius;
   root.width =
     root.shiftX + sumGraphNodeProp(root, "width") - startEndReducedSpacing;
   const measuredWidth = root.width;

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/NestedPipelineGraphLayout.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/NestedPipelineGraphLayout.ts
@@ -72,8 +72,10 @@ export function nestedGraphLayout(
   root.y = root.shiftY + layout.nodeRadius;
   root.width =
     root.shiftX + sumGraphNodeProp(root, "width") - startEndReducedSpacing;
-  const measuredWidth = root.width;
-  const measuredHeight = root.y + root.height;
+  root.x += layout.graphSpacingLeft;
+  root.y += layout.graphSpacingTop;
+  const measuredWidth = root.x + root.width + layout.graphSpacingRight;
+  const measuredHeight = root.y + root.height + layout.graphSpacingBottom;
 
   computePositions(root, 0, layout);
   const connections = computeConnections(root);

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
@@ -1,5 +1,7 @@
 import {
   CSSProperties,
+  Dispatch,
+  SetStateAction,
   useCallback,
   useContext,
   useEffect,
@@ -56,6 +58,10 @@ export function PipelineGraph({
   setMinScale,
   setInitialScale,
   setDefaultTransform,
+  setAutoStageViewHeight,
+  setDefaultStageViewHeight,
+  centerGraph,
+  setCenterGraph,
 }: Props) {
   const fullLayout = useMemo(() => {
     return {
@@ -179,7 +185,6 @@ export function PipelineGraph({
     return () => observer.disconnect();
   }, [transform?.wrapperComponent]);
 
-  const [fitToWidth, setFitToWidth] = useState(true);
   useEffect(() => {
     if (!setMinScale || !setInitialScale || !transform) return;
     const { width: transformWidth, height: transformHeight } =
@@ -211,8 +216,14 @@ export function PipelineGraph({
       positionX: centerOffsetX,
       positionY: centerOffsetY,
     });
-    if (fitToWidth) {
+    setDefaultStageViewHeight?.(measuredHeight);
+    if (centerGraph) {
       // Don't scale too small by default.
+      const autoHeight = Math.max(
+        Math.min(measuredHeight, fullLayout.nodeSpacingH),
+        measuredHeight * autoScale,
+      );
+      setAutoStageViewHeight?.(autoHeight);
       if (
         transform.state.scale !== autoScale ||
         transform.state.positionX !== centerOffsetX ||
@@ -220,17 +231,24 @@ export function PipelineGraph({
       ) {
         transform.setState(autoScale, centerOffsetX, centerOffsetY);
       }
-      return transform.onChange(() => setFitToWidth(false));
+      return transform.onChange(() => {
+        setCenterGraph?.(false);
+        setAutoStageViewHeight?.(0);
+      });
     }
   }, [
     transform,
     transformViewport,
-    fitToWidth,
+    centerGraph,
+    setCenterGraph,
+    fullLayout.nodeSpacingH,
     measuredWidth,
     measuredHeight,
     setMinScale,
     setInitialScale,
     setDefaultTransform,
+    setAutoStageViewHeight,
+    setDefaultStageViewHeight,
   ]);
 
   // When inside a TransformWrapper, only mount the nodes/labels intersecting
@@ -441,4 +459,8 @@ interface Props {
     positionX: number;
     positionY: number;
   }) => void;
+  setAutoStageViewHeight?: Dispatch<SetStateAction<number>>;
+  setDefaultStageViewHeight?: Dispatch<SetStateAction<number>>;
+  centerGraph?: boolean;
+  setCenterGraph?: Dispatch<SetStateAction<boolean>>;
 }

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
@@ -79,10 +79,14 @@ export function PipelineGraph({
     const apply = (width: number) => {
       if (width <= 0) return;
       const reservedSpace =
-        fullLayout.nodeSpacingH / 2 + // before start
+        // before start
+        fullLayout.graphSpacingLeft +
+        fullLayout.nodeSpacingH / 2 +
         fullLayout.nodeSpacingH * 0.7 + // start node with reduced spacing
         -fullLayout.nodeSpacingH * 0.3 + // reduced spacing to end node
-        fullLayout.nodeSpacingH / 2; // after end;
+        // after end
+        fullLayout.nodeSpacingH / 2 +
+        fullLayout.graphSpacingRight;
       const next = Math.max(
         MIN_COLUMNS_WHEN_COLLAPSED,
         Math.floor((width - reservedSpace) / fullLayout.nodeSpacingH),
@@ -99,7 +103,12 @@ export function PipelineGraph({
     });
     observer.observe(node);
     return () => observer.disconnect();
-  }, [collapsed, fullLayout.nodeSpacingH]);
+  }, [
+    collapsed,
+    fullLayout.graphSpacingLeft,
+    fullLayout.graphSpacingRight,
+    fullLayout.nodeSpacingH,
+  ]);
 
   const {
     nodes,
@@ -328,6 +337,7 @@ export function PipelineGraph({
   const outerDivStyle: CSSProperties = {
     position: "relative",
     overflow: "visible",
+    boxSizing: "unset",
   };
   if (debugPipelineGraph()) {
     outerDivStyle.border = "1px dashed red";

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraph.tsx
@@ -42,7 +42,6 @@ interface Viewport {
 }
 
 const VIEWPORT_MARGIN = 300;
-const GRAPH_PADDING = 20;
 
 const MIN_COLUMNS_WHEN_COLLAPSED = 5;
 
@@ -185,18 +184,16 @@ export function PipelineGraph({
       return;
     }
 
-    const paddedMeasuredWidth = measuredWidth + GRAPH_PADDING * 2;
-    const paddedMeasuredHeight = measuredHeight + GRAPH_PADDING * 2;
-    const initialScale = Math.min(1, transformWidth / paddedMeasuredWidth);
+    const initialScale = Math.min(1, transformWidth / measuredWidth);
     const minScale = initialScale * 0.75;
     const autoScale = Math.max(initialScale, 0.5);
     const centerOffsetX = Math.max(
       0,
-      (transformWidth - paddedMeasuredWidth * autoScale) / 2,
+      (transformWidth - measuredWidth * autoScale) / 2,
     );
     const centerOffsetY = Math.max(
       0,
-      (transformHeight - paddedMeasuredHeight * autoScale) / 2,
+      (transformHeight - measuredHeight * autoScale) / 2,
     );
     setMinScale(minScale);
     setInitialScale(initialScale);
@@ -331,7 +328,6 @@ export function PipelineGraph({
   const outerDivStyle: CSSProperties = {
     position: "relative",
     overflow: "visible",
-    margin: GRAPH_PADDING,
   };
   if (debugPipelineGraph()) {
     outerDivStyle.border = "1px dashed red";

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.spec.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphLayout.spec.ts
@@ -365,6 +365,10 @@ describe("PipelineGraphLayout", () => {
       labelOffsetV: 22,
       smallLabelOffsetV: 15,
       ypStart: 55,
+      graphSpacingTop: 0,
+      graphSpacingRight: 0,
+      graphSpacingBottom: 0,
+      graphSpacingLeft: 0,
     };
 
     const makeSmallLabel = (stageName: string) => {

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
@@ -16,7 +16,7 @@ export const defaultLayout = {
   nodeSpacingH: 140,
   parallelSpacingH: 140,
   nodeSpacingV: 70,
-  nodeRadius: 12,
+  nodeRadius: 14,
   terminalRadius: 10,
   curveRadius: 15,
   connectorStrokeWidth: 2,

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
@@ -23,6 +23,10 @@ export const defaultLayout = {
   labelOffsetV: 22,
   smallLabelOffsetV: 15,
   ypStart: 55,
+  graphSpacingTop: 0,
+  graphSpacingRight: 0,
+  graphSpacingBottom: 0,
+  graphSpacingLeft: 0,
 };
 
 // Typedefs

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/__snapshots__/NestedPipelineGraphLayout.spec.ts.snap
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/__snapshots__/NestedPipelineGraphLayout.spec.ts.snap
@@ -17,7 +17,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -39,7 +39,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -61,7 +61,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -83,7 +83,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -105,7 +105,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -127,7 +127,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -149,7 +149,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "stage",
           "width": 140,
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -163,7 +163,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "end",
           "width": 35,
           "x": 931,
-          "y": 16,
+          "y": 14,
         },
       ],
       "height": 48,
@@ -177,7 +177,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "root",
       "width": 966,
       "x": 0,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -191,7 +191,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -213,7 +213,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -235,7 +235,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -257,7 +257,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -279,7 +279,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -301,7 +301,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -323,7 +323,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -337,7 +337,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "end",
       "width": 35,
       "x": 931,
-      "y": 16,
+      "y": 14,
     },
   ],
   "bigLabels": [],
@@ -348,7 +348,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_6",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -358,7 +358,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -367,7 +367,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_16",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -376,7 +376,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_6",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -385,7 +385,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_17",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -394,7 +394,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_16",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -403,7 +403,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_26",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -412,7 +412,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_17",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -421,7 +421,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_42",
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -430,7 +430,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_26",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -439,7 +439,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_54",
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -448,7 +448,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_42",
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -458,7 +458,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "isPlaceholder": true,
           "key": "end-node",
           "x": 931,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -467,12 +467,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_54",
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
   ],
-  "measuredHeight": 64,
+  "measuredHeight": 62,
   "measuredWidth": 966,
   "nodes": [
     {
@@ -487,7 +487,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -509,7 +509,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -531,7 +531,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -553,7 +553,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -575,7 +575,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -597,7 +597,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -619,7 +619,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -633,7 +633,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "end",
       "width": 35,
       "x": 931,
-      "y": 16,
+      "y": 14,
     },
   ],
   "smallLabels": [],
@@ -652,7 +652,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       },
       "text": "",
       "x": 133,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_16",
@@ -668,7 +668,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       },
       "text": "",
       "x": 273,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_17",
@@ -684,7 +684,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       },
       "text": "",
       "x": 413,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_26",
@@ -700,7 +700,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       },
       "text": "",
       "x": 553,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_42",
@@ -716,7 +716,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       },
       "text": "",
       "x": 693,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_54",
@@ -732,7 +732,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       },
       "text": "",
       "x": 833,
-      "y": 71,
+      "y": 69,
     },
   ],
 }
@@ -756,7 +756,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -778,7 +778,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [
@@ -803,7 +803,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 38,
+              "y": 36,
             },
             {
               "children": [],
@@ -826,7 +826,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 108,
+              "y": 106,
             },
             {
               "children": [
@@ -850,7 +850,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
                   "type": "stage",
                   "width": 140,
                   "x": 413,
-                  "y": 178,
+                  "y": 176,
                 },
                 {
                   "children": [],
@@ -872,7 +872,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
                   "type": "stage",
                   "width": 140,
                   "x": 553,
-                  "y": 178,
+                  "y": 176,
                 },
               ],
               "hasBranchLabel": true,
@@ -895,7 +895,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
               "type": "stage",
               "width": 280,
               "x": 413,
-              "y": 178,
+              "y": 176,
             },
           ],
           "hasBigLabel": true,
@@ -918,7 +918,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "stage",
           "width": 420,
           "x": 273,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -941,7 +941,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -956,7 +956,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "end",
           "width": 35,
           "x": 791,
-          "y": 38,
+          "y": 36,
         },
       ],
       "height": 188,
@@ -970,7 +970,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "root",
       "width": 826,
       "x": 0,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -985,7 +985,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -1007,7 +1007,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [
@@ -1032,7 +1032,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -1055,7 +1055,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 108,
+          "y": 106,
         },
         {
           "children": [
@@ -1079,7 +1079,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 178,
+              "y": 176,
             },
             {
               "children": [],
@@ -1101,7 +1101,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 178,
+              "y": 176,
             },
           ],
           "hasBranchLabel": true,
@@ -1124,7 +1124,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "stage",
           "width": 280,
           "x": 413,
-          "y": 178,
+          "y": 176,
         },
       ],
       "hasBigLabel": true,
@@ -1147,7 +1147,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 420,
       "x": 273,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -1170,7 +1170,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -1193,7 +1193,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 108,
+      "y": 106,
     },
     {
       "children": [
@@ -1217,7 +1217,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 178,
+          "y": 176,
         },
         {
           "children": [],
@@ -1239,7 +1239,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 178,
+          "y": 176,
         },
       ],
       "hasBranchLabel": true,
@@ -1262,7 +1262,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 280,
       "x": 413,
-      "y": 178,
+      "y": 176,
     },
     {
       "children": [],
@@ -1284,7 +1284,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 178,
+      "y": 176,
     },
     {
       "children": [],
@@ -1306,7 +1306,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 178,
+      "y": 176,
     },
     {
       "children": [],
@@ -1329,7 +1329,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -1344,7 +1344,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "end",
       "width": 35,
       "x": 791,
-      "y": 38,
+      "y": 36,
     },
   ],
   "bigLabels": [
@@ -1356,7 +1356,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "stage": undefined,
       "text": "Start",
       "x": 35,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_12",
@@ -1372,7 +1372,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       },
       "text": "Parallel Stage",
       "x": 413,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_54",
@@ -1388,7 +1388,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       },
       "text": "Skipped stage",
       "x": 693,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_end-node",
@@ -1398,7 +1398,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "stage": undefined,
       "text": "End",
       "x": 791,
-      "y": 38,
+      "y": 36,
     },
   ],
   "branchLabels": [
@@ -1416,7 +1416,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       },
       "text": "Branch C",
       "x": 273,
-      "y": 178,
+      "y": 176,
     },
   ],
   "connections": [
@@ -1425,7 +1425,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_6",
           "x": 133,
-          "y": 38,
+          "y": 36,
         },
       ],
       "hasBranchLabels": false,
@@ -1435,7 +1435,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 38,
+          "y": 36,
         },
       ],
     },
@@ -1444,18 +1444,18 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_16",
           "x": 413,
-          "y": 38,
+          "y": 36,
         },
         {
           "key": "n_17",
           "x": 413,
-          "y": 108,
+          "y": 106,
         },
         {
           "isHidden": true,
           "key": "n_18",
           "x": 413,
-          "y": 178,
+          "y": 176,
         },
       ],
       "hasBranchLabels": true,
@@ -1464,7 +1464,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_6",
           "x": 133,
-          "y": 38,
+          "y": 36,
         },
       ],
     },
@@ -1473,7 +1473,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_26",
           "x": 413,
-          "y": 178,
+          "y": 176,
         },
       ],
       "hasBranchLabels": false,
@@ -1483,7 +1483,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "isHidden": true,
           "key": "n_18",
           "x": 413,
-          "y": 178,
+          "y": 176,
         },
       ],
     },
@@ -1492,7 +1492,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_42",
           "x": 553,
-          "y": 178,
+          "y": 176,
         },
       ],
       "hasBranchLabels": false,
@@ -1501,7 +1501,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "key": "n_26",
           "x": 413,
-          "y": 178,
+          "y": 176,
         },
       ],
     },
@@ -1511,7 +1511,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "isPlaceholder": true,
           "key": "end-node",
           "x": 791,
-          "y": 38,
+          "y": 36,
         },
       ],
       "hasBranchLabels": false,
@@ -1520,29 +1520,29 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "isSkipped": true,
           "key": "n_54",
           "x": 693,
-          "y": 38,
+          "y": 36,
         },
       ],
       "sourceNodes": [
         {
           "key": "n_16",
           "x": 413,
-          "y": 38,
+          "y": 36,
         },
         {
           "key": "n_17",
           "x": 413,
-          "y": 108,
+          "y": 106,
         },
         {
           "key": "n_42",
           "x": 553,
-          "y": 178,
+          "y": 176,
         },
       ],
     },
   ],
-  "measuredHeight": 226,
+  "measuredHeight": 224,
   "measuredWidth": 826,
   "nodes": [
     {
@@ -1558,7 +1558,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -1580,7 +1580,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -1603,7 +1603,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -1626,7 +1626,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 108,
+      "y": 106,
     },
     {
       "children": [],
@@ -1648,7 +1648,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 178,
+      "y": 176,
     },
     {
       "children": [],
@@ -1670,7 +1670,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 178,
+      "y": 176,
     },
     {
       "children": [],
@@ -1693,7 +1693,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -1708,7 +1708,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "type": "end",
       "width": 35,
       "x": 791,
-      "y": 38,
+      "y": 36,
     },
   ],
   "smallLabels": [
@@ -1726,7 +1726,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       },
       "text": "Non-Parallel Stage",
       "x": 133,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_small_n_16",
@@ -1742,7 +1742,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       },
       "text": "Branch A",
       "x": 413,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_small_n_17",
@@ -1758,7 +1758,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       },
       "text": "Branch B",
       "x": 413,
-      "y": 108,
+      "y": 106,
     },
     {
       "key": "l_small_n_26",
@@ -1774,7 +1774,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       },
       "text": "Nested 1",
       "x": 413,
-      "y": 178,
+      "y": 176,
     },
     {
       "key": "l_small_n_42",
@@ -1790,7 +1790,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       },
       "text": "Nested 2",
       "x": 553,
-      "y": 178,
+      "y": 176,
     },
   ],
   "timings": [],
@@ -1814,7 +1814,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -1836,7 +1836,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -1858,7 +1858,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -1880,7 +1880,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -1902,7 +1902,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -1924,7 +1924,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -1946,7 +1946,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -1968,7 +1968,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 973,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -1982,7 +1982,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "end",
           "width": 35,
           "x": 1071,
-          "y": 16,
+          "y": 14,
         },
       ],
       "height": 48,
@@ -1996,7 +1996,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "root",
       "width": 1106,
       "x": 0,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2010,7 +2010,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2032,7 +2032,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2054,7 +2054,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2076,7 +2076,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2098,7 +2098,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2120,7 +2120,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2142,7 +2142,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2164,7 +2164,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 973,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2178,7 +2178,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "end",
       "width": 35,
       "x": 1071,
-      "y": 16,
+      "y": 14,
     },
   ],
   "bigLabels": [],
@@ -2189,7 +2189,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_6",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -2199,7 +2199,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -2208,7 +2208,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_9",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -2217,7 +2217,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_6",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -2226,7 +2226,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_10",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -2235,7 +2235,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_9",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -2244,7 +2244,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_18",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -2253,7 +2253,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_10",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -2262,7 +2262,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_19",
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -2271,7 +2271,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_18",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -2280,7 +2280,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_31",
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -2289,7 +2289,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_19",
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -2298,7 +2298,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_32",
           "x": 973,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -2307,7 +2307,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_31",
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -2317,7 +2317,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "isPlaceholder": true,
           "key": "end-node",
           "x": 1071,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -2326,12 +2326,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_32",
           "x": 973,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
   ],
-  "measuredHeight": 64,
+  "measuredHeight": 62,
   "measuredWidth": 1106,
   "nodes": [
     {
@@ -2346,7 +2346,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2368,7 +2368,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2390,7 +2390,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2412,7 +2412,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2434,7 +2434,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2456,7 +2456,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2478,7 +2478,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2500,7 +2500,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 973,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -2514,7 +2514,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "end",
       "width": 35,
       "x": 1071,
-      "y": 16,
+      "y": 14,
     },
   ],
   "smallLabels": [],
@@ -2533,7 +2533,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "",
       "x": 133,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_9",
@@ -2549,7 +2549,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "",
       "x": 273,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_10",
@@ -2565,7 +2565,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "",
       "x": 413,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_18",
@@ -2581,7 +2581,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "",
       "x": 553,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_19",
@@ -2597,7 +2597,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "",
       "x": 693,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_31",
@@ -2613,7 +2613,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "",
       "x": 833,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_32",
@@ -2629,7 +2629,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "",
       "x": 973,
-      "y": 71,
+      "y": 69,
     },
   ],
 }
@@ -2653,7 +2653,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [
@@ -2680,7 +2680,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
                   "type": "stage",
                   "width": 140,
                   "x": 133,
-                  "y": 60,
+                  "y": 58,
                 },
                 {
                   "children": [],
@@ -2703,7 +2703,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
                   "type": "stage",
                   "width": 140,
                   "x": 133,
-                  "y": 130,
+                  "y": 128,
                 },
               ],
               "hasBigLabel": true,
@@ -2726,7 +2726,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
               "type": "stage",
               "width": 140,
               "x": 133,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [
@@ -2751,7 +2751,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
                   "type": "stage",
                   "width": 140,
                   "x": 273,
-                  "y": 60,
+                  "y": 58,
                 },
                 {
                   "children": [],
@@ -2774,7 +2774,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
                   "type": "stage",
                   "width": 140,
                   "x": 273,
-                  "y": 130,
+                  "y": 128,
                 },
               ],
               "hasBigLabel": true,
@@ -2797,7 +2797,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
               "type": "stage",
               "width": 140,
               "x": 273,
-              "y": 60,
+              "y": 58,
             },
           ],
           "hasBigLabel": true,
@@ -2819,7 +2819,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 280,
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [
@@ -2844,7 +2844,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [],
@@ -2867,7 +2867,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 130,
+              "y": 128,
             },
           ],
           "hasBigLabel": true,
@@ -2890,7 +2890,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -2905,7 +2905,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "end",
           "width": 35,
           "x": 511,
-          "y": 60,
+          "y": 58,
         },
       ],
       "height": 118,
@@ -2919,7 +2919,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "root",
       "width": 546,
       "x": 0,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -2934,7 +2934,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [
@@ -2961,7 +2961,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
               "type": "stage",
               "width": 140,
               "x": 133,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [],
@@ -2984,7 +2984,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
               "type": "stage",
               "width": 140,
               "x": 133,
-              "y": 130,
+              "y": 128,
             },
           ],
           "hasBigLabel": true,
@@ -3007,7 +3007,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [
@@ -3032,7 +3032,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
               "type": "stage",
               "width": 140,
               "x": 273,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [],
@@ -3055,7 +3055,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
               "type": "stage",
               "width": 140,
               "x": 273,
-              "y": 130,
+              "y": 128,
             },
           ],
           "hasBigLabel": true,
@@ -3078,7 +3078,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBigLabel": true,
@@ -3100,7 +3100,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 280,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [
@@ -3125,7 +3125,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -3148,7 +3148,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 130,
+          "y": 128,
         },
       ],
       "hasBigLabel": true,
@@ -3171,7 +3171,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -3194,7 +3194,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -3217,7 +3217,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 130,
+      "y": 128,
     },
     {
       "children": [
@@ -3242,7 +3242,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -3265,7 +3265,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 130,
+          "y": 128,
         },
       ],
       "hasBigLabel": true,
@@ -3288,7 +3288,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -3311,7 +3311,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -3334,7 +3334,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 130,
+      "y": 128,
     },
     {
       "children": [
@@ -3359,7 +3359,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -3382,7 +3382,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 130,
+          "y": 128,
         },
       ],
       "hasBigLabel": true,
@@ -3405,7 +3405,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -3428,7 +3428,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -3451,7 +3451,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 130,
+      "y": 128,
     },
     {
       "children": [],
@@ -3466,7 +3466,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "end",
       "width": 35,
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "bigLabels": [
@@ -3478,7 +3478,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "stage": undefined,
       "text": "Start",
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_n_6",
@@ -3494,7 +3494,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "1",
       "x": 203,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_7",
@@ -3510,7 +3510,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "Parallel",
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_n_16",
@@ -3526,7 +3526,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "Parallel",
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_n_28",
@@ -3542,7 +3542,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "2",
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_end-node",
@@ -3552,7 +3552,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "stage": undefined,
       "text": "End",
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "branchLabels": [],
@@ -3562,12 +3562,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_9",
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "key": "n_10",
           "x": 133,
-          "y": 130,
+          "y": 128,
         },
       ],
       "hasBranchLabels": false,
@@ -3577,7 +3577,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
@@ -3586,12 +3586,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_18",
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
         {
           "key": "n_19",
           "x": 273,
-          "y": 130,
+          "y": 128,
         },
       ],
       "hasBranchLabels": false,
@@ -3600,12 +3600,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_9",
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "key": "n_10",
           "x": 133,
-          "y": 130,
+          "y": 128,
         },
       ],
     },
@@ -3614,12 +3614,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_31",
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
         {
           "key": "n_32",
           "x": 413,
-          "y": 130,
+          "y": 128,
         },
       ],
       "hasBranchLabels": false,
@@ -3628,12 +3628,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_18",
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
         {
           "key": "n_19",
           "x": 273,
-          "y": 130,
+          "y": 128,
         },
       ],
     },
@@ -3643,7 +3643,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "isPlaceholder": true,
           "key": "end-node",
           "x": 511,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -3652,17 +3652,17 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "key": "n_31",
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
         {
           "key": "n_32",
           "x": 413,
-          "y": 130,
+          "y": 128,
         },
       ],
     },
   ],
-  "measuredHeight": 178,
+  "measuredHeight": 176,
   "measuredWidth": 546,
   "nodes": [
     {
@@ -3678,7 +3678,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -3701,7 +3701,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -3724,7 +3724,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 130,
+      "y": 128,
     },
     {
       "children": [],
@@ -3747,7 +3747,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -3770,7 +3770,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 130,
+      "y": 128,
     },
     {
       "children": [],
@@ -3793,7 +3793,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -3816,7 +3816,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 130,
+      "y": 128,
     },
     {
       "children": [],
@@ -3831,7 +3831,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "type": "end",
       "width": 35,
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "smallLabels": [
@@ -3849,7 +3849,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "branch 1.1",
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_small_n_10",
@@ -3865,7 +3865,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "branch 1.2",
       "x": 133,
-      "y": 130,
+      "y": 128,
     },
     {
       "key": "l_small_n_18",
@@ -3881,7 +3881,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "branch 2.1",
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_small_n_19",
@@ -3897,7 +3897,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "branch 2.2",
       "x": 273,
-      "y": 130,
+      "y": 128,
     },
     {
       "key": "l_small_n_31",
@@ -3913,7 +3913,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "branch 3.1",
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_small_n_32",
@@ -3929,7 +3929,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       },
       "text": "branch 3.2",
       "x": 413,
-      "y": 130,
+      "y": 128,
     },
   ],
   "timings": [],
@@ -3953,7 +3953,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -3975,7 +3975,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -3997,7 +3997,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -4019,7 +4019,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -4041,7 +4041,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -4063,7 +4063,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -4085,7 +4085,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -4107,7 +4107,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 973,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -4129,7 +4129,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 1113,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -4151,7 +4151,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 1253,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -4173,7 +4173,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 1393,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -4195,7 +4195,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 1533,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -4217,7 +4217,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 1673,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -4282,7 +4282,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "counter",
           "width": 140,
           "x": 1813,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -4296,7 +4296,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "end",
           "width": 35,
           "x": 1911,
-          "y": 16,
+          "y": 14,
         },
       ],
       "height": 48,
@@ -4310,7 +4310,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "root",
       "width": 1946,
       "x": 0,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4324,7 +4324,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4346,7 +4346,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4368,7 +4368,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4390,7 +4390,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4412,7 +4412,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4434,7 +4434,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4456,7 +4456,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4478,7 +4478,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 973,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4500,7 +4500,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1113,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4522,7 +4522,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1253,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4544,7 +4544,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1393,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4566,7 +4566,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1533,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4588,7 +4588,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1673,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4653,7 +4653,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "counter",
       "width": 140,
       "x": 1813,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4667,7 +4667,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "end",
       "width": 35,
       "x": 1911,
-      "y": 16,
+      "y": 14,
     },
   ],
   "bigLabels": [],
@@ -4678,7 +4678,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_6",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -4688,7 +4688,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -4697,7 +4697,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_17",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -4706,7 +4706,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_6",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -4715,7 +4715,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_18",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -4724,7 +4724,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_17",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -4733,7 +4733,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_35",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -4742,7 +4742,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_18",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -4751,7 +4751,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_60",
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -4760,7 +4760,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_35",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -4769,7 +4769,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_76",
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -4778,7 +4778,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_60",
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -4787,7 +4787,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_84",
           "x": 973,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -4796,7 +4796,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_76",
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -4805,7 +4805,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_37",
           "x": 1113,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -4814,7 +4814,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_84",
           "x": 973,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -4823,7 +4823,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_55",
           "x": 1253,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -4832,7 +4832,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_37",
           "x": 1113,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -4841,7 +4841,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_39",
           "x": 1393,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -4850,7 +4850,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_55",
           "x": 1253,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -4859,7 +4859,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_57",
           "x": 1533,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -4868,7 +4868,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_39",
           "x": 1393,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -4877,7 +4877,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_71",
           "x": 1673,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -4886,7 +4886,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_57",
           "x": 1533,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -4896,7 +4896,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isPlaceholder": true,
           "key": "counter-node",
           "x": 1813,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -4905,7 +4905,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_71",
           "x": 1673,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -4915,7 +4915,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isPlaceholder": true,
           "key": "end-node",
           "x": 1911,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -4925,12 +4925,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isPlaceholder": true,
           "key": "counter-node",
           "x": 1813,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
   ],
-  "measuredHeight": 64,
+  "measuredHeight": 62,
   "measuredWidth": 1946,
   "nodes": [
     {
@@ -4945,7 +4945,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4967,7 +4967,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -4989,7 +4989,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -5011,7 +5011,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -5033,7 +5033,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -5055,7 +5055,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -5077,7 +5077,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -5099,7 +5099,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 973,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -5121,7 +5121,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1113,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -5143,7 +5143,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1253,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -5165,7 +5165,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1393,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -5187,7 +5187,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1533,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -5209,7 +5209,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1673,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -5274,7 +5274,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "counter",
       "width": 140,
       "x": 1813,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -5288,7 +5288,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "end",
       "width": 35,
       "x": 1911,
-      "y": 16,
+      "y": 14,
     },
   ],
   "smallLabels": [],
@@ -5307,7 +5307,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "",
       "x": 133,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_17",
@@ -5323,7 +5323,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "",
       "x": 273,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_18",
@@ -5339,7 +5339,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "",
       "x": 413,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_35",
@@ -5355,7 +5355,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "",
       "x": 553,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_60",
@@ -5371,7 +5371,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "",
       "x": 693,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_76",
@@ -5387,7 +5387,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "",
       "x": 833,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_84",
@@ -5403,7 +5403,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "",
       "x": 973,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_37",
@@ -5419,7 +5419,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "",
       "x": 1113,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_55",
@@ -5435,7 +5435,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "",
       "x": 1253,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_39",
@@ -5451,7 +5451,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "",
       "x": 1393,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_57",
@@ -5467,7 +5467,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "",
       "x": 1533,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_71",
@@ -5483,7 +5483,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "",
       "x": 1673,
-      "y": 71,
+      "y": 69,
     },
   ],
 }
@@ -5507,7 +5507,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -5529,7 +5529,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [
@@ -5554,7 +5554,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 38,
+              "y": 36,
             },
             {
               "children": [],
@@ -5578,7 +5578,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 108,
+              "y": 106,
             },
             {
               "children": [
@@ -5602,7 +5602,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                   "type": "stage",
                   "width": 140,
                   "x": 413,
-                  "y": 200,
+                  "y": 198,
                 },
                 {
                   "children": [],
@@ -5624,7 +5624,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                   "type": "stage",
                   "width": 140,
                   "x": 553,
-                  "y": 200,
+                  "y": 198,
                 },
                 {
                   "children": [],
@@ -5647,7 +5647,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                   "type": "stage",
                   "width": 140,
                   "x": 693,
-                  "y": 200,
+                  "y": 198,
                 },
                 {
                   "children": [],
@@ -5670,7 +5670,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                   "type": "stage",
                   "width": 140,
                   "x": 833,
-                  "y": 200,
+                  "y": 198,
                 },
                 {
                   "children": [],
@@ -5685,7 +5685,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                   "type": "stage-end",
                   "width": 140,
                   "x": 903,
-                  "y": 200,
+                  "y": 198,
                 },
               ],
               "hasBranchLabel": true,
@@ -5709,7 +5709,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 630,
               "x": 413,
-              "y": 200,
+              "y": 198,
             },
             {
               "children": [
@@ -5734,7 +5734,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                   "type": "stage",
                   "width": 140,
                   "x": 553,
-                  "y": 292,
+                  "y": 290,
                 },
                 {
                   "children": [],
@@ -5756,7 +5756,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                   "type": "stage",
                   "width": 140,
                   "x": 693,
-                  "y": 292,
+                  "y": 290,
                 },
               ],
               "firstChildIsSkipped": true,
@@ -5780,7 +5780,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 280,
               "x": 413,
-              "y": 292,
+              "y": 290,
             },
             {
               "children": [
@@ -5805,7 +5805,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                   "type": "stage",
                   "width": 140,
                   "x": 413,
-                  "y": 384,
+                  "y": 382,
                 },
                 {
                   "children": [],
@@ -5827,7 +5827,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                   "type": "stage",
                   "width": 140,
                   "x": 553,
-                  "y": 384,
+                  "y": 382,
                 },
                 {
                   "children": [],
@@ -5849,7 +5849,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                   "type": "stage",
                   "width": 140,
                   "x": 693,
-                  "y": 384,
+                  "y": 382,
                 },
                 {
                   "children": [],
@@ -5871,7 +5871,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                   "type": "stage",
                   "width": 140,
                   "x": 833,
-                  "y": 384,
+                  "y": 382,
                 },
               ],
               "firstChildIsSkipped": true,
@@ -5895,7 +5895,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 560,
               "x": 413,
-              "y": 384,
+              "y": 382,
             },
           ],
           "hasBigLabel": true,
@@ -5918,7 +5918,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 770,
           "x": 273,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -5941,7 +5941,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 1043,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -5964,7 +5964,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 1183,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [
@@ -5990,7 +5990,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 1463,
-              "y": 38,
+              "y": 36,
             },
             {
               "children": [],
@@ -6013,7 +6013,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 1463,
-              "y": 108,
+              "y": 106,
             },
             {
               "children": [
@@ -6037,7 +6037,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                   "type": "stage",
                   "width": 140,
                   "x": 1463,
-                  "y": 178,
+                  "y": 176,
                 },
                 {
                   "children": [],
@@ -6059,7 +6059,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                   "type": "stage",
                   "width": 140,
                   "x": 1603,
-                  "y": 178,
+                  "y": 176,
                 },
               ],
               "hasBranchLabel": true,
@@ -6082,7 +6082,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 280,
               "x": 1463,
-              "y": 178,
+              "y": 176,
             },
           ],
           "firstChildIsSkipped": true,
@@ -6106,7 +6106,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 420,
           "x": 1323,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -6121,7 +6121,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "end",
           "width": 35,
           "x": 1701,
-          "y": 38,
+          "y": 36,
         },
       ],
       "height": 394,
@@ -6135,7 +6135,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "root",
       "width": 1736,
       "x": 0,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -6150,7 +6150,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -6172,7 +6172,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [
@@ -6197,7 +6197,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -6221,7 +6221,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 108,
+          "y": 106,
         },
         {
           "children": [
@@ -6245,7 +6245,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 200,
+              "y": 198,
             },
             {
               "children": [],
@@ -6267,7 +6267,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 200,
+              "y": 198,
             },
             {
               "children": [],
@@ -6290,7 +6290,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 693,
-              "y": 200,
+              "y": 198,
             },
             {
               "children": [],
@@ -6313,7 +6313,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 833,
-              "y": 200,
+              "y": 198,
             },
             {
               "children": [],
@@ -6328,7 +6328,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage-end",
               "width": 140,
               "x": 903,
-              "y": 200,
+              "y": 198,
             },
           ],
           "hasBranchLabel": true,
@@ -6352,7 +6352,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 630,
           "x": 413,
-          "y": 200,
+          "y": 198,
         },
         {
           "children": [
@@ -6377,7 +6377,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 292,
+              "y": 290,
             },
             {
               "children": [],
@@ -6399,7 +6399,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 693,
-              "y": 292,
+              "y": 290,
             },
           ],
           "firstChildIsSkipped": true,
@@ -6423,7 +6423,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 280,
           "x": 413,
-          "y": 292,
+          "y": 290,
         },
         {
           "children": [
@@ -6448,7 +6448,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 384,
+              "y": 382,
             },
             {
               "children": [],
@@ -6470,7 +6470,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 384,
+              "y": 382,
             },
             {
               "children": [],
@@ -6492,7 +6492,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 693,
-              "y": 384,
+              "y": 382,
             },
             {
               "children": [],
@@ -6514,7 +6514,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 833,
-              "y": 384,
+              "y": 382,
             },
           ],
           "firstChildIsSkipped": true,
@@ -6538,7 +6538,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 560,
           "x": 413,
-          "y": 384,
+          "y": 382,
         },
       ],
       "hasBigLabel": true,
@@ -6561,7 +6561,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 770,
       "x": 273,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -6584,7 +6584,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -6608,7 +6608,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 108,
+      "y": 106,
     },
     {
       "children": [
@@ -6632,7 +6632,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 200,
+          "y": 198,
         },
         {
           "children": [],
@@ -6654,7 +6654,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 200,
+          "y": 198,
         },
         {
           "children": [],
@@ -6677,7 +6677,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 200,
+          "y": 198,
         },
         {
           "children": [],
@@ -6700,7 +6700,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 833,
-          "y": 200,
+          "y": 198,
         },
         {
           "children": [],
@@ -6715,7 +6715,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage-end",
           "width": 140,
           "x": 903,
-          "y": 200,
+          "y": 198,
         },
       ],
       "hasBranchLabel": true,
@@ -6739,7 +6739,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 630,
       "x": 413,
-      "y": 200,
+      "y": 198,
     },
     {
       "children": [],
@@ -6761,7 +6761,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 200,
+      "y": 198,
     },
     {
       "children": [],
@@ -6783,7 +6783,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 200,
+      "y": 198,
     },
     {
       "children": [],
@@ -6806,7 +6806,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 200,
+      "y": 198,
     },
     {
       "children": [],
@@ -6829,7 +6829,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 200,
+      "y": 198,
     },
     {
       "children": [],
@@ -6844,7 +6844,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage-end",
       "width": 140,
       "x": 903,
-      "y": 200,
+      "y": 198,
     },
     {
       "children": [
@@ -6869,7 +6869,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 292,
+          "y": 290,
         },
         {
           "children": [],
@@ -6891,7 +6891,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 292,
+          "y": 290,
         },
       ],
       "firstChildIsSkipped": true,
@@ -6915,7 +6915,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 280,
       "x": 413,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [],
@@ -6938,7 +6938,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [],
@@ -6960,7 +6960,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [
@@ -6985,7 +6985,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 384,
+          "y": 382,
         },
         {
           "children": [],
@@ -7007,7 +7007,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 384,
+          "y": 382,
         },
         {
           "children": [],
@@ -7029,7 +7029,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 384,
+          "y": 382,
         },
         {
           "children": [],
@@ -7051,7 +7051,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 833,
-          "y": 384,
+          "y": 382,
         },
       ],
       "firstChildIsSkipped": true,
@@ -7075,7 +7075,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 560,
       "x": 413,
-      "y": 384,
+      "y": 382,
     },
     {
       "children": [],
@@ -7098,7 +7098,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 384,
+      "y": 382,
     },
     {
       "children": [],
@@ -7120,7 +7120,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 384,
+      "y": 382,
     },
     {
       "children": [],
@@ -7142,7 +7142,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 384,
+      "y": 382,
     },
     {
       "children": [],
@@ -7164,7 +7164,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 384,
+      "y": 382,
     },
     {
       "children": [],
@@ -7187,7 +7187,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1043,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -7210,7 +7210,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1183,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [
@@ -7236,7 +7236,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 1463,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -7259,7 +7259,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 1463,
-          "y": 108,
+          "y": 106,
         },
         {
           "children": [
@@ -7283,7 +7283,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 1463,
-              "y": 178,
+              "y": 176,
             },
             {
               "children": [],
@@ -7305,7 +7305,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "type": "stage",
               "width": 140,
               "x": 1603,
-              "y": 178,
+              "y": 176,
             },
           ],
           "hasBranchLabel": true,
@@ -7328,7 +7328,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 280,
           "x": 1463,
-          "y": 178,
+          "y": 176,
         },
       ],
       "firstChildIsSkipped": true,
@@ -7352,7 +7352,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 420,
       "x": 1323,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -7376,7 +7376,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1463,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -7399,7 +7399,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1463,
-      "y": 108,
+      "y": 106,
     },
     {
       "children": [
@@ -7423,7 +7423,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 1463,
-          "y": 178,
+          "y": 176,
         },
         {
           "children": [],
@@ -7445,7 +7445,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "type": "stage",
           "width": 140,
           "x": 1603,
-          "y": 178,
+          "y": 176,
         },
       ],
       "hasBranchLabel": true,
@@ -7468,7 +7468,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 280,
       "x": 1463,
-      "y": 178,
+      "y": 176,
     },
     {
       "children": [],
@@ -7490,7 +7490,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1463,
-      "y": 178,
+      "y": 176,
     },
     {
       "children": [],
@@ -7512,7 +7512,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1603,
-      "y": 178,
+      "y": 176,
     },
     {
       "children": [],
@@ -7527,7 +7527,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "end",
       "width": 35,
       "x": 1701,
-      "y": 38,
+      "y": 36,
     },
   ],
   "bigLabels": [
@@ -7539,7 +7539,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "stage": undefined,
       "text": "Start",
       "x": 35,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_11",
@@ -7555,7 +7555,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Parallel Stage",
       "x": 623,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_76",
@@ -7571,7 +7571,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Skipped stage c nested 3",
       "x": 693,
-      "y": 200,
+      "y": 198,
     },
     {
       "key": "l_big_n_84",
@@ -7587,7 +7587,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Skipped stage c nested 4",
       "x": 833,
-      "y": 200,
+      "y": 198,
     },
     {
       "key": "l_big_n_37",
@@ -7603,7 +7603,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Skipped stage d nested 1",
       "x": 553,
-      "y": 292,
+      "y": 290,
     },
     {
       "key": "l_big_n_39",
@@ -7619,7 +7619,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Skipped stage e nested 1",
       "x": 413,
-      "y": 384,
+      "y": 382,
     },
     {
       "key": "l_big_n_103",
@@ -7635,7 +7635,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Skipped stage 1",
       "x": 1043,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_118",
@@ -7651,7 +7651,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Skipped stage 2",
       "x": 1183,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_133",
@@ -7667,7 +7667,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Parallel Stage 2",
       "x": 1463,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_end-node",
@@ -7677,7 +7677,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "stage": undefined,
       "text": "End",
       "x": 1701,
-      "y": 38,
+      "y": 36,
     },
   ],
   "branchLabels": [
@@ -7695,7 +7695,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Branch C",
       "x": 273,
-      "y": 200,
+      "y": 198,
     },
     {
       "key": "l_branch_n_20",
@@ -7711,7 +7711,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Branch D",
       "x": 273,
-      "y": 292,
+      "y": 290,
     },
     {
       "key": "l_branch_n_21",
@@ -7727,7 +7727,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Branch E",
       "x": 273,
-      "y": 384,
+      "y": 382,
     },
     {
       "key": "l_branch_n_139",
@@ -7743,7 +7743,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Branch C",
       "x": 1323,
-      "y": 178,
+      "y": 176,
     },
   ],
   "connections": [
@@ -7752,7 +7752,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_6",
           "x": 133,
-          "y": 38,
+          "y": 36,
         },
       ],
       "hasBranchLabels": false,
@@ -7762,7 +7762,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 38,
+          "y": 36,
         },
       ],
     },
@@ -7771,33 +7771,33 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_17",
           "x": 553,
-          "y": 38,
+          "y": 36,
         },
         {
           "isSkipped": true,
           "key": "n_18",
           "x": 553,
-          "y": 108,
+          "y": 106,
         },
         {
           "isHidden": true,
           "key": "n_19",
           "x": 413,
-          "y": 200,
+          "y": 198,
         },
         {
           "firstChildIsSkipped": true,
           "isHidden": true,
           "key": "n_20",
           "x": 413,
-          "y": 292,
+          "y": 290,
         },
         {
           "firstChildIsSkipped": true,
           "isHidden": true,
           "key": "n_21",
           "x": 413,
-          "y": 384,
+          "y": 382,
         },
       ],
       "hasBranchLabels": true,
@@ -7806,7 +7806,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_6",
           "x": 133,
-          "y": 38,
+          "y": 36,
         },
       ],
     },
@@ -7815,7 +7815,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_35",
           "x": 413,
-          "y": 200,
+          "y": 198,
         },
       ],
       "hasBranchLabels": false,
@@ -7825,7 +7825,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isHidden": true,
           "key": "n_19",
           "x": 413,
-          "y": 200,
+          "y": 198,
         },
       ],
     },
@@ -7834,7 +7834,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_60",
           "x": 553,
-          "y": 200,
+          "y": 198,
         },
       ],
       "hasBranchLabels": false,
@@ -7843,7 +7843,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_35",
           "x": 413,
-          "y": 200,
+          "y": 198,
         },
       ],
     },
@@ -7854,7 +7854,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isPlaceholder": true,
           "key": "stage_end_n_19",
           "x": 903,
-          "y": 200,
+          "y": 198,
         },
       ],
       "hasBranchLabels": false,
@@ -7863,20 +7863,20 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isSkipped": true,
           "key": "n_76",
           "x": 693,
-          "y": 200,
+          "y": 198,
         },
         {
           "isSkipped": true,
           "key": "n_84",
           "x": 833,
-          "y": 200,
+          "y": 198,
         },
       ],
       "sourceNodes": [
         {
           "key": "n_60",
           "x": 553,
-          "y": 200,
+          "y": 198,
         },
       ],
     },
@@ -7885,7 +7885,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_55",
           "x": 693,
-          "y": 292,
+          "y": 290,
         },
       ],
       "hasBranchLabels": false,
@@ -7894,7 +7894,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isSkipped": true,
           "key": "n_37",
           "x": 553,
-          "y": 292,
+          "y": 290,
         },
       ],
       "sourceNodes": [
@@ -7903,7 +7903,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isHidden": true,
           "key": "n_20",
           "x": 413,
-          "y": 292,
+          "y": 290,
         },
       ],
     },
@@ -7912,7 +7912,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_57",
           "x": 553,
-          "y": 384,
+          "y": 382,
         },
       ],
       "hasBranchLabels": false,
@@ -7921,7 +7921,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isSkipped": true,
           "key": "n_39",
           "x": 413,
-          "y": 384,
+          "y": 382,
         },
       ],
       "sourceNodes": [
@@ -7930,7 +7930,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isHidden": true,
           "key": "n_21",
           "x": 413,
-          "y": 384,
+          "y": 382,
         },
       ],
     },
@@ -7939,7 +7939,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_71",
           "x": 693,
-          "y": 384,
+          "y": 382,
         },
       ],
       "hasBranchLabels": false,
@@ -7948,7 +7948,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_57",
           "x": 553,
-          "y": 384,
+          "y": 382,
         },
       ],
     },
@@ -7957,7 +7957,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_86",
           "x": 833,
-          "y": 384,
+          "y": 382,
         },
       ],
       "hasBranchLabels": false,
@@ -7966,7 +7966,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_71",
           "x": 693,
-          "y": 384,
+          "y": 382,
         },
       ],
     },
@@ -7976,18 +7976,18 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isSkipped": true,
           "key": "n_137",
           "x": 1463,
-          "y": 38,
+          "y": 36,
         },
         {
           "key": "n_138",
           "x": 1463,
-          "y": 108,
+          "y": 106,
         },
         {
           "isHidden": true,
           "key": "n_139",
           "x": 1463,
-          "y": 178,
+          "y": 176,
         },
       ],
       "hasBranchLabels": true,
@@ -7996,43 +7996,43 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isSkipped": true,
           "key": "n_103",
           "x": 1043,
-          "y": 38,
+          "y": 36,
         },
         {
           "isSkipped": true,
           "key": "n_118",
           "x": 1183,
-          "y": 38,
+          "y": 36,
         },
       ],
       "sourceNodes": [
         {
           "key": "n_17",
           "x": 553,
-          "y": 38,
+          "y": 36,
         },
         {
           "isSkipped": true,
           "key": "n_18",
           "x": 553,
-          "y": 108,
+          "y": 106,
         },
         {
           "isHidden": true,
           "isPlaceholder": true,
           "key": "stage_end_n_19",
           "x": 903,
-          "y": 200,
+          "y": 198,
         },
         {
           "key": "n_55",
           "x": 693,
-          "y": 292,
+          "y": 290,
         },
         {
           "key": "n_86",
           "x": 833,
-          "y": 384,
+          "y": 382,
         },
       ],
     },
@@ -8041,7 +8041,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_149",
           "x": 1463,
-          "y": 178,
+          "y": 176,
         },
       ],
       "hasBranchLabels": false,
@@ -8051,7 +8051,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isHidden": true,
           "key": "n_139",
           "x": 1463,
-          "y": 178,
+          "y": 176,
         },
       ],
     },
@@ -8060,7 +8060,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_160",
           "x": 1603,
-          "y": 178,
+          "y": 176,
         },
       ],
       "hasBranchLabels": false,
@@ -8069,7 +8069,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "key": "n_149",
           "x": 1463,
-          "y": 178,
+          "y": 176,
         },
       ],
     },
@@ -8079,7 +8079,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isPlaceholder": true,
           "key": "end-node",
           "x": 1701,
-          "y": 38,
+          "y": 36,
         },
       ],
       "hasBranchLabels": false,
@@ -8089,22 +8089,22 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "isSkipped": true,
           "key": "n_137",
           "x": 1463,
-          "y": 38,
+          "y": 36,
         },
         {
           "key": "n_138",
           "x": 1463,
-          "y": 108,
+          "y": 106,
         },
         {
           "key": "n_160",
           "x": 1603,
-          "y": 178,
+          "y": 176,
         },
       ],
     },
   ],
-  "measuredHeight": 432,
+  "measuredHeight": 430,
   "measuredWidth": 1736,
   "nodes": [
     {
@@ -8120,7 +8120,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -8142,7 +8142,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -8165,7 +8165,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -8189,7 +8189,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 108,
+      "y": 106,
     },
     {
       "children": [],
@@ -8211,7 +8211,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 200,
+      "y": 198,
     },
     {
       "children": [],
@@ -8233,7 +8233,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 200,
+      "y": 198,
     },
     {
       "children": [],
@@ -8256,7 +8256,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 200,
+      "y": 198,
     },
     {
       "children": [],
@@ -8279,7 +8279,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 200,
+      "y": 198,
     },
     {
       "children": [],
@@ -8302,7 +8302,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [],
@@ -8324,7 +8324,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [],
@@ -8347,7 +8347,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 384,
+      "y": 382,
     },
     {
       "children": [],
@@ -8369,7 +8369,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 384,
+      "y": 382,
     },
     {
       "children": [],
@@ -8391,7 +8391,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 384,
+      "y": 382,
     },
     {
       "children": [],
@@ -8413,7 +8413,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 384,
+      "y": 382,
     },
     {
       "children": [],
@@ -8436,7 +8436,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1043,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -8459,7 +8459,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1183,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -8483,7 +8483,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1463,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -8506,7 +8506,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1463,
-      "y": 108,
+      "y": 106,
     },
     {
       "children": [],
@@ -8528,7 +8528,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1463,
-      "y": 178,
+      "y": 176,
     },
     {
       "children": [],
@@ -8550,7 +8550,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "stage",
       "width": 140,
       "x": 1603,
-      "y": 178,
+      "y": 176,
     },
     {
       "children": [],
@@ -8565,7 +8565,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "type": "end",
       "width": 35,
       "x": 1701,
-      "y": 38,
+      "y": 36,
     },
   ],
   "smallLabels": [
@@ -8583,7 +8583,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Non-Parallel Stage",
       "x": 133,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_small_n_17",
@@ -8599,7 +8599,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Branch A",
       "x": 553,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_small_n_18",
@@ -8615,7 +8615,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Skipped Branch B",
       "x": 553,
-      "y": 108,
+      "y": 106,
     },
     {
       "key": "l_small_n_35",
@@ -8631,7 +8631,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Nested 1 C",
       "x": 413,
-      "y": 200,
+      "y": 198,
     },
     {
       "key": "l_small_n_60",
@@ -8647,7 +8647,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Nested 2 C",
       "x": 553,
-      "y": 200,
+      "y": 198,
     },
     {
       "key": "l_small_n_55",
@@ -8663,7 +8663,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Nested 2 D",
       "x": 693,
-      "y": 292,
+      "y": 290,
     },
     {
       "key": "l_small_n_57",
@@ -8679,7 +8679,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Nested 2 E",
       "x": 553,
-      "y": 384,
+      "y": 382,
     },
     {
       "key": "l_small_n_71",
@@ -8695,7 +8695,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Nested 3 E",
       "x": 693,
-      "y": 384,
+      "y": 382,
     },
     {
       "key": "l_small_n_86",
@@ -8711,7 +8711,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Nested 4 E",
       "x": 833,
-      "y": 384,
+      "y": 382,
     },
     {
       "key": "l_small_n_137",
@@ -8727,7 +8727,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Branch A",
       "x": 1463,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_small_n_138",
@@ -8743,7 +8743,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Branch B",
       "x": 1463,
-      "y": 108,
+      "y": 106,
     },
     {
       "key": "l_small_n_149",
@@ -8759,7 +8759,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Nested 1",
       "x": 1463,
-      "y": 178,
+      "y": 176,
     },
     {
       "key": "l_small_n_160",
@@ -8775,7 +8775,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       },
       "text": "Nested 2",
       "x": 1603,
-      "y": 178,
+      "y": 176,
     },
   ],
   "timings": [],
@@ -8799,7 +8799,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -8821,7 +8821,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -8843,7 +8843,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -8865,7 +8865,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -8887,7 +8887,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -8909,7 +8909,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -8931,7 +8931,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -8953,7 +8953,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 973,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -8975,7 +8975,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 1113,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -8997,7 +8997,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 1253,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -9019,7 +9019,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 1393,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -9041,7 +9041,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 1533,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -9063,7 +9063,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 1673,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -9077,7 +9077,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "end",
           "width": 35,
           "x": 1771,
-          "y": 16,
+          "y": 14,
         },
       ],
       "height": 48,
@@ -9091,7 +9091,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "root",
       "width": 1806,
       "x": 0,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9105,7 +9105,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9127,7 +9127,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9149,7 +9149,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9171,7 +9171,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9193,7 +9193,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9215,7 +9215,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9237,7 +9237,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9259,7 +9259,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 973,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9281,7 +9281,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 1113,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9303,7 +9303,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 1253,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9325,7 +9325,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 1393,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9347,7 +9347,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 1533,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9369,7 +9369,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 1673,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9383,7 +9383,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "end",
       "width": 35,
       "x": 1771,
-      "y": 16,
+      "y": 14,
     },
   ],
   "bigLabels": [],
@@ -9394,7 +9394,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_10",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -9404,7 +9404,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -9413,7 +9413,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_16",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -9422,7 +9422,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_10",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -9431,7 +9431,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_33",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -9440,7 +9440,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_16",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -9449,7 +9449,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_34",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -9458,7 +9458,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_33",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -9467,7 +9467,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_17",
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -9476,7 +9476,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_34",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -9485,7 +9485,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_12",
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -9494,7 +9494,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_17",
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -9503,7 +9503,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_21",
           "x": 973,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -9512,7 +9512,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_12",
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -9521,7 +9521,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_28",
           "x": 1113,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -9530,7 +9530,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_21",
           "x": 973,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -9539,7 +9539,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_55",
           "x": 1253,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -9548,7 +9548,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_28",
           "x": 1113,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -9557,7 +9557,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_60",
           "x": 1393,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -9566,7 +9566,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_55",
           "x": 1253,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -9575,7 +9575,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_61",
           "x": 1533,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -9584,7 +9584,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_60",
           "x": 1393,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -9593,7 +9593,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_22",
           "x": 1673,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -9602,7 +9602,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_61",
           "x": 1533,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -9612,7 +9612,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isPlaceholder": true,
           "key": "end-node",
           "x": 1771,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -9621,12 +9621,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_22",
           "x": 1673,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
   ],
-  "measuredHeight": 64,
+  "measuredHeight": 62,
   "measuredWidth": 1806,
   "nodes": [
     {
@@ -9641,7 +9641,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9663,7 +9663,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9685,7 +9685,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9707,7 +9707,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9729,7 +9729,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9751,7 +9751,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9773,7 +9773,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9795,7 +9795,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 973,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9817,7 +9817,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 1113,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9839,7 +9839,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 1253,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9861,7 +9861,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 1393,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9883,7 +9883,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 1533,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9905,7 +9905,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 1673,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -9919,7 +9919,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "end",
       "width": 35,
       "x": 1771,
-      "y": 16,
+      "y": 14,
     },
   ],
   "smallLabels": [],
@@ -9938,7 +9938,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "",
       "x": 133,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_16",
@@ -9954,7 +9954,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "",
       "x": 273,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_33",
@@ -9970,7 +9970,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "",
       "x": 413,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_34",
@@ -9986,7 +9986,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "",
       "x": 553,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_17",
@@ -10002,7 +10002,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "",
       "x": 693,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_12",
@@ -10018,7 +10018,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "",
       "x": 833,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_21",
@@ -10034,7 +10034,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "",
       "x": 973,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_28",
@@ -10050,7 +10050,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "",
       "x": 1113,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_55",
@@ -10066,7 +10066,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "",
       "x": 1253,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_60",
@@ -10082,7 +10082,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "",
       "x": 1393,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_61",
@@ -10098,7 +10098,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "",
       "x": 1533,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_22",
@@ -10114,7 +10114,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "",
       "x": 1673,
-      "y": 71,
+      "y": 69,
     },
   ],
 }
@@ -10138,7 +10138,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 82,
+          "y": 80,
         },
         {
           "children": [
@@ -10171,7 +10171,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                               "type": "stage",
                               "width": 140,
                               "x": 413,
-                              "y": 82,
+                              "y": 80,
                             },
                             {
                               "children": [],
@@ -10194,7 +10194,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                               "type": "stage",
                               "width": 140,
                               "x": 413,
-                              "y": 152,
+                              "y": 150,
                             },
                           ],
                           "hasBigLabel": true,
@@ -10217,7 +10217,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                           "type": "stage",
                           "width": 140,
                           "x": 413,
-                          "y": 82,
+                          "y": 80,
                         },
                         {
                           "children": [],
@@ -10232,7 +10232,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                           "type": "stage-end",
                           "width": 140,
                           "x": 483,
-                          "y": 82,
+                          "y": 80,
                         },
                       ],
                       "hasStageEnd": true,
@@ -10256,7 +10256,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       "type": "stage",
                       "width": 350,
                       "x": 273,
-                      "y": 82,
+                      "y": 80,
                     },
                     {
                       "children": [],
@@ -10279,7 +10279,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       "type": "stage",
                       "width": 140,
                       "x": 273,
-                      "y": 222,
+                      "y": 220,
                     },
                   ],
                   "hasBigLabel": true,
@@ -10302,7 +10302,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage",
                   "width": 350,
                   "x": 273,
-                  "y": 82,
+                  "y": 80,
                 },
                 {
                   "children": [],
@@ -10317,7 +10317,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage-end",
                   "width": 140,
                   "x": 553,
-                  "y": 82,
+                  "y": 80,
                 },
               ],
               "hasBranchLabel": true,
@@ -10341,7 +10341,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 420,
               "x": 273,
-              "y": 82,
+              "y": 80,
             },
             {
               "children": [
@@ -10369,7 +10369,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                           "type": "stage",
                           "width": 140,
                           "x": 413,
-                          "y": 336,
+                          "y": 334,
                         },
                         {
                           "children": [
@@ -10394,7 +10394,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                               "type": "stage",
                               "width": 140,
                               "x": 553,
-                              "y": 336,
+                              "y": 334,
                             },
                             {
                               "children": [],
@@ -10417,7 +10417,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                               "type": "stage",
                               "width": 140,
                               "x": 553,
-                              "y": 406,
+                              "y": 404,
                             },
                           ],
                           "hasBigLabel": true,
@@ -10440,7 +10440,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                           "type": "stage",
                           "width": 140,
                           "x": 553,
-                          "y": 336,
+                          "y": 334,
                         },
                         {
                           "children": [],
@@ -10455,7 +10455,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                           "type": "stage-end",
                           "width": 140,
                           "x": 623,
-                          "y": 336,
+                          "y": 334,
                         },
                       ],
                       "hasBranchLabel": true,
@@ -10479,7 +10479,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       "type": "stage",
                       "width": 350,
                       "x": 413,
-                      "y": 336,
+                      "y": 334,
                     },
                     {
                       "children": [],
@@ -10502,7 +10502,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       "type": "stage",
                       "width": 140,
                       "x": 413,
-                      "y": 476,
+                      "y": 474,
                     },
                   ],
                   "hasBigLabel": true,
@@ -10525,7 +10525,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage",
                   "width": 490,
                   "x": 273,
-                  "y": 336,
+                  "y": 334,
                 },
                 {
                   "children": [],
@@ -10540,7 +10540,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage-end",
                   "width": 140,
                   "x": 693,
-                  "y": 336,
+                  "y": 334,
                 },
               ],
               "hasBranchLabel": true,
@@ -10564,7 +10564,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 560,
               "x": 273,
-              "y": 336,
+              "y": 334,
             },
           ],
           "hasBigLabel": true,
@@ -10587,7 +10587,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 700,
           "x": 133,
-          "y": 82,
+          "y": 80,
         },
         {
           "children": [],
@@ -10602,7 +10602,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "end",
           "width": 35,
           "x": 791,
-          "y": 82,
+          "y": 80,
         },
       ],
       "height": 442,
@@ -10616,7 +10616,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "root",
       "width": 826,
       "x": 0,
-      "y": 82,
+      "y": 80,
     },
     {
       "children": [],
@@ -10631,7 +10631,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 82,
+      "y": 80,
     },
     {
       "children": [
@@ -10664,7 +10664,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                           "type": "stage",
                           "width": 140,
                           "x": 413,
-                          "y": 82,
+                          "y": 80,
                         },
                         {
                           "children": [],
@@ -10687,7 +10687,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                           "type": "stage",
                           "width": 140,
                           "x": 413,
-                          "y": 152,
+                          "y": 150,
                         },
                       ],
                       "hasBigLabel": true,
@@ -10710,7 +10710,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       "type": "stage",
                       "width": 140,
                       "x": 413,
-                      "y": 82,
+                      "y": 80,
                     },
                     {
                       "children": [],
@@ -10725,7 +10725,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       "type": "stage-end",
                       "width": 140,
                       "x": 483,
-                      "y": 82,
+                      "y": 80,
                     },
                   ],
                   "hasStageEnd": true,
@@ -10749,7 +10749,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage",
                   "width": 350,
                   "x": 273,
-                  "y": 82,
+                  "y": 80,
                 },
                 {
                   "children": [],
@@ -10772,7 +10772,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage",
                   "width": 140,
                   "x": 273,
-                  "y": 222,
+                  "y": 220,
                 },
               ],
               "hasBigLabel": true,
@@ -10795,7 +10795,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 350,
               "x": 273,
-              "y": 82,
+              "y": 80,
             },
             {
               "children": [],
@@ -10810,7 +10810,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage-end",
               "width": 140,
               "x": 553,
-              "y": 82,
+              "y": 80,
             },
           ],
           "hasBranchLabel": true,
@@ -10834,7 +10834,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 420,
           "x": 273,
-          "y": 82,
+          "y": 80,
         },
         {
           "children": [
@@ -10862,7 +10862,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       "type": "stage",
                       "width": 140,
                       "x": 413,
-                      "y": 336,
+                      "y": 334,
                     },
                     {
                       "children": [
@@ -10887,7 +10887,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                           "type": "stage",
                           "width": 140,
                           "x": 553,
-                          "y": 336,
+                          "y": 334,
                         },
                         {
                           "children": [],
@@ -10910,7 +10910,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                           "type": "stage",
                           "width": 140,
                           "x": 553,
-                          "y": 406,
+                          "y": 404,
                         },
                       ],
                       "hasBigLabel": true,
@@ -10933,7 +10933,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       "type": "stage",
                       "width": 140,
                       "x": 553,
-                      "y": 336,
+                      "y": 334,
                     },
                     {
                       "children": [],
@@ -10948,7 +10948,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       "type": "stage-end",
                       "width": 140,
                       "x": 623,
-                      "y": 336,
+                      "y": 334,
                     },
                   ],
                   "hasBranchLabel": true,
@@ -10972,7 +10972,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage",
                   "width": 350,
                   "x": 413,
-                  "y": 336,
+                  "y": 334,
                 },
                 {
                   "children": [],
@@ -10995,7 +10995,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage",
                   "width": 140,
                   "x": 413,
-                  "y": 476,
+                  "y": 474,
                 },
               ],
               "hasBigLabel": true,
@@ -11018,7 +11018,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 490,
               "x": 273,
-              "y": 336,
+              "y": 334,
             },
             {
               "children": [],
@@ -11033,7 +11033,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage-end",
               "width": 140,
               "x": 693,
-              "y": 336,
+              "y": 334,
             },
           ],
           "hasBranchLabel": true,
@@ -11057,7 +11057,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 560,
           "x": 273,
-          "y": 336,
+          "y": 334,
         },
       ],
       "hasBigLabel": true,
@@ -11080,7 +11080,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 700,
       "x": 133,
-      "y": 82,
+      "y": 80,
     },
     {
       "children": [
@@ -11111,7 +11111,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       "type": "stage",
                       "width": 140,
                       "x": 413,
-                      "y": 82,
+                      "y": 80,
                     },
                     {
                       "children": [],
@@ -11134,7 +11134,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       "type": "stage",
                       "width": 140,
                       "x": 413,
-                      "y": 152,
+                      "y": 150,
                     },
                   ],
                   "hasBigLabel": true,
@@ -11157,7 +11157,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage",
                   "width": 140,
                   "x": 413,
-                  "y": 82,
+                  "y": 80,
                 },
                 {
                   "children": [],
@@ -11172,7 +11172,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage-end",
                   "width": 140,
                   "x": 483,
-                  "y": 82,
+                  "y": 80,
                 },
               ],
               "hasStageEnd": true,
@@ -11196,7 +11196,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 350,
               "x": 273,
-              "y": 82,
+              "y": 80,
             },
             {
               "children": [],
@@ -11219,7 +11219,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 140,
               "x": 273,
-              "y": 222,
+              "y": 220,
             },
           ],
           "hasBigLabel": true,
@@ -11242,7 +11242,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 350,
           "x": 273,
-          "y": 82,
+          "y": 80,
         },
         {
           "children": [],
@@ -11257,7 +11257,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage-end",
           "width": 140,
           "x": 553,
-          "y": 82,
+          "y": 80,
         },
       ],
       "hasBranchLabel": true,
@@ -11281,7 +11281,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 420,
       "x": 273,
-      "y": 82,
+      "y": 80,
     },
     {
       "children": [
@@ -11310,7 +11310,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage",
                   "width": 140,
                   "x": 413,
-                  "y": 82,
+                  "y": 80,
                 },
                 {
                   "children": [],
@@ -11333,7 +11333,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage",
                   "width": 140,
                   "x": 413,
-                  "y": 152,
+                  "y": 150,
                 },
               ],
               "hasBigLabel": true,
@@ -11356,7 +11356,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 82,
+              "y": 80,
             },
             {
               "children": [],
@@ -11371,7 +11371,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage-end",
               "width": 140,
               "x": 483,
-              "y": 82,
+              "y": 80,
             },
           ],
           "hasStageEnd": true,
@@ -11395,7 +11395,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 350,
           "x": 273,
-          "y": 82,
+          "y": 80,
         },
         {
           "children": [],
@@ -11418,7 +11418,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 222,
+          "y": 220,
         },
       ],
       "hasBigLabel": true,
@@ -11441,7 +11441,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 350,
       "x": 273,
-      "y": 82,
+      "y": 80,
     },
     {
       "children": [
@@ -11468,7 +11468,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 82,
+              "y": 80,
             },
             {
               "children": [],
@@ -11491,7 +11491,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 152,
+              "y": 150,
             },
           ],
           "hasBigLabel": true,
@@ -11514,7 +11514,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 82,
+          "y": 80,
         },
         {
           "children": [],
@@ -11529,7 +11529,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage-end",
           "width": 140,
           "x": 483,
-          "y": 82,
+          "y": 80,
         },
       ],
       "hasStageEnd": true,
@@ -11553,7 +11553,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 350,
       "x": 273,
-      "y": 82,
+      "y": 80,
     },
     {
       "children": [
@@ -11578,7 +11578,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 82,
+          "y": 80,
         },
         {
           "children": [],
@@ -11601,7 +11601,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 152,
+          "y": 150,
         },
       ],
       "hasBigLabel": true,
@@ -11624,7 +11624,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 82,
+      "y": 80,
     },
     {
       "children": [],
@@ -11647,7 +11647,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 82,
+      "y": 80,
     },
     {
       "children": [],
@@ -11670,7 +11670,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 152,
+      "y": 150,
     },
     {
       "children": [],
@@ -11685,7 +11685,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage-end",
       "width": 140,
       "x": 483,
-      "y": 82,
+      "y": 80,
     },
     {
       "children": [],
@@ -11708,7 +11708,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 222,
+      "y": 220,
     },
     {
       "children": [],
@@ -11723,7 +11723,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage-end",
       "width": 140,
       "x": 553,
-      "y": 82,
+      "y": 80,
     },
     {
       "children": [
@@ -11751,7 +11751,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage",
                   "width": 140,
                   "x": 413,
-                  "y": 336,
+                  "y": 334,
                 },
                 {
                   "children": [
@@ -11776,7 +11776,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       "type": "stage",
                       "width": 140,
                       "x": 553,
-                      "y": 336,
+                      "y": 334,
                     },
                     {
                       "children": [],
@@ -11799,7 +11799,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       "type": "stage",
                       "width": 140,
                       "x": 553,
-                      "y": 406,
+                      "y": 404,
                     },
                   ],
                   "hasBigLabel": true,
@@ -11822,7 +11822,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage",
                   "width": 140,
                   "x": 553,
-                  "y": 336,
+                  "y": 334,
                 },
                 {
                   "children": [],
@@ -11837,7 +11837,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage-end",
                   "width": 140,
                   "x": 623,
-                  "y": 336,
+                  "y": 334,
                 },
               ],
               "hasBranchLabel": true,
@@ -11861,7 +11861,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 350,
               "x": 413,
-              "y": 336,
+              "y": 334,
             },
             {
               "children": [],
@@ -11884,7 +11884,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 476,
+              "y": 474,
             },
           ],
           "hasBigLabel": true,
@@ -11907,7 +11907,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 490,
           "x": 273,
-          "y": 336,
+          "y": 334,
         },
         {
           "children": [],
@@ -11922,7 +11922,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage-end",
           "width": 140,
           "x": 693,
-          "y": 336,
+          "y": 334,
         },
       ],
       "hasBranchLabel": true,
@@ -11946,7 +11946,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 560,
       "x": 273,
-      "y": 336,
+      "y": 334,
     },
     {
       "children": [
@@ -11972,7 +11972,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 336,
+              "y": 334,
             },
             {
               "children": [
@@ -11997,7 +11997,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage",
                   "width": 140,
                   "x": 553,
-                  "y": 336,
+                  "y": 334,
                 },
                 {
                   "children": [],
@@ -12020,7 +12020,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   "type": "stage",
                   "width": 140,
                   "x": 553,
-                  "y": 406,
+                  "y": 404,
                 },
               ],
               "hasBigLabel": true,
@@ -12043,7 +12043,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 336,
+              "y": 334,
             },
             {
               "children": [],
@@ -12058,7 +12058,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage-end",
               "width": 140,
               "x": 623,
-              "y": 336,
+              "y": 334,
             },
           ],
           "hasBranchLabel": true,
@@ -12082,7 +12082,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 350,
           "x": 413,
-          "y": 336,
+          "y": 334,
         },
         {
           "children": [],
@@ -12105,7 +12105,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 476,
+          "y": 474,
         },
       ],
       "hasBigLabel": true,
@@ -12128,7 +12128,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 490,
       "x": 273,
-      "y": 336,
+      "y": 334,
     },
     {
       "children": [
@@ -12152,7 +12152,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 336,
+          "y": 334,
         },
         {
           "children": [
@@ -12177,7 +12177,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 336,
+              "y": 334,
             },
             {
               "children": [],
@@ -12200,7 +12200,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 406,
+              "y": 404,
             },
           ],
           "hasBigLabel": true,
@@ -12223,7 +12223,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 336,
+          "y": 334,
         },
         {
           "children": [],
@@ -12238,7 +12238,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage-end",
           "width": 140,
           "x": 623,
-          "y": 336,
+          "y": 334,
         },
       ],
       "hasBranchLabel": true,
@@ -12262,7 +12262,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 350,
       "x": 413,
-      "y": 336,
+      "y": 334,
     },
     {
       "children": [],
@@ -12284,7 +12284,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 336,
+      "y": 334,
     },
     {
       "children": [
@@ -12309,7 +12309,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 336,
+          "y": 334,
         },
         {
           "children": [],
@@ -12332,7 +12332,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 406,
+          "y": 404,
         },
       ],
       "hasBigLabel": true,
@@ -12355,7 +12355,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 336,
+      "y": 334,
     },
     {
       "children": [],
@@ -12378,7 +12378,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 336,
+      "y": 334,
     },
     {
       "children": [],
@@ -12401,7 +12401,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 406,
+      "y": 404,
     },
     {
       "children": [],
@@ -12416,7 +12416,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage-end",
       "width": 140,
       "x": 623,
-      "y": 336,
+      "y": 334,
     },
     {
       "children": [],
@@ -12439,7 +12439,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 476,
+      "y": 474,
     },
     {
       "children": [],
@@ -12454,7 +12454,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage-end",
       "width": 140,
       "x": 693,
-      "y": 336,
+      "y": 334,
     },
     {
       "children": [],
@@ -12469,7 +12469,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "end",
       "width": 35,
       "x": 791,
-      "y": 82,
+      "y": 80,
     },
   ],
   "bigLabels": [
@@ -12481,7 +12481,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "stage": undefined,
       "text": "Start",
       "x": 35,
-      "y": 82,
+      "y": 80,
     },
     {
       "key": "l_big_n_4",
@@ -12497,7 +12497,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "Top level",
       "x": 413,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_10",
@@ -12513,7 +12513,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "Branch A",
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_n_16",
@@ -12529,7 +12529,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "A-1",
       "x": 413,
-      "y": 82,
+      "y": 80,
     },
     {
       "key": "l_big_n_12",
@@ -12545,7 +12545,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "Branch B",
       "x": 483,
-      "y": 314,
+      "y": 312,
     },
     {
       "key": "l_big_n_55",
@@ -12561,7 +12561,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "B-1-2",
       "x": 553,
-      "y": 336,
+      "y": 334,
     },
     {
       "key": "l_big_end-node",
@@ -12571,7 +12571,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "stage": undefined,
       "text": "End",
       "x": 791,
-      "y": 82,
+      "y": 80,
     },
   ],
   "branchLabels": [
@@ -12589,7 +12589,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "BranchA",
       "x": 133,
-      "y": 82,
+      "y": 80,
     },
     {
       "key": "l_branch_n_8",
@@ -12605,7 +12605,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "BranchB",
       "x": 133,
-      "y": 336,
+      "y": 334,
     },
     {
       "key": "l_branch_n_21",
@@ -12621,7 +12621,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "B-1",
       "x": 273,
-      "y": 336,
+      "y": 334,
     },
   ],
   "connections": [
@@ -12631,13 +12631,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isHidden": true,
           "key": "n_7",
           "x": 273,
-          "y": 82,
+          "y": 80,
         },
         {
           "isHidden": true,
           "key": "n_8",
           "x": 273,
-          "y": 336,
+          "y": 334,
         },
       ],
       "hasBranchLabels": true,
@@ -12647,7 +12647,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 82,
+          "y": 80,
         },
       ],
     },
@@ -12657,12 +12657,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isHidden": true,
           "key": "n_-16",
           "x": 273,
-          "y": 82,
+          "y": 80,
         },
         {
           "key": "n_17",
           "x": 273,
-          "y": 222,
+          "y": 220,
         },
       ],
       "hasBranchLabels": false,
@@ -12672,7 +12672,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isHidden": true,
           "key": "n_7",
           "x": 273,
-          "y": 82,
+          "y": 80,
         },
       ],
     },
@@ -12681,12 +12681,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_33",
           "x": 413,
-          "y": 82,
+          "y": 80,
         },
         {
           "key": "n_34",
           "x": 413,
-          "y": 152,
+          "y": 150,
         },
       ],
       "hasBranchLabels": false,
@@ -12696,7 +12696,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isHidden": true,
           "key": "n_-16",
           "x": 273,
-          "y": 82,
+          "y": 80,
         },
       ],
     },
@@ -12707,7 +12707,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isPlaceholder": true,
           "key": "stage_end_n_-16",
           "x": 483,
-          "y": 82,
+          "y": 80,
         },
       ],
       "hasBranchLabels": false,
@@ -12716,12 +12716,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_33",
           "x": 413,
-          "y": 82,
+          "y": 80,
         },
         {
           "key": "n_34",
           "x": 413,
-          "y": 152,
+          "y": 150,
         },
       ],
     },
@@ -12732,7 +12732,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isPlaceholder": true,
           "key": "stage_end_n_7",
           "x": 553,
-          "y": 82,
+          "y": 80,
         },
       ],
       "hasBranchLabels": false,
@@ -12743,12 +12743,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isPlaceholder": true,
           "key": "stage_end_n_-16",
           "x": 483,
-          "y": 82,
+          "y": 80,
         },
         {
           "key": "n_17",
           "x": 273,
-          "y": 222,
+          "y": 220,
         },
       ],
     },
@@ -12758,12 +12758,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isHidden": true,
           "key": "n_21",
           "x": 413,
-          "y": 336,
+          "y": 334,
         },
         {
           "key": "n_22",
           "x": 413,
-          "y": 476,
+          "y": 474,
         },
       ],
       "hasBranchLabels": true,
@@ -12773,7 +12773,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isHidden": true,
           "key": "n_8",
           "x": 273,
-          "y": 336,
+          "y": 334,
         },
       ],
     },
@@ -12782,7 +12782,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_28",
           "x": 413,
-          "y": 336,
+          "y": 334,
         },
       ],
       "hasBranchLabels": false,
@@ -12792,7 +12792,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isHidden": true,
           "key": "n_21",
           "x": 413,
-          "y": 336,
+          "y": 334,
         },
       ],
     },
@@ -12801,12 +12801,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_60",
           "x": 553,
-          "y": 336,
+          "y": 334,
         },
         {
           "key": "n_61",
           "x": 553,
-          "y": 406,
+          "y": 404,
         },
       ],
       "hasBranchLabels": false,
@@ -12815,7 +12815,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_28",
           "x": 413,
-          "y": 336,
+          "y": 334,
         },
       ],
     },
@@ -12826,7 +12826,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isPlaceholder": true,
           "key": "stage_end_n_21",
           "x": 623,
-          "y": 336,
+          "y": 334,
         },
       ],
       "hasBranchLabels": false,
@@ -12835,12 +12835,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "key": "n_60",
           "x": 553,
-          "y": 336,
+          "y": 334,
         },
         {
           "key": "n_61",
           "x": 553,
-          "y": 406,
+          "y": 404,
         },
       ],
     },
@@ -12851,7 +12851,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isPlaceholder": true,
           "key": "stage_end_n_8",
           "x": 693,
-          "y": 336,
+          "y": 334,
         },
       ],
       "hasBranchLabels": false,
@@ -12862,12 +12862,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isPlaceholder": true,
           "key": "stage_end_n_21",
           "x": 623,
-          "y": 336,
+          "y": 334,
         },
         {
           "key": "n_22",
           "x": 413,
-          "y": 476,
+          "y": 474,
         },
       ],
     },
@@ -12877,7 +12877,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isPlaceholder": true,
           "key": "end-node",
           "x": 791,
-          "y": 82,
+          "y": 80,
         },
       ],
       "hasBranchLabels": false,
@@ -12888,19 +12888,19 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "isPlaceholder": true,
           "key": "stage_end_n_7",
           "x": 553,
-          "y": 82,
+          "y": 80,
         },
         {
           "isHidden": true,
           "isPlaceholder": true,
           "key": "stage_end_n_8",
           "x": 693,
-          "y": 336,
+          "y": 334,
         },
       ],
     },
   ],
-  "measuredHeight": 524,
+  "measuredHeight": 522,
   "measuredWidth": 826,
   "nodes": [
     {
@@ -12916,7 +12916,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 82,
+      "y": 80,
     },
     {
       "children": [],
@@ -12939,7 +12939,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 82,
+      "y": 80,
     },
     {
       "children": [],
@@ -12962,7 +12962,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 152,
+      "y": 150,
     },
     {
       "children": [],
@@ -12985,7 +12985,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 222,
+      "y": 220,
     },
     {
       "children": [],
@@ -13007,7 +13007,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 336,
+      "y": 334,
     },
     {
       "children": [],
@@ -13030,7 +13030,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 336,
+      "y": 334,
     },
     {
       "children": [],
@@ -13053,7 +13053,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 406,
+      "y": 404,
     },
     {
       "children": [],
@@ -13076,7 +13076,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 476,
+      "y": 474,
     },
     {
       "children": [],
@@ -13091,7 +13091,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "type": "end",
       "width": 35,
       "x": 791,
-      "y": 82,
+      "y": 80,
     },
   ],
   "smallLabels": [
@@ -13109,7 +13109,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "A-1-1",
       "x": 413,
-      "y": 82,
+      "y": 80,
     },
     {
       "key": "l_small_n_34",
@@ -13125,7 +13125,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "A-1-2",
       "x": 413,
-      "y": 152,
+      "y": 150,
     },
     {
       "key": "l_small_n_17",
@@ -13141,7 +13141,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "A-2",
       "x": 273,
-      "y": 222,
+      "y": 220,
     },
     {
       "key": "l_small_n_28",
@@ -13157,7 +13157,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "B-1-1",
       "x": 413,
-      "y": 336,
+      "y": 334,
     },
     {
       "key": "l_small_n_60",
@@ -13173,7 +13173,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "B-1-2-1",
       "x": 553,
-      "y": 336,
+      "y": 334,
     },
     {
       "key": "l_small_n_61",
@@ -13189,7 +13189,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "B-1-2-2",
       "x": 553,
-      "y": 406,
+      "y": 404,
     },
     {
       "key": "l_small_n_22",
@@ -13205,7 +13205,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       },
       "text": "B-2",
       "x": 413,
-      "y": 476,
+      "y": 474,
     },
   ],
   "timings": [],
@@ -13229,7 +13229,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -13251,7 +13251,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -13273,7 +13273,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -13295,7 +13295,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -13317,7 +13317,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -13339,7 +13339,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -13361,7 +13361,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -13383,7 +13383,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 973,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -13405,7 +13405,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 1113,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -13427,7 +13427,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 1253,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -13449,7 +13449,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 1393,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -13471,7 +13471,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 1533,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -13493,7 +13493,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 1673,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -13572,7 +13572,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "counter",
           "width": 140,
           "x": 1813,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -13586,7 +13586,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "end",
           "width": 35,
           "x": 1911,
-          "y": 16,
+          "y": 14,
         },
       ],
       "height": 48,
@@ -13600,7 +13600,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "root",
       "width": 1946,
       "x": 0,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13614,7 +13614,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13636,7 +13636,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13658,7 +13658,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13680,7 +13680,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13702,7 +13702,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13724,7 +13724,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13746,7 +13746,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13768,7 +13768,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 973,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13790,7 +13790,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 1113,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13812,7 +13812,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 1253,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13834,7 +13834,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 1393,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13856,7 +13856,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 1533,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13878,7 +13878,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 1673,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13957,7 +13957,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "counter",
       "width": 140,
       "x": 1813,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -13971,7 +13971,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "end",
       "width": 35,
       "x": 1911,
-      "y": 16,
+      "y": 14,
     },
   ],
   "bigLabels": [],
@@ -13982,7 +13982,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_12",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -13992,7 +13992,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -14001,7 +14001,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_26",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -14010,7 +14010,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_12",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -14019,7 +14019,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_35",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -14028,7 +14028,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_26",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -14037,7 +14037,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_36",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -14046,7 +14046,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_35",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -14055,7 +14055,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_37",
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -14064,7 +14064,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_36",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -14073,7 +14073,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_67",
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -14082,7 +14082,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_37",
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -14091,7 +14091,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_72",
           "x": 973,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -14100,7 +14100,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_67",
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -14109,7 +14109,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_73",
           "x": 1113,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -14118,7 +14118,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_72",
           "x": 973,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -14127,7 +14127,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_99",
           "x": 1253,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -14136,7 +14136,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_73",
           "x": 1113,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -14145,7 +14145,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_14",
           "x": 1393,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -14154,7 +14154,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_99",
           "x": 1253,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -14163,7 +14163,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_28",
           "x": 1533,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -14172,7 +14172,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_14",
           "x": 1393,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -14181,7 +14181,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_51",
           "x": 1673,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -14190,7 +14190,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_28",
           "x": 1533,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -14200,7 +14200,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "isPlaceholder": true,
           "key": "counter-node",
           "x": 1813,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -14209,7 +14209,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_51",
           "x": 1673,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -14219,7 +14219,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "isPlaceholder": true,
           "key": "end-node",
           "x": 1911,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -14229,12 +14229,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "isPlaceholder": true,
           "key": "counter-node",
           "x": 1813,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
   ],
-  "measuredHeight": 64,
+  "measuredHeight": 62,
   "measuredWidth": 1946,
   "nodes": [
     {
@@ -14249,7 +14249,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -14271,7 +14271,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -14293,7 +14293,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -14315,7 +14315,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -14337,7 +14337,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -14359,7 +14359,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -14381,7 +14381,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -14403,7 +14403,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 973,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -14425,7 +14425,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 1113,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -14447,7 +14447,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 1253,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -14469,7 +14469,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 1393,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -14491,7 +14491,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 1533,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -14513,7 +14513,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 1673,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -14592,7 +14592,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "counter",
       "width": 140,
       "x": 1813,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -14606,7 +14606,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "end",
       "width": 35,
       "x": 1911,
-      "y": 16,
+      "y": 14,
     },
   ],
   "smallLabels": [],
@@ -14625,7 +14625,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "",
       "x": 133,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_26",
@@ -14641,7 +14641,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "",
       "x": 273,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_35",
@@ -14657,7 +14657,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "",
       "x": 413,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_36",
@@ -14673,7 +14673,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "",
       "x": 553,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_37",
@@ -14689,7 +14689,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "",
       "x": 693,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_67",
@@ -14705,7 +14705,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "",
       "x": 833,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_72",
@@ -14721,7 +14721,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "",
       "x": 973,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_73",
@@ -14737,7 +14737,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "",
       "x": 1113,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_99",
@@ -14753,7 +14753,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "",
       "x": 1253,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_14",
@@ -14769,7 +14769,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "",
       "x": 1393,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_28",
@@ -14785,7 +14785,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "",
       "x": 1533,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_51",
@@ -14801,7 +14801,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "",
       "x": 1673,
-      "y": 71,
+      "y": 69,
     },
   ],
 }
@@ -14825,7 +14825,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [
@@ -14851,7 +14851,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 413,
-                  "y": 60,
+                  "y": 58,
                 },
                 {
                   "children": [
@@ -14876,7 +14876,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                       "type": "stage",
                       "width": 140,
                       "x": 553,
-                      "y": 60,
+                      "y": 58,
                     },
                     {
                       "children": [],
@@ -14899,7 +14899,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                       "type": "stage",
                       "width": 140,
                       "x": 553,
-                      "y": 130,
+                      "y": 128,
                     },
                     {
                       "children": [],
@@ -14922,7 +14922,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                       "type": "stage",
                       "width": 140,
                       "x": 553,
-                      "y": 200,
+                      "y": 198,
                     },
                   ],
                   "hasBigLabel": true,
@@ -14945,7 +14945,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 553,
-                  "y": 60,
+                  "y": 58,
                 },
                 {
                   "children": [
@@ -14970,7 +14970,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                       "type": "stage",
                       "width": 140,
                       "x": 693,
-                      "y": 60,
+                      "y": 58,
                     },
                     {
                       "children": [],
@@ -14993,7 +14993,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                       "type": "stage",
                       "width": 140,
                       "x": 693,
-                      "y": 130,
+                      "y": 128,
                     },
                   ],
                   "hasBigLabel": true,
@@ -15016,7 +15016,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 693,
-                  "y": 60,
+                  "y": 58,
                 },
                 {
                   "children": [],
@@ -15038,7 +15038,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 833,
-                  "y": 60,
+                  "y": 58,
                 },
               ],
               "hasBranchLabel": true,
@@ -15061,7 +15061,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 560,
               "x": 273,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [
@@ -15085,7 +15085,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 413,
-                  "y": 292,
+                  "y": 290,
                 },
                 {
                   "children": [],
@@ -15107,7 +15107,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 553,
-                  "y": 292,
+                  "y": 290,
                 },
                 {
                   "children": [
@@ -15132,7 +15132,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                       "type": "stage",
                       "width": 140,
                       "x": 693,
-                      "y": 292,
+                      "y": 290,
                     },
                     {
                       "children": [],
@@ -15155,7 +15155,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                       "type": "stage",
                       "width": 140,
                       "x": 693,
-                      "y": 362,
+                      "y": 360,
                     },
                   ],
                   "hasBigLabel": true,
@@ -15178,7 +15178,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 693,
-                  "y": 292,
+                  "y": 290,
                 },
                 {
                   "children": [],
@@ -15200,7 +15200,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 833,
-                  "y": 292,
+                  "y": 290,
                 },
               ],
               "hasBranchLabel": true,
@@ -15223,7 +15223,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 560,
               "x": 273,
-              "y": 292,
+              "y": 290,
             },
             {
               "children": [
@@ -15247,7 +15247,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 273,
-                  "y": 432,
+                  "y": 430,
                 },
                 {
                   "children": [],
@@ -15269,7 +15269,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 413,
-                  "y": 432,
+                  "y": 430,
                 },
                 {
                   "children": [],
@@ -15291,7 +15291,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 553,
-                  "y": 432,
+                  "y": 430,
                 },
                 {
                   "children": [],
@@ -15313,7 +15313,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 693,
-                  "y": 432,
+                  "y": 430,
                 },
                 {
                   "children": [],
@@ -15335,7 +15335,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 833,
-                  "y": 432,
+                  "y": 430,
                 },
                 {
                   "children": [],
@@ -15357,7 +15357,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 973,
-                  "y": 432,
+                  "y": 430,
                 },
                 {
                   "children": [],
@@ -15379,7 +15379,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 1113,
-                  "y": 432,
+                  "y": 430,
                 },
               ],
               "hasBranchLabel": true,
@@ -15402,7 +15402,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 980,
               "x": 273,
-              "y": 432,
+              "y": 430,
             },
           ],
           "hasBigLabel": true,
@@ -15425,7 +15425,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 1120,
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -15440,7 +15440,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "end",
           "width": 35,
           "x": 1211,
-          "y": 60,
+          "y": 58,
         },
       ],
       "height": 420,
@@ -15454,7 +15454,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "root",
       "width": 1246,
       "x": 0,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -15469,7 +15469,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [
@@ -15495,7 +15495,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [
@@ -15520,7 +15520,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 553,
-                  "y": 60,
+                  "y": 58,
                 },
                 {
                   "children": [],
@@ -15543,7 +15543,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 553,
-                  "y": 130,
+                  "y": 128,
                 },
                 {
                   "children": [],
@@ -15566,7 +15566,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 553,
-                  "y": 200,
+                  "y": 198,
                 },
               ],
               "hasBigLabel": true,
@@ -15589,7 +15589,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [
@@ -15614,7 +15614,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 693,
-                  "y": 60,
+                  "y": 58,
                 },
                 {
                   "children": [],
@@ -15637,7 +15637,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 693,
-                  "y": 130,
+                  "y": 128,
                 },
               ],
               "hasBigLabel": true,
@@ -15660,7 +15660,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 693,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [],
@@ -15682,7 +15682,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 833,
-              "y": 60,
+              "y": 58,
             },
           ],
           "hasBranchLabel": true,
@@ -15705,7 +15705,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 560,
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [
@@ -15729,7 +15729,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 292,
+              "y": 290,
             },
             {
               "children": [],
@@ -15751,7 +15751,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 292,
+              "y": 290,
             },
             {
               "children": [
@@ -15776,7 +15776,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 693,
-                  "y": 292,
+                  "y": 290,
                 },
                 {
                   "children": [],
@@ -15799,7 +15799,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   "type": "stage",
                   "width": 140,
                   "x": 693,
-                  "y": 362,
+                  "y": 360,
                 },
               ],
               "hasBigLabel": true,
@@ -15822,7 +15822,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 693,
-              "y": 292,
+              "y": 290,
             },
             {
               "children": [],
@@ -15844,7 +15844,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 833,
-              "y": 292,
+              "y": 290,
             },
           ],
           "hasBranchLabel": true,
@@ -15867,7 +15867,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 560,
           "x": 273,
-          "y": 292,
+          "y": 290,
         },
         {
           "children": [
@@ -15891,7 +15891,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 273,
-              "y": 432,
+              "y": 430,
             },
             {
               "children": [],
@@ -15913,7 +15913,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 413,
-              "y": 432,
+              "y": 430,
             },
             {
               "children": [],
@@ -15935,7 +15935,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 432,
+              "y": 430,
             },
             {
               "children": [],
@@ -15957,7 +15957,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 693,
-              "y": 432,
+              "y": 430,
             },
             {
               "children": [],
@@ -15979,7 +15979,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 833,
-              "y": 432,
+              "y": 430,
             },
             {
               "children": [],
@@ -16001,7 +16001,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 973,
-              "y": 432,
+              "y": 430,
             },
             {
               "children": [],
@@ -16023,7 +16023,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 1113,
-              "y": 432,
+              "y": 430,
             },
           ],
           "hasBranchLabel": true,
@@ -16046,7 +16046,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 980,
           "x": 273,
-          "y": 432,
+          "y": 430,
         },
       ],
       "hasBigLabel": true,
@@ -16069,7 +16069,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 1120,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [
@@ -16093,7 +16093,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [
@@ -16118,7 +16118,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [],
@@ -16141,7 +16141,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 130,
+              "y": 128,
             },
             {
               "children": [],
@@ -16164,7 +16164,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 553,
-              "y": 200,
+              "y": 198,
             },
           ],
           "hasBigLabel": true,
@@ -16187,7 +16187,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [
@@ -16212,7 +16212,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 693,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [],
@@ -16235,7 +16235,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 693,
-              "y": 130,
+              "y": 128,
             },
           ],
           "hasBigLabel": true,
@@ -16258,7 +16258,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -16280,7 +16280,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 833,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabel": true,
@@ -16303,7 +16303,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 560,
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -16325,7 +16325,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [
@@ -16350,7 +16350,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -16373,7 +16373,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 130,
+          "y": 128,
         },
         {
           "children": [],
@@ -16396,7 +16396,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 200,
+          "y": 198,
         },
       ],
       "hasBigLabel": true,
@@ -16419,7 +16419,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -16442,7 +16442,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -16465,7 +16465,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 130,
+      "y": 128,
     },
     {
       "children": [],
@@ -16488,7 +16488,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 200,
+      "y": 198,
     },
     {
       "children": [
@@ -16513,7 +16513,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -16536,7 +16536,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 130,
+          "y": 128,
         },
       ],
       "hasBigLabel": true,
@@ -16559,7 +16559,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -16582,7 +16582,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -16605,7 +16605,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 130,
+      "y": 128,
     },
     {
       "children": [],
@@ -16627,7 +16627,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [
@@ -16651,7 +16651,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 292,
+          "y": 290,
         },
         {
           "children": [],
@@ -16673,7 +16673,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 292,
+          "y": 290,
         },
         {
           "children": [
@@ -16698,7 +16698,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 693,
-              "y": 292,
+              "y": 290,
             },
             {
               "children": [],
@@ -16721,7 +16721,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "type": "stage",
               "width": 140,
               "x": 693,
-              "y": 362,
+              "y": 360,
             },
           ],
           "hasBigLabel": true,
@@ -16744,7 +16744,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 292,
+          "y": 290,
         },
         {
           "children": [],
@@ -16766,7 +16766,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 833,
-          "y": 292,
+          "y": 290,
         },
       ],
       "hasBranchLabel": true,
@@ -16789,7 +16789,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 560,
       "x": 273,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [],
@@ -16811,7 +16811,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [],
@@ -16833,7 +16833,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [
@@ -16858,7 +16858,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 292,
+          "y": 290,
         },
         {
           "children": [],
@@ -16881,7 +16881,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 362,
+          "y": 360,
         },
       ],
       "hasBigLabel": true,
@@ -16904,7 +16904,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [],
@@ -16927,7 +16927,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [],
@@ -16950,7 +16950,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 362,
+      "y": 360,
     },
     {
       "children": [],
@@ -16972,7 +16972,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [
@@ -16996,7 +16996,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 432,
+          "y": 430,
         },
         {
           "children": [],
@@ -17018,7 +17018,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 432,
+          "y": 430,
         },
         {
           "children": [],
@@ -17040,7 +17040,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 432,
+          "y": 430,
         },
         {
           "children": [],
@@ -17062,7 +17062,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 432,
+          "y": 430,
         },
         {
           "children": [],
@@ -17084,7 +17084,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 833,
-          "y": 432,
+          "y": 430,
         },
         {
           "children": [],
@@ -17106,7 +17106,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 973,
-          "y": 432,
+          "y": 430,
         },
         {
           "children": [],
@@ -17128,7 +17128,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "type": "stage",
           "width": 140,
           "x": 1113,
-          "y": 432,
+          "y": 430,
         },
       ],
       "hasBranchLabel": true,
@@ -17151,7 +17151,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 980,
       "x": 273,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -17173,7 +17173,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -17195,7 +17195,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -17217,7 +17217,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -17239,7 +17239,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -17261,7 +17261,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -17283,7 +17283,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 973,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -17305,7 +17305,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 1113,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -17320,7 +17320,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "end",
       "width": 35,
       "x": 1211,
-      "y": 60,
+      "y": 58,
     },
   ],
   "bigLabels": [
@@ -17332,7 +17332,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "stage": undefined,
       "text": "Start",
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_n_5",
@@ -17348,7 +17348,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Parallel",
       "x": 623,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_26",
@@ -17364,7 +17364,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Test",
       "x": 553,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_n_67",
@@ -17380,7 +17380,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Test 2",
       "x": 693,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_n_49",
@@ -17396,7 +17396,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Parallel",
       "x": 693,
-      "y": 292,
+      "y": 290,
     },
     {
       "key": "l_big_end-node",
@@ -17406,7 +17406,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "stage": undefined,
       "text": "End",
       "x": 1211,
-      "y": 60,
+      "y": 58,
     },
   ],
   "branchLabels": [
@@ -17424,7 +17424,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "A",
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_branch_n_9",
@@ -17440,7 +17440,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "B",
       "x": 133,
-      "y": 292,
+      "y": 290,
     },
     {
       "key": "l_branch_n_10",
@@ -17456,7 +17456,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "C",
       "x": 133,
-      "y": 432,
+      "y": 430,
     },
   ],
   "connections": [
@@ -17466,19 +17466,19 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "isHidden": true,
           "key": "n_8",
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
         {
           "isHidden": true,
           "key": "n_9",
           "x": 273,
-          "y": 292,
+          "y": 290,
         },
         {
           "isHidden": true,
           "key": "n_10",
           "x": 273,
-          "y": 432,
+          "y": 430,
         },
       ],
       "hasBranchLabels": true,
@@ -17488,7 +17488,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
@@ -17497,7 +17497,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_12",
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -17507,7 +17507,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "isHidden": true,
           "key": "n_8",
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
@@ -17516,17 +17516,17 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_35",
           "x": 553,
-          "y": 60,
+          "y": 58,
         },
         {
           "key": "n_36",
           "x": 553,
-          "y": 130,
+          "y": 128,
         },
         {
           "key": "n_37",
           "x": 553,
-          "y": 200,
+          "y": 198,
         },
       ],
       "hasBranchLabels": false,
@@ -17535,7 +17535,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_12",
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
@@ -17544,12 +17544,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_72",
           "x": 693,
-          "y": 60,
+          "y": 58,
         },
         {
           "key": "n_73",
           "x": 693,
-          "y": 130,
+          "y": 128,
         },
       ],
       "hasBranchLabels": false,
@@ -17558,17 +17558,17 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_35",
           "x": 553,
-          "y": 60,
+          "y": 58,
         },
         {
           "key": "n_36",
           "x": 553,
-          "y": 130,
+          "y": 128,
         },
         {
           "key": "n_37",
           "x": 553,
-          "y": 200,
+          "y": 198,
         },
       ],
     },
@@ -17577,7 +17577,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_99",
           "x": 833,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -17586,12 +17586,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_72",
           "x": 693,
-          "y": 60,
+          "y": 58,
         },
         {
           "key": "n_73",
           "x": 693,
-          "y": 130,
+          "y": 128,
         },
       ],
     },
@@ -17600,7 +17600,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_14",
           "x": 413,
-          "y": 292,
+          "y": 290,
         },
       ],
       "hasBranchLabels": false,
@@ -17610,7 +17610,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "isHidden": true,
           "key": "n_9",
           "x": 273,
-          "y": 292,
+          "y": 290,
         },
       ],
     },
@@ -17619,7 +17619,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_28",
           "x": 553,
-          "y": 292,
+          "y": 290,
         },
       ],
       "hasBranchLabels": false,
@@ -17628,7 +17628,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_14",
           "x": 413,
-          "y": 292,
+          "y": 290,
         },
       ],
     },
@@ -17637,12 +17637,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_51",
           "x": 693,
-          "y": 292,
+          "y": 290,
         },
         {
           "key": "n_52",
           "x": 693,
-          "y": 362,
+          "y": 360,
         },
       ],
       "hasBranchLabels": false,
@@ -17651,7 +17651,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_28",
           "x": 553,
-          "y": 292,
+          "y": 290,
         },
       ],
     },
@@ -17660,7 +17660,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_85",
           "x": 833,
-          "y": 292,
+          "y": 290,
         },
       ],
       "hasBranchLabels": false,
@@ -17669,12 +17669,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_51",
           "x": 693,
-          "y": 292,
+          "y": 290,
         },
         {
           "key": "n_52",
           "x": 693,
-          "y": 362,
+          "y": 360,
         },
       ],
     },
@@ -17683,7 +17683,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_16",
           "x": 273,
-          "y": 432,
+          "y": 430,
         },
       ],
       "hasBranchLabels": false,
@@ -17693,7 +17693,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "isHidden": true,
           "key": "n_10",
           "x": 273,
-          "y": 432,
+          "y": 430,
         },
       ],
     },
@@ -17702,7 +17702,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_31",
           "x": 413,
-          "y": 432,
+          "y": 430,
         },
       ],
       "hasBranchLabels": false,
@@ -17711,7 +17711,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_16",
           "x": 273,
-          "y": 432,
+          "y": 430,
         },
       ],
     },
@@ -17720,7 +17720,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_57",
           "x": 553,
-          "y": 432,
+          "y": 430,
         },
       ],
       "hasBranchLabels": false,
@@ -17729,7 +17729,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_31",
           "x": 413,
-          "y": 432,
+          "y": 430,
         },
       ],
     },
@@ -17738,7 +17738,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_76",
           "x": 693,
-          "y": 432,
+          "y": 430,
         },
       ],
       "hasBranchLabels": false,
@@ -17747,7 +17747,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_57",
           "x": 553,
-          "y": 432,
+          "y": 430,
         },
       ],
     },
@@ -17756,7 +17756,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_92",
           "x": 833,
-          "y": 432,
+          "y": 430,
         },
       ],
       "hasBranchLabels": false,
@@ -17765,7 +17765,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_76",
           "x": 693,
-          "y": 432,
+          "y": 430,
         },
       ],
     },
@@ -17774,7 +17774,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_104",
           "x": 973,
-          "y": 432,
+          "y": 430,
         },
       ],
       "hasBranchLabels": false,
@@ -17783,7 +17783,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_92",
           "x": 833,
-          "y": 432,
+          "y": 430,
         },
       ],
     },
@@ -17792,7 +17792,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_111",
           "x": 1113,
-          "y": 432,
+          "y": 430,
         },
       ],
       "hasBranchLabels": false,
@@ -17801,7 +17801,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_104",
           "x": 973,
-          "y": 432,
+          "y": 430,
         },
       ],
     },
@@ -17811,7 +17811,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "isPlaceholder": true,
           "key": "end-node",
           "x": 1211,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -17820,22 +17820,22 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "key": "n_99",
           "x": 833,
-          "y": 60,
+          "y": 58,
         },
         {
           "key": "n_85",
           "x": 833,
-          "y": 292,
+          "y": 290,
         },
         {
           "key": "n_111",
           "x": 1113,
-          "y": 432,
+          "y": 430,
         },
       ],
     },
   ],
-  "measuredHeight": 480,
+  "measuredHeight": 478,
   "measuredWidth": 1246,
   "nodes": [
     {
@@ -17851,7 +17851,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -17873,7 +17873,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -17896,7 +17896,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -17919,7 +17919,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 130,
+      "y": 128,
     },
     {
       "children": [],
@@ -17942,7 +17942,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 200,
+      "y": 198,
     },
     {
       "children": [],
@@ -17965,7 +17965,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -17988,7 +17988,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 130,
+      "y": 128,
     },
     {
       "children": [],
@@ -18010,7 +18010,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -18032,7 +18032,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [],
@@ -18054,7 +18054,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [],
@@ -18077,7 +18077,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [],
@@ -18100,7 +18100,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 362,
+      "y": 360,
     },
     {
       "children": [],
@@ -18122,7 +18122,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 292,
+      "y": 290,
     },
     {
       "children": [],
@@ -18144,7 +18144,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -18166,7 +18166,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -18188,7 +18188,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -18210,7 +18210,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -18232,7 +18232,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -18254,7 +18254,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 973,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -18276,7 +18276,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "stage",
       "width": 140,
       "x": 1113,
-      "y": 432,
+      "y": 430,
     },
     {
       "children": [],
@@ -18291,7 +18291,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "type": "end",
       "width": 35,
       "x": 1211,
-      "y": 60,
+      "y": 58,
     },
   ],
   "smallLabels": [
@@ -18309,7 +18309,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Checkout",
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_small_n_35",
@@ -18325,7 +18325,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "A1",
       "x": 553,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_small_n_36",
@@ -18341,7 +18341,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "A2",
       "x": 553,
-      "y": 130,
+      "y": 128,
     },
     {
       "key": "l_small_n_37",
@@ -18357,7 +18357,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "A3",
       "x": 553,
-      "y": 200,
+      "y": 198,
     },
     {
       "key": "l_small_n_72",
@@ -18373,7 +18373,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "A1",
       "x": 693,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_small_n_73",
@@ -18389,7 +18389,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "A2",
       "x": 693,
-      "y": 130,
+      "y": 128,
     },
     {
       "key": "l_small_n_99",
@@ -18405,7 +18405,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Coverage",
       "x": 833,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_small_n_14",
@@ -18421,7 +18421,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Checkout",
       "x": 413,
-      "y": 292,
+      "y": 290,
     },
     {
       "key": "l_small_n_28",
@@ -18437,7 +18437,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Build",
       "x": 553,
-      "y": 292,
+      "y": 290,
     },
     {
       "key": "l_small_n_51",
@@ -18453,7 +18453,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "B1",
       "x": 693,
-      "y": 292,
+      "y": 290,
     },
     {
       "key": "l_small_n_52",
@@ -18469,7 +18469,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "B2",
       "x": 693,
-      "y": 362,
+      "y": 360,
     },
     {
       "key": "l_small_n_85",
@@ -18485,7 +18485,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Archive",
       "x": 833,
-      "y": 292,
+      "y": 290,
     },
     {
       "key": "l_small_n_16",
@@ -18501,7 +18501,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Stage - 1",
       "x": 273,
-      "y": 432,
+      "y": 430,
     },
     {
       "key": "l_small_n_31",
@@ -18517,7 +18517,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Stage - 2",
       "x": 413,
-      "y": 432,
+      "y": 430,
     },
     {
       "key": "l_small_n_57",
@@ -18533,7 +18533,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Stage - 3",
       "x": 553,
-      "y": 432,
+      "y": 430,
     },
     {
       "key": "l_small_n_76",
@@ -18549,7 +18549,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Stage - 4",
       "x": 693,
-      "y": 432,
+      "y": 430,
     },
     {
       "key": "l_small_n_92",
@@ -18565,7 +18565,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Stage - 5",
       "x": 833,
-      "y": 432,
+      "y": 430,
     },
     {
       "key": "l_small_n_104",
@@ -18581,7 +18581,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Stage - 6",
       "x": 973,
-      "y": 432,
+      "y": 430,
     },
     {
       "key": "l_small_n_111",
@@ -18597,7 +18597,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       },
       "text": "Stage - 7",
       "x": 1113,
-      "y": 432,
+      "y": 430,
     },
   ],
   "timings": [],
@@ -18621,7 +18621,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -18643,7 +18643,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -18665,7 +18665,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -18687,7 +18687,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -18709,7 +18709,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -18723,7 +18723,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "type": "end",
           "width": 35,
           "x": 651,
-          "y": 16,
+          "y": 14,
         },
       ],
       "height": 48,
@@ -18737,7 +18737,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "root",
       "width": 686,
       "x": 0,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -18751,7 +18751,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -18773,7 +18773,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -18795,7 +18795,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -18817,7 +18817,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -18839,7 +18839,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -18853,7 +18853,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "end",
       "width": 35,
       "x": 651,
-      "y": 16,
+      "y": 14,
     },
   ],
   "bigLabels": [],
@@ -18864,7 +18864,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "key": "n_4",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -18874,7 +18874,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -18883,7 +18883,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "key": "n_6",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -18892,7 +18892,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "key": "n_4",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -18901,7 +18901,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "key": "n_10",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -18910,7 +18910,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "key": "n_6",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -18919,7 +18919,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "key": "n_17",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -18928,7 +18928,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "key": "n_10",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -18938,7 +18938,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "isPlaceholder": true,
           "key": "end-node",
           "x": 651,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -18947,12 +18947,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "key": "n_17",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
   ],
-  "measuredHeight": 64,
+  "measuredHeight": 62,
   "measuredWidth": 686,
   "nodes": [
     {
@@ -18967,7 +18967,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -18989,7 +18989,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -19011,7 +19011,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -19033,7 +19033,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -19055,7 +19055,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -19069,7 +19069,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "end",
       "width": 35,
       "x": 651,
-      "y": 16,
+      "y": 14,
     },
   ],
   "smallLabels": [],
@@ -19088,7 +19088,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       },
       "text": "",
       "x": 133,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_6",
@@ -19104,7 +19104,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       },
       "text": "",
       "x": 273,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_10",
@@ -19120,7 +19120,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       },
       "text": "",
       "x": 413,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_17",
@@ -19136,7 +19136,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       },
       "text": "",
       "x": 553,
-      "y": 71,
+      "y": 69,
     },
   ],
 }
@@ -19160,7 +19160,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [
@@ -19185,7 +19185,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
               "type": "stage",
               "width": 140,
               "x": 133,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [],
@@ -19207,7 +19207,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
               "type": "stage",
               "width": 140,
               "x": 273,
-              "y": 60,
+              "y": 58,
             },
           ],
           "firstChildIsSkipped": true,
@@ -19230,7 +19230,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "type": "stage",
           "width": 280,
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -19252,7 +19252,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -19267,7 +19267,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "type": "end",
           "width": 35,
           "x": 511,
-          "y": 60,
+          "y": 58,
         },
       ],
       "height": 48,
@@ -19281,7 +19281,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "root",
       "width": 546,
       "x": 0,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -19296,7 +19296,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [
@@ -19321,7 +19321,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -19343,7 +19343,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
       ],
       "firstChildIsSkipped": true,
@@ -19366,7 +19366,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 280,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -19389,7 +19389,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -19411,7 +19411,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -19433,7 +19433,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -19448,7 +19448,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "end",
       "width": 35,
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "bigLabels": [
@@ -19460,7 +19460,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "stage": undefined,
       "text": "Start",
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_n_4",
@@ -19476,7 +19476,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       },
       "text": "Wrapper",
       "x": 203,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_6",
@@ -19492,7 +19492,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       },
       "text": "Skipped 1",
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_end-node",
@@ -19502,7 +19502,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "stage": undefined,
       "text": "End",
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "branchLabels": [],
@@ -19514,7 +19514,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "isHidden": true,
           "key": "n_4",
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -19524,7 +19524,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
@@ -19533,7 +19533,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "key": "n_10",
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -19542,7 +19542,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "isSkipped": true,
           "key": "n_6",
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
       ],
       "sourceNodes": [
@@ -19551,7 +19551,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "isHidden": true,
           "key": "n_4",
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
@@ -19560,7 +19560,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "key": "n_17",
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -19569,7 +19569,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "key": "n_10",
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
@@ -19579,7 +19579,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "isPlaceholder": true,
           "key": "end-node",
           "x": 511,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -19588,12 +19588,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "key": "n_17",
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
   ],
-  "measuredHeight": 108,
+  "measuredHeight": 106,
   "measuredWidth": 546,
   "nodes": [
     {
@@ -19609,7 +19609,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -19632,7 +19632,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -19654,7 +19654,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -19676,7 +19676,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -19691,7 +19691,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "type": "end",
       "width": 35,
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "smallLabels": [
@@ -19709,7 +19709,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       },
       "text": "Not skipped",
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_small_n_17",
@@ -19725,7 +19725,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       },
       "text": "Next",
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
   ],
   "timings": [],
@@ -19749,7 +19749,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -19771,7 +19771,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -19793,7 +19793,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -19815,7 +19815,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -19837,7 +19837,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -19851,7 +19851,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "type": "end",
           "width": 35,
           "x": 651,
-          "y": 16,
+          "y": 14,
         },
       ],
       "height": 48,
@@ -19865,7 +19865,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "root",
       "width": 686,
       "x": 0,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -19879,7 +19879,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -19901,7 +19901,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -19923,7 +19923,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -19945,7 +19945,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -19967,7 +19967,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -19981,7 +19981,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "end",
       "width": 35,
       "x": 651,
-      "y": 16,
+      "y": 14,
     },
   ],
   "bigLabels": [],
@@ -19992,7 +19992,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "key": "n_4",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -20002,7 +20002,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -20011,7 +20011,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "key": "n_6",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -20020,7 +20020,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "key": "n_4",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -20029,7 +20029,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "key": "n_11",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -20038,7 +20038,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "key": "n_6",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -20047,7 +20047,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "key": "n_17",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -20056,7 +20056,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "key": "n_11",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -20066,7 +20066,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "isPlaceholder": true,
           "key": "end-node",
           "x": 651,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -20075,12 +20075,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "key": "n_17",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
   ],
-  "measuredHeight": 64,
+  "measuredHeight": 62,
   "measuredWidth": 686,
   "nodes": [
     {
@@ -20095,7 +20095,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -20117,7 +20117,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -20139,7 +20139,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -20161,7 +20161,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -20183,7 +20183,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -20197,7 +20197,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "end",
       "width": 35,
       "x": 651,
-      "y": 16,
+      "y": 14,
     },
   ],
   "smallLabels": [],
@@ -20216,7 +20216,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       },
       "text": "",
       "x": 133,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_6",
@@ -20232,7 +20232,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       },
       "text": "",
       "x": 273,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_11",
@@ -20248,7 +20248,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       },
       "text": "",
       "x": 413,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_17",
@@ -20264,7 +20264,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       },
       "text": "",
       "x": 553,
-      "y": 71,
+      "y": 69,
     },
   ],
 }
@@ -20288,7 +20288,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [
@@ -20312,7 +20312,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
               "type": "stage",
               "width": 140,
               "x": 133,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [],
@@ -20335,7 +20335,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
               "type": "stage",
               "width": 140,
               "x": 273,
-              "y": 60,
+              "y": 58,
             },
           ],
           "hasBigLabel": true,
@@ -20357,7 +20357,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "type": "stage",
           "width": 280,
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -20379,7 +20379,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -20394,7 +20394,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "type": "end",
           "width": 35,
           "x": 511,
-          "y": 60,
+          "y": 58,
         },
       ],
       "height": 48,
@@ -20408,7 +20408,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "root",
       "width": 546,
       "x": 0,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -20423,7 +20423,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [
@@ -20447,7 +20447,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -20470,7 +20470,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBigLabel": true,
@@ -20492,7 +20492,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 280,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -20514,7 +20514,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -20537,7 +20537,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -20559,7 +20559,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -20574,7 +20574,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "end",
       "width": 35,
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "bigLabels": [
@@ -20586,7 +20586,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "stage": undefined,
       "text": "Start",
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_n_4",
@@ -20602,7 +20602,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       },
       "text": "Wrapper",
       "x": 203,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_11",
@@ -20618,7 +20618,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       },
       "text": "Skipped 1",
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_end-node",
@@ -20628,7 +20628,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "stage": undefined,
       "text": "End",
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "branchLabels": [],
@@ -20638,7 +20638,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "key": "n_6",
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -20648,7 +20648,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
@@ -20657,7 +20657,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "key": "n_17",
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -20666,14 +20666,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "isSkipped": true,
           "key": "n_11",
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
       ],
       "sourceNodes": [
         {
           "key": "n_6",
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
@@ -20683,7 +20683,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "isPlaceholder": true,
           "key": "end-node",
           "x": 511,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -20692,12 +20692,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "key": "n_17",
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
   ],
-  "measuredHeight": 108,
+  "measuredHeight": 106,
   "measuredWidth": 546,
   "nodes": [
     {
@@ -20713,7 +20713,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -20735,7 +20735,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -20758,7 +20758,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -20780,7 +20780,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -20795,7 +20795,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "type": "end",
       "width": 35,
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "smallLabels": [
@@ -20813,7 +20813,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       },
       "text": "Not skipped",
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_small_n_17",
@@ -20829,7 +20829,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       },
       "text": "Next",
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
   ],
   "timings": [],
@@ -20853,7 +20853,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -20875,7 +20875,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -20897,7 +20897,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -20919,7 +20919,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -20941,7 +20941,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -20955,7 +20955,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "type": "end",
           "width": 35,
           "x": 651,
-          "y": 16,
+          "y": 14,
         },
       ],
       "height": 48,
@@ -20969,7 +20969,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "root",
       "width": 686,
       "x": 0,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -20983,7 +20983,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -21005,7 +21005,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -21027,7 +21027,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -21049,7 +21049,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -21071,7 +21071,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -21085,7 +21085,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "end",
       "width": 35,
       "x": 651,
-      "y": 16,
+      "y": 14,
     },
   ],
   "bigLabels": [],
@@ -21096,7 +21096,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "key": "n_4",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -21106,7 +21106,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -21115,7 +21115,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "key": "n_6",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -21124,7 +21124,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "key": "n_4",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -21133,7 +21133,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "key": "n_10",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -21142,7 +21142,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "key": "n_6",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -21151,7 +21151,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "key": "n_16",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -21160,7 +21160,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "key": "n_10",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -21170,7 +21170,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "isPlaceholder": true,
           "key": "end-node",
           "x": 651,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -21179,12 +21179,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "key": "n_16",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
   ],
-  "measuredHeight": 64,
+  "measuredHeight": 62,
   "measuredWidth": 686,
   "nodes": [
     {
@@ -21199,7 +21199,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -21221,7 +21221,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -21243,7 +21243,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -21265,7 +21265,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -21287,7 +21287,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -21301,7 +21301,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "end",
       "width": 35,
       "x": 651,
-      "y": 16,
+      "y": 14,
     },
   ],
   "smallLabels": [],
@@ -21320,7 +21320,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       },
       "text": "",
       "x": 133,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_6",
@@ -21336,7 +21336,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       },
       "text": "",
       "x": 273,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_10",
@@ -21352,7 +21352,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       },
       "text": "",
       "x": 413,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_16",
@@ -21368,7 +21368,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       },
       "text": "",
       "x": 553,
-      "y": 71,
+      "y": 69,
     },
   ],
 }
@@ -21392,7 +21392,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [
@@ -21417,7 +21417,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
               "type": "stage",
               "width": 140,
               "x": 133,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [],
@@ -21440,7 +21440,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
               "type": "stage",
               "width": 140,
               "x": 273,
-              "y": 60,
+              "y": 58,
             },
           ],
           "firstChildIsSkipped": true,
@@ -21463,7 +21463,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "type": "stage",
           "width": 280,
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -21485,7 +21485,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -21500,7 +21500,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "type": "end",
           "width": 35,
           "x": 511,
-          "y": 60,
+          "y": 58,
         },
       ],
       "height": 48,
@@ -21514,7 +21514,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "root",
       "width": 546,
       "x": 0,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -21529,7 +21529,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [
@@ -21554,7 +21554,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -21577,7 +21577,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
       ],
       "firstChildIsSkipped": true,
@@ -21600,7 +21600,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 280,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -21623,7 +21623,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -21646,7 +21646,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -21668,7 +21668,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -21683,7 +21683,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "end",
       "width": 35,
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "bigLabels": [
@@ -21695,7 +21695,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "stage": undefined,
       "text": "Start",
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_n_4",
@@ -21711,7 +21711,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       },
       "text": "Wrapper",
       "x": 203,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_6",
@@ -21727,7 +21727,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       },
       "text": "Skipped 1",
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_n_10",
@@ -21743,7 +21743,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       },
       "text": "Skipped 2",
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_end-node",
@@ -21753,7 +21753,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "stage": undefined,
       "text": "End",
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "branchLabels": [],
@@ -21765,7 +21765,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "isHidden": true,
           "key": "n_4",
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -21775,7 +21775,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
@@ -21784,7 +21784,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "key": "n_16",
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -21793,13 +21793,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "isSkipped": true,
           "key": "n_6",
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "isSkipped": true,
           "key": "n_10",
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
       ],
       "sourceNodes": [
@@ -21808,7 +21808,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "isHidden": true,
           "key": "n_4",
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
@@ -21818,7 +21818,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "isPlaceholder": true,
           "key": "end-node",
           "x": 511,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -21827,12 +21827,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "key": "n_16",
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
   ],
-  "measuredHeight": 108,
+  "measuredHeight": 106,
   "measuredWidth": 546,
   "nodes": [
     {
@@ -21848,7 +21848,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -21871,7 +21871,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -21894,7 +21894,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -21916,7 +21916,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -21931,7 +21931,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "type": "end",
       "width": 35,
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "smallLabels": [
@@ -21949,7 +21949,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       },
       "text": "Next",
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
   ],
   "timings": [],
@@ -21973,7 +21973,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -21995,7 +21995,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -22017,7 +22017,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -22039,7 +22039,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -22061,7 +22061,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "stage",
           "width": 140,
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -22083,7 +22083,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "stage",
           "width": 140,
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -22105,7 +22105,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "stage",
           "width": 140,
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
         {
           "children": [],
@@ -22119,7 +22119,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "end",
           "width": 35,
           "x": 931,
-          "y": 16,
+          "y": 14,
         },
       ],
       "height": 48,
@@ -22133,7 +22133,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "root",
       "width": 966,
       "x": 0,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22147,7 +22147,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22169,7 +22169,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22191,7 +22191,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22213,7 +22213,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22235,7 +22235,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22257,7 +22257,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22279,7 +22279,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22293,7 +22293,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "end",
       "width": 35,
       "x": 931,
-      "y": 16,
+      "y": 14,
     },
   ],
   "bigLabels": [],
@@ -22304,7 +22304,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_4",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -22314,7 +22314,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -22323,7 +22323,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_9",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -22332,7 +22332,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_4",
           "x": 133,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -22341,7 +22341,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_10",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -22350,7 +22350,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_9",
           "x": 273,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -22359,7 +22359,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_20",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -22368,7 +22368,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_10",
           "x": 413,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -22377,7 +22377,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_21",
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -22386,7 +22386,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_20",
           "x": 553,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -22395,7 +22395,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_38",
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -22404,7 +22404,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_21",
           "x": 693,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
@@ -22414,7 +22414,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "isPlaceholder": true,
           "key": "end-node",
           "x": 931,
-          "y": 16,
+          "y": 14,
         },
       ],
       "hasBranchLabels": false,
@@ -22423,12 +22423,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_38",
           "x": 833,
-          "y": 16,
+          "y": 14,
         },
       ],
     },
   ],
-  "measuredHeight": 64,
+  "measuredHeight": 62,
   "measuredWidth": 966,
   "nodes": [
     {
@@ -22443,7 +22443,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22465,7 +22465,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22487,7 +22487,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22509,7 +22509,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22531,7 +22531,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 553,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22553,7 +22553,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 693,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22575,7 +22575,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 833,
-      "y": 16,
+      "y": 14,
     },
     {
       "children": [],
@@ -22589,7 +22589,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "end",
       "width": 35,
       "x": 931,
-      "y": 16,
+      "y": 14,
     },
   ],
   "smallLabels": [],
@@ -22608,7 +22608,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       },
       "text": "",
       "x": 133,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_9",
@@ -22624,7 +22624,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       },
       "text": "",
       "x": 273,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_10",
@@ -22640,7 +22640,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       },
       "text": "",
       "x": 413,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_20",
@@ -22656,7 +22656,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       },
       "text": "",
       "x": 553,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_21",
@@ -22672,7 +22672,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       },
       "text": "",
       "x": 693,
-      "y": 71,
+      "y": 69,
     },
     {
       "key": "l_t_n_38",
@@ -22688,7 +22688,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       },
       "text": "",
       "x": 833,
-      "y": 71,
+      "y": 69,
     },
   ],
 }
@@ -22712,7 +22712,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [
@@ -22739,7 +22739,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
                   "type": "stage",
                   "width": 140,
                   "x": 133,
-                  "y": 60,
+                  "y": 58,
                 },
                 {
                   "children": [],
@@ -22762,7 +22762,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
                   "type": "stage",
                   "width": 140,
                   "x": 133,
-                  "y": 130,
+                  "y": 128,
                 },
               ],
               "hasBigLabel": true,
@@ -22785,7 +22785,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
               "type": "stage",
               "width": 140,
               "x": 133,
-              "y": 60,
+              "y": 58,
             },
             {
               "allChildrenSkipped": true,
@@ -22812,7 +22812,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
                   "type": "stage",
                   "width": 140,
                   "x": 273,
-                  "y": 60,
+                  "y": 58,
                 },
                 {
                   "children": [],
@@ -22836,7 +22836,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
                   "type": "stage",
                   "width": 140,
                   "x": 273,
-                  "y": 130,
+                  "y": 128,
                 },
               ],
               "firstChildIsSkipped": true,
@@ -22860,7 +22860,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
               "type": "stage",
               "width": 140,
               "x": 273,
-              "y": 60,
+              "y": 58,
             },
           ],
           "hasBigLabel": true,
@@ -22882,7 +22882,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "stage",
           "width": 280,
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -22904,7 +22904,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -22919,7 +22919,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "end",
           "width": 35,
           "x": 511,
-          "y": 60,
+          "y": 58,
         },
       ],
       "height": 118,
@@ -22933,7 +22933,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "root",
       "width": 546,
       "x": 0,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -22948,7 +22948,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [
@@ -22975,7 +22975,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
               "type": "stage",
               "width": 140,
               "x": 133,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [],
@@ -22998,7 +22998,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
               "type": "stage",
               "width": 140,
               "x": 133,
-              "y": 130,
+              "y": 128,
             },
           ],
           "hasBigLabel": true,
@@ -23021,7 +23021,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "allChildrenSkipped": true,
@@ -23048,7 +23048,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
               "type": "stage",
               "width": 140,
               "x": 273,
-              "y": 60,
+              "y": 58,
             },
             {
               "children": [],
@@ -23072,7 +23072,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
               "type": "stage",
               "width": 140,
               "x": 273,
-              "y": 130,
+              "y": 128,
             },
           ],
           "firstChildIsSkipped": true,
@@ -23096,7 +23096,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBigLabel": true,
@@ -23118,7 +23118,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 280,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [
@@ -23143,7 +23143,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -23166,7 +23166,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 130,
+          "y": 128,
         },
       ],
       "hasBigLabel": true,
@@ -23189,7 +23189,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -23212,7 +23212,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -23235,7 +23235,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 130,
+      "y": 128,
     },
     {
       "allChildrenSkipped": true,
@@ -23262,7 +23262,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
         {
           "children": [],
@@ -23286,7 +23286,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 130,
+          "y": 128,
         },
       ],
       "firstChildIsSkipped": true,
@@ -23310,7 +23310,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -23334,7 +23334,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -23358,7 +23358,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 130,
+      "y": 128,
     },
     {
       "children": [],
@@ -23380,7 +23380,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -23395,7 +23395,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "end",
       "width": 35,
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "bigLabels": [
@@ -23407,7 +23407,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "stage": undefined,
       "text": "Start",
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_n_4",
@@ -23423,7 +23423,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       },
       "text": "Wrapper",
       "x": 203,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_6",
@@ -23439,7 +23439,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       },
       "text": "one",
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_n_17",
@@ -23455,7 +23455,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       },
       "text": "two",
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_big_end-node",
@@ -23465,7 +23465,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "stage": undefined,
       "text": "End",
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "branchLabels": [],
@@ -23475,12 +23475,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_9",
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "key": "n_10",
           "x": 133,
-          "y": 130,
+          "y": 128,
         },
       ],
       "hasBranchLabels": false,
@@ -23490,7 +23490,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
@@ -23500,13 +23500,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "isSkipped": true,
           "key": "n_20",
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
         {
           "isSkipped": true,
           "key": "n_21",
           "x": 273,
-          "y": 130,
+          "y": 128,
         },
       ],
       "hasBranchLabels": false,
@@ -23515,12 +23515,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_9",
           "x": 133,
-          "y": 60,
+          "y": 58,
         },
         {
           "key": "n_10",
           "x": 133,
-          "y": 130,
+          "y": 128,
         },
       ],
     },
@@ -23534,7 +23534,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "isHidden": true,
           "key": "n_17",
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
@@ -23543,7 +23543,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_38",
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -23553,13 +23553,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "isSkipped": true,
           "key": "n_20",
           "x": 273,
-          "y": 60,
+          "y": 58,
         },
         {
           "isSkipped": true,
           "key": "n_21",
           "x": 273,
-          "y": 130,
+          "y": 128,
         },
       ],
     },
@@ -23569,7 +23569,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "isPlaceholder": true,
           "key": "end-node",
           "x": 511,
-          "y": 60,
+          "y": 58,
         },
       ],
       "hasBranchLabels": false,
@@ -23578,12 +23578,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "key": "n_38",
           "x": 413,
-          "y": 60,
+          "y": 58,
         },
       ],
     },
   ],
-  "measuredHeight": 178,
+  "measuredHeight": 176,
   "measuredWidth": 546,
   "nodes": [
     {
@@ -23599,7 +23599,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -23622,7 +23622,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -23645,7 +23645,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 130,
+      "y": 128,
     },
     {
       "children": [],
@@ -23669,7 +23669,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -23693,7 +23693,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 130,
+      "y": 128,
     },
     {
       "children": [],
@@ -23715,7 +23715,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
     {
       "children": [],
@@ -23730,7 +23730,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "type": "end",
       "width": 35,
       "x": 511,
-      "y": 60,
+      "y": 58,
     },
   ],
   "smallLabels": [
@@ -23748,7 +23748,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       },
       "text": "nested 1",
       "x": 133,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_small_n_10",
@@ -23764,7 +23764,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       },
       "text": "nested 2",
       "x": 133,
-      "y": 130,
+      "y": 128,
     },
     {
       "key": "l_small_n_20",
@@ -23780,7 +23780,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       },
       "text": "Skipped 1",
       "x": 273,
-      "y": 60,
+      "y": 58,
     },
     {
       "key": "l_small_n_21",
@@ -23796,7 +23796,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       },
       "text": "Skipped 2",
       "x": 273,
-      "y": 130,
+      "y": 128,
     },
     {
       "key": "l_small_n_38",
@@ -23812,7 +23812,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       },
       "text": "Next",
       "x": 413,
-      "y": 60,
+      "y": 58,
     },
   ],
   "timings": [],
@@ -23837,7 +23837,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -23859,7 +23859,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [
@@ -23884,7 +23884,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
               "type": "stage",
               "width": 140,
               "x": 273,
-              "y": 38,
+              "y": 36,
             },
             {
               "children": [],
@@ -23907,7 +23907,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
               "type": "stage",
               "width": 140,
               "x": 273,
-              "y": 108,
+              "y": 106,
             },
             {
               "children": [],
@@ -23931,7 +23931,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
               "type": "stage",
               "width": 140,
               "x": 273,
-              "y": 178,
+              "y": 176,
             },
           ],
           "hasBigLabel": true,
@@ -23954,7 +23954,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -23977,7 +23977,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -23992,7 +23992,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "type": "end",
           "width": 35,
           "x": 511,
-          "y": 38,
+          "y": 36,
         },
       ],
       "height": 188,
@@ -24006,7 +24006,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "root",
       "width": 546,
       "x": 0,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24021,7 +24021,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24043,7 +24043,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [
@@ -24068,7 +24068,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -24091,7 +24091,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 108,
+          "y": 106,
         },
         {
           "children": [],
@@ -24115,7 +24115,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 178,
+          "y": 176,
         },
       ],
       "hasBigLabel": true,
@@ -24138,7 +24138,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24161,7 +24161,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24184,7 +24184,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 108,
+      "y": 106,
     },
     {
       "children": [],
@@ -24208,7 +24208,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 178,
+      "y": 176,
     },
     {
       "children": [],
@@ -24231,7 +24231,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24246,7 +24246,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "end",
       "width": 35,
       "x": 511,
-      "y": 38,
+      "y": 36,
     },
   ],
   "bigLabels": [
@@ -24258,7 +24258,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "stage": undefined,
       "text": "Start",
       "x": 35,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_12",
@@ -24274,7 +24274,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       },
       "text": "Parallel Stage",
       "x": 273,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_54",
@@ -24290,7 +24290,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       },
       "text": "Skipped stage",
       "x": 413,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_end-node",
@@ -24300,7 +24300,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "stage": undefined,
       "text": "End",
       "x": 511,
-      "y": 38,
+      "y": 36,
     },
   ],
   "branchLabels": [],
@@ -24310,7 +24310,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "key": "n_6",
           "x": 133,
-          "y": 38,
+          "y": 36,
         },
       ],
       "hasBranchLabels": false,
@@ -24320,7 +24320,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 38,
+          "y": 36,
         },
       ],
     },
@@ -24329,17 +24329,17 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "key": "n_16",
           "x": 273,
-          "y": 38,
+          "y": 36,
         },
         {
           "key": "n_17",
           "x": 273,
-          "y": 108,
+          "y": 106,
         },
         {
           "key": "n_18",
           "x": 273,
-          "y": 178,
+          "y": 176,
         },
       ],
       "hasBranchLabels": false,
@@ -24348,7 +24348,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "key": "n_6",
           "x": 133,
-          "y": 38,
+          "y": 36,
         },
       ],
     },
@@ -24358,7 +24358,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "isPlaceholder": true,
           "key": "end-node",
           "x": 511,
-          "y": 38,
+          "y": 36,
         },
       ],
       "hasBranchLabels": false,
@@ -24367,29 +24367,29 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "isSkipped": true,
           "key": "n_54",
           "x": 413,
-          "y": 38,
+          "y": 36,
         },
       ],
       "sourceNodes": [
         {
           "key": "n_16",
           "x": 273,
-          "y": 38,
+          "y": 36,
         },
         {
           "key": "n_17",
           "x": 273,
-          "y": 108,
+          "y": 106,
         },
         {
           "key": "n_18",
           "x": 273,
-          "y": 178,
+          "y": 176,
         },
       ],
     },
   ],
-  "measuredHeight": 226,
+  "measuredHeight": 224,
   "measuredWidth": 546,
   "nodes": [
     {
@@ -24405,7 +24405,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24427,7 +24427,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24450,7 +24450,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24473,7 +24473,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 108,
+      "y": 106,
     },
     {
       "children": [],
@@ -24497,7 +24497,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 178,
+      "y": 176,
     },
     {
       "children": [],
@@ -24520,7 +24520,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24535,7 +24535,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "end",
       "width": 35,
       "x": 511,
-      "y": 38,
+      "y": 36,
     },
   ],
   "smallLabels": [
@@ -24553,7 +24553,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       },
       "text": "Non-Parallel Stage",
       "x": 133,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_small_n_16",
@@ -24569,7 +24569,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       },
       "text": "Branch A",
       "x": 273,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_small_n_17",
@@ -24585,7 +24585,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       },
       "text": "Branch B",
       "x": 273,
-      "y": 108,
+      "y": 106,
     },
     {
       "key": "l_small_n_18",
@@ -24602,7 +24602,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       },
       "text": "Branch C",
       "x": 273,
-      "y": 178,
+      "y": 176,
     },
   ],
   "timings": [],
@@ -24627,7 +24627,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "type": "start",
           "width": 98,
           "x": 35,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -24649,7 +24649,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "type": "stage",
           "width": 140,
           "x": 133,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -24672,7 +24672,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "type": "stage",
           "width": 140,
           "x": 273,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -24695,7 +24695,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "type": "stage",
           "width": 140,
           "x": 413,
-          "y": 38,
+          "y": 36,
         },
         {
           "children": [],
@@ -24710,7 +24710,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "type": "end",
           "width": 35,
           "x": 511,
-          "y": 38,
+          "y": 36,
         },
       ],
       "height": 48,
@@ -24724,7 +24724,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "root",
       "width": 546,
       "x": 0,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24739,7 +24739,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24761,7 +24761,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24784,7 +24784,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24807,7 +24807,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24822,7 +24822,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "end",
       "width": 35,
       "x": 511,
-      "y": 38,
+      "y": 36,
     },
   ],
   "bigLabels": [
@@ -24834,7 +24834,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "stage": undefined,
       "text": "Start",
       "x": 35,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_n_54",
@@ -24850,7 +24850,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       },
       "text": "Skipped stage",
       "x": 413,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_big_end-node",
@@ -24860,7 +24860,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "stage": undefined,
       "text": "End",
       "x": 511,
-      "y": 38,
+      "y": 36,
     },
   ],
   "branchLabels": [],
@@ -24870,7 +24870,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "key": "n_6",
           "x": 133,
-          "y": 38,
+          "y": 36,
         },
       ],
       "hasBranchLabels": false,
@@ -24880,7 +24880,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "isPlaceholder": true,
           "key": "start-node",
           "x": 35,
-          "y": 38,
+          "y": 36,
         },
       ],
     },
@@ -24889,7 +24889,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "key": "n_12",
           "x": 273,
-          "y": 38,
+          "y": 36,
         },
       ],
       "hasBranchLabels": false,
@@ -24898,7 +24898,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "key": "n_6",
           "x": 133,
-          "y": 38,
+          "y": 36,
         },
       ],
     },
@@ -24908,7 +24908,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "isPlaceholder": true,
           "key": "end-node",
           "x": 511,
-          "y": 38,
+          "y": 36,
         },
       ],
       "hasBranchLabels": false,
@@ -24917,19 +24917,19 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "isSkipped": true,
           "key": "n_54",
           "x": 413,
-          "y": 38,
+          "y": 36,
         },
       ],
       "sourceNodes": [
         {
           "key": "n_12",
           "x": 273,
-          "y": 38,
+          "y": 36,
         },
       ],
     },
   ],
-  "measuredHeight": 86,
+  "measuredHeight": 84,
   "measuredWidth": 546,
   "nodes": [
     {
@@ -24945,7 +24945,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "start",
       "width": 98,
       "x": 35,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24967,7 +24967,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 133,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -24990,7 +24990,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 273,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -25013,7 +25013,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "stage",
       "width": 140,
       "x": 413,
-      "y": 38,
+      "y": 36,
     },
     {
       "children": [],
@@ -25028,7 +25028,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       "type": "end",
       "width": 35,
       "x": 511,
-      "y": 38,
+      "y": 36,
     },
   ],
   "smallLabels": [
@@ -25046,7 +25046,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       },
       "text": "Non-Parallel Stage",
       "x": 133,
-      "y": 38,
+      "y": 36,
     },
     {
       "key": "l_small_n_12",
@@ -25063,7 +25063,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       },
       "text": "Parallel Stage",
       "x": 273,
-      "y": 38,
+      "y": 36,
     },
   ],
   "timings": [],

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/__snapshots__/NestedPipelineGraphLayout.spec.ts.snap
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/__snapshots__/NestedPipelineGraphLayout.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "children": [
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -22,7 +22,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "6",
           "isPlaceholder": false,
           "key": "n_6",
@@ -44,7 +44,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "16",
           "isPlaceholder": false,
           "key": "n_16",
@@ -66,7 +66,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "17",
           "isPlaceholder": false,
           "key": "n_17",
@@ -88,7 +88,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "26",
           "isPlaceholder": false,
           "key": "n_26",
@@ -110,7 +110,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "42",
           "isPlaceholder": false,
           "key": "n_42",
@@ -132,7 +132,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "54",
           "isPlaceholder": false,
           "key": "n_54",
@@ -153,7 +153,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -166,7 +166,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "y": 16,
         },
       ],
-      "height": 70,
+      "height": 48,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -181,7 +181,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -196,7 +196,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -218,7 +218,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "16",
       "isPlaceholder": false,
       "key": "n_16",
@@ -240,7 +240,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isPlaceholder": false,
       "key": "n_17",
@@ -262,7 +262,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "26",
       "isPlaceholder": false,
       "key": "n_26",
@@ -284,7 +284,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "42",
       "isPlaceholder": false,
       "key": "n_42",
@@ -306,7 +306,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "54",
       "isPlaceholder": false,
       "key": "n_54",
@@ -327,7 +327,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -472,12 +472,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       ],
     },
   ],
-  "measuredHeight": 86,
+  "measuredHeight": 64,
   "measuredWidth": 966,
   "nodes": [
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -492,7 +492,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -514,7 +514,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "16",
       "isPlaceholder": false,
       "key": "n_16",
@@ -536,7 +536,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isPlaceholder": false,
       "key": "n_17",
@@ -558,7 +558,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "26",
       "isPlaceholder": false,
       "key": "n_26",
@@ -580,7 +580,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "42",
       "isPlaceholder": false,
       "key": "n_42",
@@ -602,7 +602,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "54",
       "isPlaceholder": false,
       "key": "n_54",
@@ -623,7 +623,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -746,7 +746,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -761,7 +761,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "6",
           "isPlaceholder": false,
           "key": "n_6",
@@ -785,7 +785,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "16",
               "isParallel": true,
               "isPlaceholder": false,
@@ -808,14 +808,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "17",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_17",
               "name": "Branch B",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "17",
@@ -833,7 +833,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "26",
                   "isPlaceholder": false,
                   "key": "n_26",
@@ -855,7 +855,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "42",
                   "isPlaceholder": false,
                   "key": "n_42",
@@ -876,7 +876,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
                 },
               ],
               "hasBranchLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "18",
               "isHidden": true,
               "isParallel": true,
@@ -884,7 +884,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
               "key": "n_18",
               "name": "Branch C",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "18",
@@ -900,7 +900,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 210,
+          "height": 188,
           "id": "12",
           "isHidden": true,
           "isPlaceholder": false,
@@ -923,7 +923,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "54",
           "isPlaceholder": false,
           "isSkipped": true,
@@ -946,7 +946,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -959,7 +959,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "y": 38,
         },
       ],
-      "height": 210,
+      "height": 188,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -975,7 +975,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -990,7 +990,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -1014,7 +1014,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "16",
           "isParallel": true,
           "isPlaceholder": false,
@@ -1037,14 +1037,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "17",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_17",
           "name": "Branch B",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "17",
@@ -1062,7 +1062,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "26",
               "isPlaceholder": false,
               "key": "n_26",
@@ -1084,7 +1084,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "42",
               "isPlaceholder": false,
               "key": "n_42",
@@ -1105,7 +1105,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
             },
           ],
           "hasBranchLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "18",
           "isHidden": true,
           "isParallel": true,
@@ -1113,7 +1113,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
           "key": "n_18",
           "name": "Branch C",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "18",
@@ -1129,7 +1129,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 210,
+      "height": 188,
       "id": "12",
       "isHidden": true,
       "isPlaceholder": false,
@@ -1152,7 +1152,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "16",
       "isParallel": true,
       "isPlaceholder": false,
@@ -1175,14 +1175,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_17",
       "name": "Branch B",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "17",
@@ -1200,7 +1200,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "26",
           "isPlaceholder": false,
           "key": "n_26",
@@ -1222,7 +1222,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "42",
           "isPlaceholder": false,
           "key": "n_42",
@@ -1243,7 +1243,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
         },
       ],
       "hasBranchLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "18",
       "isHidden": true,
       "isParallel": true,
@@ -1251,7 +1251,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       "key": "n_18",
       "name": "Branch C",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "18",
@@ -1267,7 +1267,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "26",
       "isPlaceholder": false,
       "key": "n_26",
@@ -1289,7 +1289,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "42",
       "isPlaceholder": false,
       "key": "n_42",
@@ -1311,7 +1311,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "54",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -1334,7 +1334,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -1542,13 +1542,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
       ],
     },
   ],
-  "measuredHeight": 248,
+  "measuredHeight": 226,
   "measuredWidth": 826,
   "nodes": [
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -1563,7 +1563,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -1585,7 +1585,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "16",
       "isParallel": true,
       "isPlaceholder": false,
@@ -1608,14 +1608,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_17",
       "name": "Branch B",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "17",
@@ -1631,7 +1631,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "26",
       "isPlaceholder": false,
       "key": "n_26",
@@ -1653,7 +1653,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "42",
       "isPlaceholder": false,
       "key": "n_42",
@@ -1675,7 +1675,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "54",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -1698,7 +1698,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > complexParallelSmokes.j
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -1804,7 +1804,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       "children": [
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -1819,7 +1819,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "6",
           "isPlaceholder": false,
           "key": "n_6",
@@ -1841,7 +1841,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "9",
           "isPlaceholder": false,
           "key": "n_9",
@@ -1863,7 +1863,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "10",
           "isPlaceholder": false,
           "key": "n_10",
@@ -1885,7 +1885,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "18",
           "isPlaceholder": false,
           "key": "n_18",
@@ -1907,7 +1907,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "19",
           "isPlaceholder": false,
           "key": "n_19",
@@ -1929,7 +1929,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "31",
           "isPlaceholder": false,
           "key": "n_31",
@@ -1951,7 +1951,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "32",
           "isPlaceholder": false,
           "key": "n_32",
@@ -1972,7 +1972,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -1985,7 +1985,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "y": 16,
         },
       ],
-      "height": 70,
+      "height": 48,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -2000,7 +2000,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -2015,7 +2015,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -2037,7 +2037,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "9",
       "isPlaceholder": false,
       "key": "n_9",
@@ -2059,7 +2059,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isPlaceholder": false,
       "key": "n_10",
@@ -2081,7 +2081,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "18",
       "isPlaceholder": false,
       "key": "n_18",
@@ -2103,7 +2103,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "19",
       "isPlaceholder": false,
       "key": "n_19",
@@ -2125,7 +2125,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "31",
       "isPlaceholder": false,
       "key": "n_31",
@@ -2147,7 +2147,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "32",
       "isPlaceholder": false,
       "key": "n_32",
@@ -2168,7 +2168,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -2331,12 +2331,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       ],
     },
   ],
-  "measuredHeight": 86,
+  "measuredHeight": 64,
   "measuredWidth": 1106,
   "nodes": [
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -2351,7 +2351,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -2373,7 +2373,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "9",
       "isPlaceholder": false,
       "key": "n_9",
@@ -2395,7 +2395,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isPlaceholder": false,
       "key": "n_10",
@@ -2417,7 +2417,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "18",
       "isPlaceholder": false,
       "key": "n_18",
@@ -2439,7 +2439,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "19",
       "isPlaceholder": false,
       "key": "n_19",
@@ -2461,7 +2461,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "31",
       "isPlaceholder": false,
       "key": "n_31",
@@ -2483,7 +2483,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "32",
       "isPlaceholder": false,
       "key": "n_32",
@@ -2504,7 +2504,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -2643,7 +2643,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -2662,7 +2662,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "9",
                   "isParallel": true,
                   "isPlaceholder": false,
@@ -2685,14 +2685,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "10",
                   "isParallel": true,
                   "isPlaceholder": false,
                   "key": "n_10",
                   "name": "branch 1.2",
                   "shiftX": 0,
-                  "shiftY": 0,
+                  "shiftY": 22,
                   "stage": {
                     "children": [],
                     "id": "10",
@@ -2708,7 +2708,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
               ],
               "hasBigLabel": true,
               "hasParallel": true,
-              "height": 140,
+              "height": 118,
               "id": "7",
               "isHidden": true,
               "isPlaceholder": false,
@@ -2733,7 +2733,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "18",
                   "isParallel": true,
                   "isPlaceholder": false,
@@ -2756,14 +2756,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "19",
                   "isParallel": true,
                   "isPlaceholder": false,
                   "key": "n_19",
                   "name": "branch 2.2",
                   "shiftX": 0,
-                  "shiftY": 0,
+                  "shiftY": 22,
                   "stage": {
                     "children": [],
                     "id": "19",
@@ -2779,7 +2779,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
               ],
               "hasBigLabel": true,
               "hasParallel": true,
-              "height": 140,
+              "height": 118,
               "id": "16",
               "isHidden": true,
               "isPlaceholder": false,
@@ -2801,7 +2801,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
             },
           ],
           "hasBigLabel": true,
-          "height": 140,
+          "height": 118,
           "id": "6",
           "isHidden": true,
           "isPlaceholder": false,
@@ -2826,7 +2826,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "31",
               "isParallel": true,
               "isPlaceholder": false,
@@ -2849,14 +2849,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "32",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_32",
               "name": "branch 3.2",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "32",
@@ -2872,7 +2872,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 140,
+          "height": 118,
           "id": "28",
           "isHidden": true,
           "isPlaceholder": false,
@@ -2895,7 +2895,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -2908,7 +2908,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           "y": 60,
         },
       ],
-      "height": 140,
+      "height": 118,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -2924,7 +2924,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -2943,7 +2943,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "9",
               "isParallel": true,
               "isPlaceholder": false,
@@ -2966,14 +2966,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "10",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_10",
               "name": "branch 1.2",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "10",
@@ -2989,7 +2989,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 140,
+          "height": 118,
           "id": "7",
           "isHidden": true,
           "isPlaceholder": false,
@@ -3014,7 +3014,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "18",
               "isParallel": true,
               "isPlaceholder": false,
@@ -3037,14 +3037,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "19",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_19",
               "name": "branch 2.2",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "19",
@@ -3060,7 +3060,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 140,
+          "height": 118,
           "id": "16",
           "isHidden": true,
           "isPlaceholder": false,
@@ -3082,7 +3082,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         },
       ],
       "hasBigLabel": true,
-      "height": 140,
+      "height": 118,
       "id": "6",
       "isHidden": true,
       "isPlaceholder": false,
@@ -3107,7 +3107,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "9",
           "isParallel": true,
           "isPlaceholder": false,
@@ -3130,14 +3130,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "10",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_10",
           "name": "branch 1.2",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "10",
@@ -3153,7 +3153,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 140,
+      "height": 118,
       "id": "7",
       "isHidden": true,
       "isPlaceholder": false,
@@ -3176,7 +3176,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "9",
       "isParallel": true,
       "isPlaceholder": false,
@@ -3199,14 +3199,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_10",
       "name": "branch 1.2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "10",
@@ -3224,7 +3224,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "18",
           "isParallel": true,
           "isPlaceholder": false,
@@ -3247,14 +3247,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "19",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_19",
           "name": "branch 2.2",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "19",
@@ -3270,7 +3270,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 140,
+      "height": 118,
       "id": "16",
       "isHidden": true,
       "isPlaceholder": false,
@@ -3293,7 +3293,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "18",
       "isParallel": true,
       "isPlaceholder": false,
@@ -3316,14 +3316,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "19",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_19",
       "name": "branch 2.2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "19",
@@ -3341,7 +3341,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "31",
           "isParallel": true,
           "isPlaceholder": false,
@@ -3364,14 +3364,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "32",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_32",
           "name": "branch 3.2",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "32",
@@ -3387,7 +3387,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 140,
+      "height": 118,
       "id": "28",
       "isHidden": true,
       "isPlaceholder": false,
@@ -3410,7 +3410,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "31",
       "isParallel": true,
       "isPlaceholder": false,
@@ -3433,14 +3433,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "32",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_32",
       "name": "branch 3.2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "32",
@@ -3456,7 +3456,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -3662,13 +3662,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
       ],
     },
   ],
-  "measuredHeight": 200,
+  "measuredHeight": 178,
   "measuredWidth": 546,
   "nodes": [
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -3683,7 +3683,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "9",
       "isParallel": true,
       "isPlaceholder": false,
@@ -3706,14 +3706,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_10",
       "name": "branch 1.2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "10",
@@ -3729,7 +3729,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "18",
       "isParallel": true,
       "isPlaceholder": false,
@@ -3752,14 +3752,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "19",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_19",
       "name": "branch 2.2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "19",
@@ -3775,7 +3775,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "31",
       "isParallel": true,
       "isPlaceholder": false,
@@ -3798,14 +3798,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "32",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_32",
       "name": "branch 3.2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "32",
@@ -3821,7 +3821,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh771_non_wrapped_paral
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -3943,7 +3943,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "children": [
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -3958,7 +3958,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "6",
           "isPlaceholder": false,
           "key": "n_6",
@@ -3980,7 +3980,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "17",
           "isPlaceholder": false,
           "key": "n_17",
@@ -4002,7 +4002,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "18",
           "isPlaceholder": false,
           "key": "n_18",
@@ -4024,7 +4024,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "35",
           "isPlaceholder": false,
           "key": "n_35",
@@ -4046,7 +4046,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "60",
           "isPlaceholder": false,
           "key": "n_60",
@@ -4068,7 +4068,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "76",
           "isPlaceholder": false,
           "key": "n_76",
@@ -4090,7 +4090,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "84",
           "isPlaceholder": false,
           "key": "n_84",
@@ -4112,7 +4112,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "37",
           "isPlaceholder": false,
           "key": "n_37",
@@ -4134,7 +4134,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "55",
           "isPlaceholder": false,
           "key": "n_55",
@@ -4156,7 +4156,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "39",
           "isPlaceholder": false,
           "key": "n_39",
@@ -4178,7 +4178,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "57",
           "isPlaceholder": false,
           "key": "n_57",
@@ -4200,7 +4200,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "71",
           "isPlaceholder": false,
           "key": "n_71",
@@ -4221,7 +4221,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -2,
           "isPlaceholder": true,
           "key": "counter-node",
@@ -4286,7 +4286,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -4299,7 +4299,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "y": 16,
         },
       ],
-      "height": 70,
+      "height": 48,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -4314,7 +4314,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -4329,7 +4329,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -4351,7 +4351,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isPlaceholder": false,
       "key": "n_17",
@@ -4373,7 +4373,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "18",
       "isPlaceholder": false,
       "key": "n_18",
@@ -4395,7 +4395,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "35",
       "isPlaceholder": false,
       "key": "n_35",
@@ -4417,7 +4417,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "60",
       "isPlaceholder": false,
       "key": "n_60",
@@ -4439,7 +4439,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "76",
       "isPlaceholder": false,
       "key": "n_76",
@@ -4461,7 +4461,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "84",
       "isPlaceholder": false,
       "key": "n_84",
@@ -4483,7 +4483,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "37",
       "isPlaceholder": false,
       "key": "n_37",
@@ -4505,7 +4505,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "55",
       "isPlaceholder": false,
       "key": "n_55",
@@ -4527,7 +4527,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "39",
       "isPlaceholder": false,
       "key": "n_39",
@@ -4549,7 +4549,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "57",
       "isPlaceholder": false,
       "key": "n_57",
@@ -4571,7 +4571,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "71",
       "isPlaceholder": false,
       "key": "n_71",
@@ -4592,7 +4592,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -2,
       "isPlaceholder": true,
       "key": "counter-node",
@@ -4657,7 +4657,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -4930,12 +4930,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       ],
     },
   ],
-  "measuredHeight": 86,
+  "measuredHeight": 64,
   "measuredWidth": 1946,
   "nodes": [
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -4950,7 +4950,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -4972,7 +4972,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isPlaceholder": false,
       "key": "n_17",
@@ -4994,7 +4994,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "18",
       "isPlaceholder": false,
       "key": "n_18",
@@ -5016,7 +5016,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "35",
       "isPlaceholder": false,
       "key": "n_35",
@@ -5038,7 +5038,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "60",
       "isPlaceholder": false,
       "key": "n_60",
@@ -5060,7 +5060,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "76",
       "isPlaceholder": false,
       "key": "n_76",
@@ -5082,7 +5082,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "84",
       "isPlaceholder": false,
       "key": "n_84",
@@ -5104,7 +5104,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "37",
       "isPlaceholder": false,
       "key": "n_37",
@@ -5126,7 +5126,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "55",
       "isPlaceholder": false,
       "key": "n_55",
@@ -5148,7 +5148,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "39",
       "isPlaceholder": false,
       "key": "n_39",
@@ -5170,7 +5170,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "57",
       "isPlaceholder": false,
       "key": "n_57",
@@ -5192,7 +5192,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "71",
       "isPlaceholder": false,
       "key": "n_71",
@@ -5213,7 +5213,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -2,
       "isPlaceholder": true,
       "key": "counter-node",
@@ -5278,7 +5278,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -5497,7 +5497,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -5512,7 +5512,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "6",
           "isPlaceholder": false,
           "key": "n_6",
@@ -5536,7 +5536,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "17",
               "isParallel": true,
               "isPlaceholder": false,
@@ -5559,7 +5559,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "18",
               "isParallel": true,
               "isPlaceholder": false,
@@ -5567,7 +5567,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "key": "n_18",
               "name": "Skipped Branch B",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "18",
@@ -5585,7 +5585,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "35",
                   "isPlaceholder": false,
                   "key": "n_35",
@@ -5607,7 +5607,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "60",
                   "isPlaceholder": false,
                   "key": "n_60",
@@ -5629,7 +5629,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                 {
                   "children": [],
                   "hasBigLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "76",
                   "isPlaceholder": false,
                   "isSkipped": true,
@@ -5652,7 +5652,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                 {
                   "children": [],
                   "hasBigLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "84",
                   "isPlaceholder": false,
                   "isSkipped": true,
@@ -5674,7 +5674,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                 },
                 {
                   "children": [],
-                  "height": 70,
+                  "height": 48,
                   "id": "100000019",
                   "isHidden": true,
                   "isPlaceholder": true,
@@ -5690,7 +5690,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               ],
               "hasBranchLabel": true,
               "hasStageEnd": true,
-              "height": 70,
+              "height": 48,
               "id": "19",
               "isHidden": true,
               "isParallel": true,
@@ -5698,7 +5698,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "key": "n_19",
               "name": "Branch C",
               "shiftX": 0,
-              "shiftY": 22,
+              "shiftY": 44,
               "stage": {
                 "children": [],
                 "id": "19",
@@ -5716,7 +5716,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                 {
                   "children": [],
                   "hasBigLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "37",
                   "isPlaceholder": false,
                   "isSkipped": true,
@@ -5739,7 +5739,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "55",
                   "isPlaceholder": false,
                   "key": "n_55",
@@ -5761,7 +5761,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               ],
               "firstChildIsSkipped": true,
               "hasBranchLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "20",
               "isHidden": true,
               "isParallel": true,
@@ -5769,7 +5769,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "key": "n_20",
               "name": "Branch D",
               "shiftX": 0,
-              "shiftY": 22,
+              "shiftY": 44,
               "stage": {
                 "children": [],
                 "id": "20",
@@ -5787,7 +5787,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                 {
                   "children": [],
                   "hasBigLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "39",
                   "isPlaceholder": false,
                   "isSkipped": true,
@@ -5810,7 +5810,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "57",
                   "isPlaceholder": false,
                   "key": "n_57",
@@ -5832,7 +5832,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "71",
                   "isPlaceholder": false,
                   "key": "n_71",
@@ -5854,7 +5854,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "86",
                   "isPlaceholder": false,
                   "key": "n_86",
@@ -5876,7 +5876,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               ],
               "firstChildIsSkipped": true,
               "hasBranchLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "21",
               "isHidden": true,
               "isParallel": true,
@@ -5884,7 +5884,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "key": "n_21",
               "name": "Branch E",
               "shiftX": 0,
-              "shiftY": 22,
+              "shiftY": 44,
               "stage": {
                 "children": [],
                 "id": "21",
@@ -5900,7 +5900,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 416,
+          "height": 394,
           "id": "11",
           "isHidden": true,
           "isPlaceholder": false,
@@ -5923,7 +5923,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "103",
           "isPlaceholder": false,
           "isSkipped": true,
@@ -5946,7 +5946,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "118",
           "isPlaceholder": false,
           "isSkipped": true,
@@ -5971,7 +5971,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "137",
               "isParallel": true,
               "isPlaceholder": false,
@@ -5995,14 +5995,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "138",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_138",
               "name": "Branch B",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "138",
@@ -6020,7 +6020,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "149",
                   "isPlaceholder": false,
                   "key": "n_149",
@@ -6042,7 +6042,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "160",
                   "isPlaceholder": false,
                   "key": "n_160",
@@ -6063,7 +6063,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
                 },
               ],
               "hasBranchLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "139",
               "isHidden": true,
               "isParallel": true,
@@ -6071,7 +6071,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
               "key": "n_139",
               "name": "Branch C",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "139",
@@ -6088,7 +6088,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "firstChildIsSkipped": true,
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 210,
+          "height": 188,
           "id": "133",
           "isHidden": true,
           "isPlaceholder": false,
@@ -6111,7 +6111,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -6124,7 +6124,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "y": 38,
         },
       ],
-      "height": 416,
+      "height": 394,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -6140,7 +6140,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -6155,7 +6155,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -6179,7 +6179,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "17",
           "isParallel": true,
           "isPlaceholder": false,
@@ -6202,7 +6202,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "18",
           "isParallel": true,
           "isPlaceholder": false,
@@ -6210,7 +6210,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "key": "n_18",
           "name": "Skipped Branch B",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "18",
@@ -6228,7 +6228,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "35",
               "isPlaceholder": false,
               "key": "n_35",
@@ -6250,7 +6250,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "60",
               "isPlaceholder": false,
               "key": "n_60",
@@ -6272,7 +6272,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasBigLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "76",
               "isPlaceholder": false,
               "isSkipped": true,
@@ -6295,7 +6295,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasBigLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "84",
               "isPlaceholder": false,
               "isSkipped": true,
@@ -6317,7 +6317,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             },
             {
               "children": [],
-              "height": 70,
+              "height": 48,
               "id": "100000019",
               "isHidden": true,
               "isPlaceholder": true,
@@ -6333,7 +6333,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           ],
           "hasBranchLabel": true,
           "hasStageEnd": true,
-          "height": 70,
+          "height": 48,
           "id": "19",
           "isHidden": true,
           "isParallel": true,
@@ -6341,7 +6341,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "key": "n_19",
           "name": "Branch C",
           "shiftX": 0,
-          "shiftY": 22,
+          "shiftY": 44,
           "stage": {
             "children": [],
             "id": "19",
@@ -6359,7 +6359,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasBigLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "37",
               "isPlaceholder": false,
               "isSkipped": true,
@@ -6382,7 +6382,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "55",
               "isPlaceholder": false,
               "key": "n_55",
@@ -6404,7 +6404,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           ],
           "firstChildIsSkipped": true,
           "hasBranchLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "20",
           "isHidden": true,
           "isParallel": true,
@@ -6412,7 +6412,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "key": "n_20",
           "name": "Branch D",
           "shiftX": 0,
-          "shiftY": 22,
+          "shiftY": 44,
           "stage": {
             "children": [],
             "id": "20",
@@ -6430,7 +6430,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasBigLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "39",
               "isPlaceholder": false,
               "isSkipped": true,
@@ -6453,7 +6453,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "57",
               "isPlaceholder": false,
               "key": "n_57",
@@ -6475,7 +6475,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "71",
               "isPlaceholder": false,
               "key": "n_71",
@@ -6497,7 +6497,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "86",
               "isPlaceholder": false,
               "key": "n_86",
@@ -6519,7 +6519,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           ],
           "firstChildIsSkipped": true,
           "hasBranchLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "21",
           "isHidden": true,
           "isParallel": true,
@@ -6527,7 +6527,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "key": "n_21",
           "name": "Branch E",
           "shiftX": 0,
-          "shiftY": 22,
+          "shiftY": 44,
           "stage": {
             "children": [],
             "id": "21",
@@ -6543,7 +6543,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 416,
+      "height": 394,
       "id": "11",
       "isHidden": true,
       "isPlaceholder": false,
@@ -6566,7 +6566,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isParallel": true,
       "isPlaceholder": false,
@@ -6589,7 +6589,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "18",
       "isParallel": true,
       "isPlaceholder": false,
@@ -6597,7 +6597,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "key": "n_18",
       "name": "Skipped Branch B",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "18",
@@ -6615,7 +6615,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "35",
           "isPlaceholder": false,
           "key": "n_35",
@@ -6637,7 +6637,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "60",
           "isPlaceholder": false,
           "key": "n_60",
@@ -6659,7 +6659,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "76",
           "isPlaceholder": false,
           "isSkipped": true,
@@ -6682,7 +6682,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "84",
           "isPlaceholder": false,
           "isSkipped": true,
@@ -6704,7 +6704,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": "100000019",
           "isHidden": true,
           "isPlaceholder": true,
@@ -6720,7 +6720,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       ],
       "hasBranchLabel": true,
       "hasStageEnd": true,
-      "height": 70,
+      "height": 48,
       "id": "19",
       "isHidden": true,
       "isParallel": true,
@@ -6728,7 +6728,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "key": "n_19",
       "name": "Branch C",
       "shiftX": 0,
-      "shiftY": 22,
+      "shiftY": 44,
       "stage": {
         "children": [],
         "id": "19",
@@ -6744,7 +6744,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "35",
       "isPlaceholder": false,
       "key": "n_35",
@@ -6766,7 +6766,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "60",
       "isPlaceholder": false,
       "key": "n_60",
@@ -6788,7 +6788,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "76",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -6811,7 +6811,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "84",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -6833,7 +6833,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": "100000019",
       "isHidden": true,
       "isPlaceholder": true,
@@ -6851,7 +6851,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "37",
           "isPlaceholder": false,
           "isSkipped": true,
@@ -6874,7 +6874,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "55",
           "isPlaceholder": false,
           "key": "n_55",
@@ -6896,7 +6896,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       ],
       "firstChildIsSkipped": true,
       "hasBranchLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "20",
       "isHidden": true,
       "isParallel": true,
@@ -6904,7 +6904,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "key": "n_20",
       "name": "Branch D",
       "shiftX": 0,
-      "shiftY": 22,
+      "shiftY": 44,
       "stage": {
         "children": [],
         "id": "20",
@@ -6920,7 +6920,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "37",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -6943,7 +6943,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "55",
       "isPlaceholder": false,
       "key": "n_55",
@@ -6967,7 +6967,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "39",
           "isPlaceholder": false,
           "isSkipped": true,
@@ -6990,7 +6990,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "57",
           "isPlaceholder": false,
           "key": "n_57",
@@ -7012,7 +7012,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "71",
           "isPlaceholder": false,
           "key": "n_71",
@@ -7034,7 +7034,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "86",
           "isPlaceholder": false,
           "key": "n_86",
@@ -7056,7 +7056,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       ],
       "firstChildIsSkipped": true,
       "hasBranchLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "21",
       "isHidden": true,
       "isParallel": true,
@@ -7064,7 +7064,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "key": "n_21",
       "name": "Branch E",
       "shiftX": 0,
-      "shiftY": 22,
+      "shiftY": 44,
       "stage": {
         "children": [],
         "id": "21",
@@ -7080,7 +7080,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "39",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -7103,7 +7103,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "57",
       "isPlaceholder": false,
       "key": "n_57",
@@ -7125,7 +7125,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "71",
       "isPlaceholder": false,
       "key": "n_71",
@@ -7147,7 +7147,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "86",
       "isPlaceholder": false,
       "key": "n_86",
@@ -7169,7 +7169,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "103",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -7192,7 +7192,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "118",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -7217,7 +7217,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "137",
           "isParallel": true,
           "isPlaceholder": false,
@@ -7241,14 +7241,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "138",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_138",
           "name": "Branch B",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "138",
@@ -7266,7 +7266,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "149",
               "isPlaceholder": false,
               "key": "n_149",
@@ -7288,7 +7288,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "160",
               "isPlaceholder": false,
               "key": "n_160",
@@ -7309,7 +7309,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
             },
           ],
           "hasBranchLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "139",
           "isHidden": true,
           "isParallel": true,
@@ -7317,7 +7317,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
           "key": "n_139",
           "name": "Branch C",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "139",
@@ -7334,7 +7334,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "firstChildIsSkipped": true,
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 210,
+      "height": 188,
       "id": "133",
       "isHidden": true,
       "isPlaceholder": false,
@@ -7357,7 +7357,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "137",
       "isParallel": true,
       "isPlaceholder": false,
@@ -7381,14 +7381,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "138",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_138",
       "name": "Branch B",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "138",
@@ -7406,7 +7406,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "149",
           "isPlaceholder": false,
           "key": "n_149",
@@ -7428,7 +7428,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "160",
           "isPlaceholder": false,
           "key": "n_160",
@@ -7449,7 +7449,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
         },
       ],
       "hasBranchLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "139",
       "isHidden": true,
       "isParallel": true,
@@ -7457,7 +7457,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "key": "n_139",
       "name": "Branch C",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "139",
@@ -7473,7 +7473,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "149",
       "isPlaceholder": false,
       "key": "n_149",
@@ -7495,7 +7495,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "160",
       "isPlaceholder": false,
       "key": "n_160",
@@ -7517,7 +7517,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -8104,13 +8104,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       ],
     },
   ],
-  "measuredHeight": 454,
+  "measuredHeight": 432,
   "measuredWidth": 1736,
   "nodes": [
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -8125,7 +8125,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -8147,7 +8147,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isParallel": true,
       "isPlaceholder": false,
@@ -8170,7 +8170,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "18",
       "isParallel": true,
       "isPlaceholder": false,
@@ -8178,7 +8178,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
       "key": "n_18",
       "name": "Skipped Branch B",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "18",
@@ -8194,7 +8194,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "35",
       "isPlaceholder": false,
       "key": "n_35",
@@ -8216,7 +8216,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "60",
       "isPlaceholder": false,
       "key": "n_60",
@@ -8238,7 +8238,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "76",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -8261,7 +8261,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "84",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -8284,7 +8284,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "37",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -8307,7 +8307,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "55",
       "isPlaceholder": false,
       "key": "n_55",
@@ -8329,7 +8329,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "39",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -8352,7 +8352,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "57",
       "isPlaceholder": false,
       "key": "n_57",
@@ -8374,7 +8374,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "71",
       "isPlaceholder": false,
       "key": "n_71",
@@ -8396,7 +8396,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "86",
       "isPlaceholder": false,
       "key": "n_86",
@@ -8418,7 +8418,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "103",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -8441,7 +8441,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "118",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -8464,7 +8464,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "137",
       "isParallel": true,
       "isPlaceholder": false,
@@ -8488,14 +8488,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "138",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_138",
       "name": "Branch B",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "138",
@@ -8511,7 +8511,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "149",
       "isPlaceholder": false,
       "key": "n_149",
@@ -8533,7 +8533,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "160",
       "isPlaceholder": false,
       "key": "n_160",
@@ -8555,7 +8555,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_complexSmokes.je
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -8789,7 +8789,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "children": [
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -8804,7 +8804,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "10",
           "isPlaceholder": false,
           "key": "n_10",
@@ -8826,7 +8826,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "16",
           "isPlaceholder": false,
           "key": "n_16",
@@ -8848,7 +8848,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "33",
           "isPlaceholder": false,
           "key": "n_33",
@@ -8870,7 +8870,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "34",
           "isPlaceholder": false,
           "key": "n_34",
@@ -8892,7 +8892,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "17",
           "isPlaceholder": false,
           "key": "n_17",
@@ -8914,7 +8914,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "12",
           "isPlaceholder": false,
           "key": "n_12",
@@ -8936,7 +8936,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "21",
           "isPlaceholder": false,
           "key": "n_21",
@@ -8958,7 +8958,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "28",
           "isPlaceholder": false,
           "key": "n_28",
@@ -8980,7 +8980,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "55",
           "isPlaceholder": false,
           "key": "n_55",
@@ -9002,7 +9002,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "60",
           "isPlaceholder": false,
           "key": "n_60",
@@ -9024,7 +9024,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "61",
           "isPlaceholder": false,
           "key": "n_61",
@@ -9046,7 +9046,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "22",
           "isPlaceholder": false,
           "key": "n_22",
@@ -9067,7 +9067,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -9080,7 +9080,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "y": 16,
         },
       ],
-      "height": 70,
+      "height": 48,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -9095,7 +9095,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -9110,7 +9110,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isPlaceholder": false,
       "key": "n_10",
@@ -9132,7 +9132,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "16",
       "isPlaceholder": false,
       "key": "n_16",
@@ -9154,7 +9154,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "33",
       "isPlaceholder": false,
       "key": "n_33",
@@ -9176,7 +9176,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "34",
       "isPlaceholder": false,
       "key": "n_34",
@@ -9198,7 +9198,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isPlaceholder": false,
       "key": "n_17",
@@ -9220,7 +9220,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "12",
       "isPlaceholder": false,
       "key": "n_12",
@@ -9242,7 +9242,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "21",
       "isPlaceholder": false,
       "key": "n_21",
@@ -9264,7 +9264,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "28",
       "isPlaceholder": false,
       "key": "n_28",
@@ -9286,7 +9286,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "55",
       "isPlaceholder": false,
       "key": "n_55",
@@ -9308,7 +9308,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "60",
       "isPlaceholder": false,
       "key": "n_60",
@@ -9330,7 +9330,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "61",
       "isPlaceholder": false,
       "key": "n_61",
@@ -9352,7 +9352,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "22",
       "isPlaceholder": false,
       "key": "n_22",
@@ -9373,7 +9373,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -9626,12 +9626,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       ],
     },
   ],
-  "measuredHeight": 86,
+  "measuredHeight": 64,
   "measuredWidth": 1806,
   "nodes": [
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -9646,7 +9646,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isPlaceholder": false,
       "key": "n_10",
@@ -9668,7 +9668,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "16",
       "isPlaceholder": false,
       "key": "n_16",
@@ -9690,7 +9690,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "33",
       "isPlaceholder": false,
       "key": "n_33",
@@ -9712,7 +9712,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "34",
       "isPlaceholder": false,
       "key": "n_34",
@@ -9734,7 +9734,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isPlaceholder": false,
       "key": "n_17",
@@ -9756,7 +9756,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "12",
       "isPlaceholder": false,
       "key": "n_12",
@@ -9778,7 +9778,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "21",
       "isPlaceholder": false,
       "key": "n_21",
@@ -9800,7 +9800,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "28",
       "isPlaceholder": false,
       "key": "n_28",
@@ -9822,7 +9822,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "55",
       "isPlaceholder": false,
       "key": "n_55",
@@ -9844,7 +9844,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "60",
       "isPlaceholder": false,
       "key": "n_60",
@@ -9866,7 +9866,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "61",
       "isPlaceholder": false,
       "key": "n_61",
@@ -9888,7 +9888,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "22",
       "isPlaceholder": false,
       "key": "n_22",
@@ -9909,7 +9909,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -10128,7 +10128,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -10153,7 +10153,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                             {
                               "children": [],
                               "hasSmallLabel": true,
-                              "height": 70,
+                              "height": 48,
                               "id": "33",
                               "isParallel": true,
                               "isPlaceholder": false,
@@ -10176,14 +10176,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                             {
                               "children": [],
                               "hasSmallLabel": true,
-                              "height": 70,
+                              "height": 48,
                               "id": "34",
                               "isParallel": true,
                               "isPlaceholder": false,
                               "key": "n_34",
                               "name": "A-1-2",
                               "shiftX": 0,
-                              "shiftY": 0,
+                              "shiftY": 22,
                               "stage": {
                                 "children": [],
                                 "id": "34",
@@ -10199,7 +10199,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                           ],
                           "hasBigLabel": true,
                           "hasParallel": true,
-                          "height": 140,
+                          "height": 118,
                           "id": "16",
                           "isHidden": true,
                           "isPlaceholder": false,
@@ -10221,7 +10221,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                         },
                         {
                           "children": [],
-                          "height": 70,
+                          "height": 48,
                           "id": 999984,
                           "isHidden": true,
                           "isPlaceholder": true,
@@ -10236,7 +10236,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                         },
                       ],
                       "hasStageEnd": true,
-                      "height": 140,
+                      "height": 118,
                       "id": -16,
                       "isHidden": true,
                       "isNestedParallel": true,
@@ -10261,14 +10261,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                     {
                       "children": [],
                       "hasSmallLabel": true,
-                      "height": 70,
+                      "height": 48,
                       "id": "17",
                       "isParallel": true,
                       "isPlaceholder": false,
                       "key": "n_17",
                       "name": "A-2",
                       "shiftX": 0,
-                      "shiftY": 0,
+                      "shiftY": 22,
                       "stage": {
                         "children": [],
                         "id": "17",
@@ -10284,7 +10284,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   ],
                   "hasBigLabel": true,
                   "hasParallel": true,
-                  "height": 210,
+                  "height": 188,
                   "id": "10",
                   "isHidden": true,
                   "isPlaceholder": false,
@@ -10306,7 +10306,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                 },
                 {
                   "children": [],
-                  "height": 70,
+                  "height": 48,
                   "id": "10000007",
                   "isHidden": true,
                   "isPlaceholder": true,
@@ -10322,7 +10322,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               ],
               "hasBranchLabel": true,
               "hasStageEnd": true,
-              "height": 210,
+              "height": 188,
               "id": "7",
               "isHidden": true,
               "isParallel": true,
@@ -10352,7 +10352,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                         {
                           "children": [],
                           "hasSmallLabel": true,
-                          "height": 70,
+                          "height": 48,
                           "id": "28",
                           "isPlaceholder": false,
                           "key": "n_28",
@@ -10376,7 +10376,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                             {
                               "children": [],
                               "hasSmallLabel": true,
-                              "height": 70,
+                              "height": 48,
                               "id": "60",
                               "isParallel": true,
                               "isPlaceholder": false,
@@ -10399,14 +10399,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                             {
                               "children": [],
                               "hasSmallLabel": true,
-                              "height": 70,
+                              "height": 48,
                               "id": "61",
                               "isParallel": true,
                               "isPlaceholder": false,
                               "key": "n_61",
                               "name": "B-1-2-2",
                               "shiftX": 0,
-                              "shiftY": 0,
+                              "shiftY": 22,
                               "stage": {
                                 "children": [],
                                 "id": "61",
@@ -10422,7 +10422,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                           ],
                           "hasBigLabel": true,
                           "hasParallel": true,
-                          "height": 140,
+                          "height": 118,
                           "id": "55",
                           "isHidden": true,
                           "isPlaceholder": false,
@@ -10444,7 +10444,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                         },
                         {
                           "children": [],
-                          "height": 70,
+                          "height": 48,
                           "id": "100000021",
                           "isHidden": true,
                           "isPlaceholder": true,
@@ -10460,7 +10460,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       ],
                       "hasBranchLabel": true,
                       "hasStageEnd": true,
-                      "height": 140,
+                      "height": 118,
                       "id": "21",
                       "isHidden": true,
                       "isParallel": true,
@@ -10484,14 +10484,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                     {
                       "children": [],
                       "hasSmallLabel": true,
-                      "height": 70,
+                      "height": 48,
                       "id": "22",
                       "isParallel": true,
                       "isPlaceholder": false,
                       "key": "n_22",
                       "name": "B-2",
                       "shiftX": 0,
-                      "shiftY": 0,
+                      "shiftY": 22,
                       "stage": {
                         "children": [],
                         "id": "22",
@@ -10507,7 +10507,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   ],
                   "hasBigLabel": true,
                   "hasParallel": true,
-                  "height": 210,
+                  "height": 188,
                   "id": "12",
                   "isHidden": true,
                   "isPlaceholder": false,
@@ -10529,7 +10529,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                 },
                 {
                   "children": [],
-                  "height": 70,
+                  "height": 48,
                   "id": "10000008",
                   "isHidden": true,
                   "isPlaceholder": true,
@@ -10545,7 +10545,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               ],
               "hasBranchLabel": true,
               "hasStageEnd": true,
-              "height": 210,
+              "height": 188,
               "id": "8",
               "isHidden": true,
               "isParallel": true,
@@ -10553,7 +10553,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               "key": "n_8",
               "name": "BranchB",
               "shiftX": 0,
-              "shiftY": 44,
+              "shiftY": 66,
               "stage": {
                 "children": [],
                 "id": "8",
@@ -10569,7 +10569,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 464,
+          "height": 442,
           "id": "4",
           "isHidden": true,
           "isPlaceholder": false,
@@ -10592,7 +10592,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -10605,7 +10605,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "y": 82,
         },
       ],
-      "height": 464,
+      "height": 442,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -10621,7 +10621,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -10646,7 +10646,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                         {
                           "children": [],
                           "hasSmallLabel": true,
-                          "height": 70,
+                          "height": 48,
                           "id": "33",
                           "isParallel": true,
                           "isPlaceholder": false,
@@ -10669,14 +10669,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                         {
                           "children": [],
                           "hasSmallLabel": true,
-                          "height": 70,
+                          "height": 48,
                           "id": "34",
                           "isParallel": true,
                           "isPlaceholder": false,
                           "key": "n_34",
                           "name": "A-1-2",
                           "shiftX": 0,
-                          "shiftY": 0,
+                          "shiftY": 22,
                           "stage": {
                             "children": [],
                             "id": "34",
@@ -10692,7 +10692,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       ],
                       "hasBigLabel": true,
                       "hasParallel": true,
-                      "height": 140,
+                      "height": 118,
                       "id": "16",
                       "isHidden": true,
                       "isPlaceholder": false,
@@ -10714,7 +10714,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                     },
                     {
                       "children": [],
-                      "height": 70,
+                      "height": 48,
                       "id": 999984,
                       "isHidden": true,
                       "isPlaceholder": true,
@@ -10729,7 +10729,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                     },
                   ],
                   "hasStageEnd": true,
-                  "height": 140,
+                  "height": 118,
                   "id": -16,
                   "isHidden": true,
                   "isNestedParallel": true,
@@ -10754,14 +10754,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "17",
                   "isParallel": true,
                   "isPlaceholder": false,
                   "key": "n_17",
                   "name": "A-2",
                   "shiftX": 0,
-                  "shiftY": 0,
+                  "shiftY": 22,
                   "stage": {
                     "children": [],
                     "id": "17",
@@ -10777,7 +10777,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               ],
               "hasBigLabel": true,
               "hasParallel": true,
-              "height": 210,
+              "height": 188,
               "id": "10",
               "isHidden": true,
               "isPlaceholder": false,
@@ -10799,7 +10799,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
             },
             {
               "children": [],
-              "height": 70,
+              "height": 48,
               "id": "10000007",
               "isHidden": true,
               "isPlaceholder": true,
@@ -10815,7 +10815,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           ],
           "hasBranchLabel": true,
           "hasStageEnd": true,
-          "height": 210,
+          "height": 188,
           "id": "7",
           "isHidden": true,
           "isParallel": true,
@@ -10845,7 +10845,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                     {
                       "children": [],
                       "hasSmallLabel": true,
-                      "height": 70,
+                      "height": 48,
                       "id": "28",
                       "isPlaceholder": false,
                       "key": "n_28",
@@ -10869,7 +10869,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                         {
                           "children": [],
                           "hasSmallLabel": true,
-                          "height": 70,
+                          "height": 48,
                           "id": "60",
                           "isParallel": true,
                           "isPlaceholder": false,
@@ -10892,14 +10892,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                         {
                           "children": [],
                           "hasSmallLabel": true,
-                          "height": 70,
+                          "height": 48,
                           "id": "61",
                           "isParallel": true,
                           "isPlaceholder": false,
                           "key": "n_61",
                           "name": "B-1-2-2",
                           "shiftX": 0,
-                          "shiftY": 0,
+                          "shiftY": 22,
                           "stage": {
                             "children": [],
                             "id": "61",
@@ -10915,7 +10915,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                       ],
                       "hasBigLabel": true,
                       "hasParallel": true,
-                      "height": 140,
+                      "height": 118,
                       "id": "55",
                       "isHidden": true,
                       "isPlaceholder": false,
@@ -10937,7 +10937,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                     },
                     {
                       "children": [],
-                      "height": 70,
+                      "height": 48,
                       "id": "100000021",
                       "isHidden": true,
                       "isPlaceholder": true,
@@ -10953,7 +10953,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   ],
                   "hasBranchLabel": true,
                   "hasStageEnd": true,
-                  "height": 140,
+                  "height": 118,
                   "id": "21",
                   "isHidden": true,
                   "isParallel": true,
@@ -10977,14 +10977,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "22",
                   "isParallel": true,
                   "isPlaceholder": false,
                   "key": "n_22",
                   "name": "B-2",
                   "shiftX": 0,
-                  "shiftY": 0,
+                  "shiftY": 22,
                   "stage": {
                     "children": [],
                     "id": "22",
@@ -11000,7 +11000,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               ],
               "hasBigLabel": true,
               "hasParallel": true,
-              "height": 210,
+              "height": 188,
               "id": "12",
               "isHidden": true,
               "isPlaceholder": false,
@@ -11022,7 +11022,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
             },
             {
               "children": [],
-              "height": 70,
+              "height": 48,
               "id": "10000008",
               "isHidden": true,
               "isPlaceholder": true,
@@ -11038,7 +11038,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           ],
           "hasBranchLabel": true,
           "hasStageEnd": true,
-          "height": 210,
+          "height": 188,
           "id": "8",
           "isHidden": true,
           "isParallel": true,
@@ -11046,7 +11046,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           "key": "n_8",
           "name": "BranchB",
           "shiftX": 0,
-          "shiftY": 44,
+          "shiftY": 66,
           "stage": {
             "children": [],
             "id": "8",
@@ -11062,7 +11062,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 464,
+      "height": 442,
       "id": "4",
       "isHidden": true,
       "isPlaceholder": false,
@@ -11093,7 +11093,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                     {
                       "children": [],
                       "hasSmallLabel": true,
-                      "height": 70,
+                      "height": 48,
                       "id": "33",
                       "isParallel": true,
                       "isPlaceholder": false,
@@ -11116,14 +11116,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                     {
                       "children": [],
                       "hasSmallLabel": true,
-                      "height": 70,
+                      "height": 48,
                       "id": "34",
                       "isParallel": true,
                       "isPlaceholder": false,
                       "key": "n_34",
                       "name": "A-1-2",
                       "shiftX": 0,
-                      "shiftY": 0,
+                      "shiftY": 22,
                       "stage": {
                         "children": [],
                         "id": "34",
@@ -11139,7 +11139,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   ],
                   "hasBigLabel": true,
                   "hasParallel": true,
-                  "height": 140,
+                  "height": 118,
                   "id": "16",
                   "isHidden": true,
                   "isPlaceholder": false,
@@ -11161,7 +11161,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                 },
                 {
                   "children": [],
-                  "height": 70,
+                  "height": 48,
                   "id": 999984,
                   "isHidden": true,
                   "isPlaceholder": true,
@@ -11176,7 +11176,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                 },
               ],
               "hasStageEnd": true,
-              "height": 140,
+              "height": 118,
               "id": -16,
               "isHidden": true,
               "isNestedParallel": true,
@@ -11201,14 +11201,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "17",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_17",
               "name": "A-2",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "17",
@@ -11224,7 +11224,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 210,
+          "height": 188,
           "id": "10",
           "isHidden": true,
           "isPlaceholder": false,
@@ -11246,7 +11246,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": "10000007",
           "isHidden": true,
           "isPlaceholder": true,
@@ -11262,7 +11262,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       ],
       "hasBranchLabel": true,
       "hasStageEnd": true,
-      "height": 210,
+      "height": 188,
       "id": "7",
       "isHidden": true,
       "isParallel": true,
@@ -11292,7 +11292,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "33",
                   "isParallel": true,
                   "isPlaceholder": false,
@@ -11315,14 +11315,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "34",
                   "isParallel": true,
                   "isPlaceholder": false,
                   "key": "n_34",
                   "name": "A-1-2",
                   "shiftX": 0,
-                  "shiftY": 0,
+                  "shiftY": 22,
                   "stage": {
                     "children": [],
                     "id": "34",
@@ -11338,7 +11338,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               ],
               "hasBigLabel": true,
               "hasParallel": true,
-              "height": 140,
+              "height": 118,
               "id": "16",
               "isHidden": true,
               "isPlaceholder": false,
@@ -11360,7 +11360,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
             },
             {
               "children": [],
-              "height": 70,
+              "height": 48,
               "id": 999984,
               "isHidden": true,
               "isPlaceholder": true,
@@ -11375,7 +11375,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
             },
           ],
           "hasStageEnd": true,
-          "height": 140,
+          "height": 118,
           "id": -16,
           "isHidden": true,
           "isNestedParallel": true,
@@ -11400,14 +11400,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "17",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_17",
           "name": "A-2",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "17",
@@ -11423,7 +11423,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 210,
+      "height": 188,
       "id": "10",
       "isHidden": true,
       "isPlaceholder": false,
@@ -11450,7 +11450,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "33",
               "isParallel": true,
               "isPlaceholder": false,
@@ -11473,14 +11473,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "34",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_34",
               "name": "A-1-2",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "34",
@@ -11496,7 +11496,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 140,
+          "height": 118,
           "id": "16",
           "isHidden": true,
           "isPlaceholder": false,
@@ -11518,7 +11518,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": 999984,
           "isHidden": true,
           "isPlaceholder": true,
@@ -11533,7 +11533,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         },
       ],
       "hasStageEnd": true,
-      "height": 140,
+      "height": 118,
       "id": -16,
       "isHidden": true,
       "isNestedParallel": true,
@@ -11560,7 +11560,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "33",
           "isParallel": true,
           "isPlaceholder": false,
@@ -11583,14 +11583,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "34",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_34",
           "name": "A-1-2",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "34",
@@ -11606,7 +11606,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 140,
+      "height": 118,
       "id": "16",
       "isHidden": true,
       "isPlaceholder": false,
@@ -11629,7 +11629,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "33",
       "isParallel": true,
       "isPlaceholder": false,
@@ -11652,14 +11652,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "34",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_34",
       "name": "A-1-2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "34",
@@ -11674,7 +11674,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": 999984,
       "isHidden": true,
       "isPlaceholder": true,
@@ -11690,14 +11690,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_17",
       "name": "A-2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "17",
@@ -11712,7 +11712,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": "10000007",
       "isHidden": true,
       "isPlaceholder": true,
@@ -11734,7 +11734,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "28",
                   "isPlaceholder": false,
                   "key": "n_28",
@@ -11758,7 +11758,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                     {
                       "children": [],
                       "hasSmallLabel": true,
-                      "height": 70,
+                      "height": 48,
                       "id": "60",
                       "isParallel": true,
                       "isPlaceholder": false,
@@ -11781,14 +11781,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                     {
                       "children": [],
                       "hasSmallLabel": true,
-                      "height": 70,
+                      "height": 48,
                       "id": "61",
                       "isParallel": true,
                       "isPlaceholder": false,
                       "key": "n_61",
                       "name": "B-1-2-2",
                       "shiftX": 0,
-                      "shiftY": 0,
+                      "shiftY": 22,
                       "stage": {
                         "children": [],
                         "id": "61",
@@ -11804,7 +11804,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                   ],
                   "hasBigLabel": true,
                   "hasParallel": true,
-                  "height": 140,
+                  "height": 118,
                   "id": "55",
                   "isHidden": true,
                   "isPlaceholder": false,
@@ -11826,7 +11826,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                 },
                 {
                   "children": [],
-                  "height": 70,
+                  "height": 48,
                   "id": "100000021",
                   "isHidden": true,
                   "isPlaceholder": true,
@@ -11842,7 +11842,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               ],
               "hasBranchLabel": true,
               "hasStageEnd": true,
-              "height": 140,
+              "height": 118,
               "id": "21",
               "isHidden": true,
               "isParallel": true,
@@ -11866,14 +11866,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "22",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_22",
               "name": "B-2",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "22",
@@ -11889,7 +11889,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 210,
+          "height": 188,
           "id": "12",
           "isHidden": true,
           "isPlaceholder": false,
@@ -11911,7 +11911,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": "10000008",
           "isHidden": true,
           "isPlaceholder": true,
@@ -11927,7 +11927,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       ],
       "hasBranchLabel": true,
       "hasStageEnd": true,
-      "height": 210,
+      "height": 188,
       "id": "8",
       "isHidden": true,
       "isParallel": true,
@@ -11935,7 +11935,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       "key": "n_8",
       "name": "BranchB",
       "shiftX": 0,
-      "shiftY": 44,
+      "shiftY": 66,
       "stage": {
         "children": [],
         "id": "8",
@@ -11955,7 +11955,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "28",
               "isPlaceholder": false,
               "key": "n_28",
@@ -11979,7 +11979,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "60",
                   "isParallel": true,
                   "isPlaceholder": false,
@@ -12002,14 +12002,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "61",
                   "isParallel": true,
                   "isPlaceholder": false,
                   "key": "n_61",
                   "name": "B-1-2-2",
                   "shiftX": 0,
-                  "shiftY": 0,
+                  "shiftY": 22,
                   "stage": {
                     "children": [],
                     "id": "61",
@@ -12025,7 +12025,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
               ],
               "hasBigLabel": true,
               "hasParallel": true,
-              "height": 140,
+              "height": 118,
               "id": "55",
               "isHidden": true,
               "isPlaceholder": false,
@@ -12047,7 +12047,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
             },
             {
               "children": [],
-              "height": 70,
+              "height": 48,
               "id": "100000021",
               "isHidden": true,
               "isPlaceholder": true,
@@ -12063,7 +12063,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           ],
           "hasBranchLabel": true,
           "hasStageEnd": true,
-          "height": 140,
+          "height": 118,
           "id": "21",
           "isHidden": true,
           "isParallel": true,
@@ -12087,14 +12087,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "22",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_22",
           "name": "B-2",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "22",
@@ -12110,7 +12110,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 210,
+      "height": 188,
       "id": "12",
       "isHidden": true,
       "isPlaceholder": false,
@@ -12135,7 +12135,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "28",
           "isPlaceholder": false,
           "key": "n_28",
@@ -12159,7 +12159,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "60",
               "isParallel": true,
               "isPlaceholder": false,
@@ -12182,14 +12182,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "61",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_61",
               "name": "B-1-2-2",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "61",
@@ -12205,7 +12205,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 140,
+          "height": 118,
           "id": "55",
           "isHidden": true,
           "isPlaceholder": false,
@@ -12227,7 +12227,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": "100000021",
           "isHidden": true,
           "isPlaceholder": true,
@@ -12243,7 +12243,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       ],
       "hasBranchLabel": true,
       "hasStageEnd": true,
-      "height": 140,
+      "height": 118,
       "id": "21",
       "isHidden": true,
       "isParallel": true,
@@ -12267,7 +12267,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "28",
       "isPlaceholder": false,
       "key": "n_28",
@@ -12291,7 +12291,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "60",
           "isParallel": true,
           "isPlaceholder": false,
@@ -12314,14 +12314,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "61",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_61",
           "name": "B-1-2-2",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "61",
@@ -12337,7 +12337,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 140,
+      "height": 118,
       "id": "55",
       "isHidden": true,
       "isPlaceholder": false,
@@ -12360,7 +12360,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "60",
       "isParallel": true,
       "isPlaceholder": false,
@@ -12383,14 +12383,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "61",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_61",
       "name": "B-1-2-2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "61",
@@ -12405,7 +12405,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": "100000021",
       "isHidden": true,
       "isPlaceholder": true,
@@ -12421,14 +12421,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "22",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_22",
       "name": "B-2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "22",
@@ -12443,7 +12443,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": "10000008",
       "isHidden": true,
       "isPlaceholder": true,
@@ -12459,7 +12459,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -12900,13 +12900,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
       ],
     },
   ],
-  "measuredHeight": 546,
+  "measuredHeight": 524,
   "measuredWidth": 826,
   "nodes": [
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -12921,7 +12921,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "33",
       "isParallel": true,
       "isPlaceholder": false,
@@ -12944,14 +12944,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "34",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_34",
       "name": "A-1-2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "34",
@@ -12967,14 +12967,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_17",
       "name": "A-2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "17",
@@ -12990,7 +12990,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "28",
       "isPlaceholder": false,
       "key": "n_28",
@@ -13012,7 +13012,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "60",
       "isParallel": true,
       "isPlaceholder": false,
@@ -13035,14 +13035,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "61",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_61",
       "name": "B-1-2-2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "61",
@@ -13058,14 +13058,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "22",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_22",
       "name": "B-2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "22",
@@ -13081,7 +13081,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_nestedParallel.j
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -13219,7 +13219,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "children": [
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -13234,7 +13234,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "12",
           "isPlaceholder": false,
           "key": "n_12",
@@ -13256,7 +13256,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "26",
           "isPlaceholder": false,
           "key": "n_26",
@@ -13278,7 +13278,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "35",
           "isPlaceholder": false,
           "key": "n_35",
@@ -13300,7 +13300,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "36",
           "isPlaceholder": false,
           "key": "n_36",
@@ -13322,7 +13322,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "37",
           "isPlaceholder": false,
           "key": "n_37",
@@ -13344,7 +13344,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "67",
           "isPlaceholder": false,
           "key": "n_67",
@@ -13366,7 +13366,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "72",
           "isPlaceholder": false,
           "key": "n_72",
@@ -13388,7 +13388,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "73",
           "isPlaceholder": false,
           "key": "n_73",
@@ -13410,7 +13410,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "99",
           "isPlaceholder": false,
           "key": "n_99",
@@ -13432,7 +13432,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "14",
           "isPlaceholder": false,
           "key": "n_14",
@@ -13454,7 +13454,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "28",
           "isPlaceholder": false,
           "key": "n_28",
@@ -13476,7 +13476,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "51",
           "isPlaceholder": false,
           "key": "n_51",
@@ -13497,7 +13497,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -2,
           "isPlaceholder": true,
           "key": "counter-node",
@@ -13576,7 +13576,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -13589,7 +13589,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "y": 16,
         },
       ],
-      "height": 70,
+      "height": 48,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -13604,7 +13604,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -13619,7 +13619,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "12",
       "isPlaceholder": false,
       "key": "n_12",
@@ -13641,7 +13641,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "26",
       "isPlaceholder": false,
       "key": "n_26",
@@ -13663,7 +13663,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "35",
       "isPlaceholder": false,
       "key": "n_35",
@@ -13685,7 +13685,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "36",
       "isPlaceholder": false,
       "key": "n_36",
@@ -13707,7 +13707,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "37",
       "isPlaceholder": false,
       "key": "n_37",
@@ -13729,7 +13729,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "67",
       "isPlaceholder": false,
       "key": "n_67",
@@ -13751,7 +13751,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "72",
       "isPlaceholder": false,
       "key": "n_72",
@@ -13773,7 +13773,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "73",
       "isPlaceholder": false,
       "key": "n_73",
@@ -13795,7 +13795,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "99",
       "isPlaceholder": false,
       "key": "n_99",
@@ -13817,7 +13817,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "14",
       "isPlaceholder": false,
       "key": "n_14",
@@ -13839,7 +13839,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "28",
       "isPlaceholder": false,
       "key": "n_28",
@@ -13861,7 +13861,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "51",
       "isPlaceholder": false,
       "key": "n_51",
@@ -13882,7 +13882,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -2,
       "isPlaceholder": true,
       "key": "counter-node",
@@ -13961,7 +13961,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -14234,12 +14234,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       ],
     },
   ],
-  "measuredHeight": 86,
+  "measuredHeight": 64,
   "measuredWidth": 1946,
   "nodes": [
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -14254,7 +14254,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "12",
       "isPlaceholder": false,
       "key": "n_12",
@@ -14276,7 +14276,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "26",
       "isPlaceholder": false,
       "key": "n_26",
@@ -14298,7 +14298,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "35",
       "isPlaceholder": false,
       "key": "n_35",
@@ -14320,7 +14320,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "36",
       "isPlaceholder": false,
       "key": "n_36",
@@ -14342,7 +14342,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "37",
       "isPlaceholder": false,
       "key": "n_37",
@@ -14364,7 +14364,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "67",
       "isPlaceholder": false,
       "key": "n_67",
@@ -14386,7 +14386,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "72",
       "isPlaceholder": false,
       "key": "n_72",
@@ -14408,7 +14408,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "73",
       "isPlaceholder": false,
       "key": "n_73",
@@ -14430,7 +14430,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "99",
       "isPlaceholder": false,
       "key": "n_99",
@@ -14452,7 +14452,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "14",
       "isPlaceholder": false,
       "key": "n_14",
@@ -14474,7 +14474,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "28",
       "isPlaceholder": false,
       "key": "n_28",
@@ -14496,7 +14496,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "51",
       "isPlaceholder": false,
       "key": "n_51",
@@ -14517,7 +14517,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -2,
       "isPlaceholder": true,
       "key": "counter-node",
@@ -14596,7 +14596,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -14815,7 +14815,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -14834,7 +14834,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "12",
                   "isPlaceholder": false,
                   "key": "n_12",
@@ -14858,7 +14858,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                     {
                       "children": [],
                       "hasSmallLabel": true,
-                      "height": 70,
+                      "height": 48,
                       "id": "35",
                       "isParallel": true,
                       "isPlaceholder": false,
@@ -14881,14 +14881,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                     {
                       "children": [],
                       "hasSmallLabel": true,
-                      "height": 70,
+                      "height": 48,
                       "id": "36",
                       "isParallel": true,
                       "isPlaceholder": false,
                       "key": "n_36",
                       "name": "A2",
                       "shiftX": 0,
-                      "shiftY": 0,
+                      "shiftY": 22,
                       "stage": {
                         "children": [],
                         "id": "36",
@@ -14904,14 +14904,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                     {
                       "children": [],
                       "hasSmallLabel": true,
-                      "height": 70,
+                      "height": 48,
                       "id": "37",
                       "isParallel": true,
                       "isPlaceholder": false,
                       "key": "n_37",
                       "name": "A3",
                       "shiftX": 0,
-                      "shiftY": 0,
+                      "shiftY": 22,
                       "stage": {
                         "children": [],
                         "id": "37",
@@ -14927,7 +14927,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   ],
                   "hasBigLabel": true,
                   "hasParallel": true,
-                  "height": 210,
+                  "height": 188,
                   "id": "26",
                   "isHidden": true,
                   "isPlaceholder": false,
@@ -14952,7 +14952,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                     {
                       "children": [],
                       "hasSmallLabel": true,
-                      "height": 70,
+                      "height": 48,
                       "id": "72",
                       "isParallel": true,
                       "isPlaceholder": false,
@@ -14975,14 +14975,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                     {
                       "children": [],
                       "hasSmallLabel": true,
-                      "height": 70,
+                      "height": 48,
                       "id": "73",
                       "isParallel": true,
                       "isPlaceholder": false,
                       "key": "n_73",
                       "name": "A2",
                       "shiftX": 0,
-                      "shiftY": 0,
+                      "shiftY": 22,
                       "stage": {
                         "children": [],
                         "id": "73",
@@ -14998,7 +14998,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   ],
                   "hasBigLabel": true,
                   "hasParallel": true,
-                  "height": 140,
+                  "height": 118,
                   "id": "67",
                   "isHidden": true,
                   "isPlaceholder": false,
@@ -15021,7 +15021,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "99",
                   "isPlaceholder": false,
                   "key": "n_99",
@@ -15042,7 +15042,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 },
               ],
               "hasBranchLabel": true,
-              "height": 210,
+              "height": 188,
               "id": "8",
               "isHidden": true,
               "isParallel": true,
@@ -15068,7 +15068,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "14",
                   "isPlaceholder": false,
                   "key": "n_14",
@@ -15090,7 +15090,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "28",
                   "isPlaceholder": false,
                   "key": "n_28",
@@ -15114,7 +15114,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                     {
                       "children": [],
                       "hasSmallLabel": true,
-                      "height": 70,
+                      "height": 48,
                       "id": "51",
                       "isParallel": true,
                       "isPlaceholder": false,
@@ -15137,14 +15137,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                     {
                       "children": [],
                       "hasSmallLabel": true,
-                      "height": 70,
+                      "height": 48,
                       "id": "52",
                       "isParallel": true,
                       "isPlaceholder": false,
                       "key": "n_52",
                       "name": "B2",
                       "shiftX": 0,
-                      "shiftY": 0,
+                      "shiftY": 22,
                       "stage": {
                         "children": [],
                         "id": "52",
@@ -15160,7 +15160,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                   ],
                   "hasBigLabel": true,
                   "hasParallel": true,
-                  "height": 140,
+                  "height": 118,
                   "id": "49",
                   "isHidden": true,
                   "isPlaceholder": false,
@@ -15183,7 +15183,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "85",
                   "isPlaceholder": false,
                   "key": "n_85",
@@ -15204,7 +15204,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 },
               ],
               "hasBranchLabel": true,
-              "height": 140,
+              "height": 118,
               "id": "9",
               "isHidden": true,
               "isParallel": true,
@@ -15212,7 +15212,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "key": "n_9",
               "name": "B",
               "shiftX": 0,
-              "shiftY": 22,
+              "shiftY": 44,
               "stage": {
                 "children": [],
                 "id": "9",
@@ -15230,7 +15230,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "16",
                   "isPlaceholder": false,
                   "key": "n_16",
@@ -15252,7 +15252,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "31",
                   "isPlaceholder": false,
                   "key": "n_31",
@@ -15274,7 +15274,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "57",
                   "isPlaceholder": false,
                   "key": "n_57",
@@ -15296,7 +15296,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "76",
                   "isPlaceholder": false,
                   "key": "n_76",
@@ -15318,7 +15318,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "92",
                   "isPlaceholder": false,
                   "key": "n_92",
@@ -15340,7 +15340,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "104",
                   "isPlaceholder": false,
                   "key": "n_104",
@@ -15362,7 +15362,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "111",
                   "isPlaceholder": false,
                   "key": "n_111",
@@ -15383,7 +15383,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 },
               ],
               "hasBranchLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "10",
               "isHidden": true,
               "isParallel": true,
@@ -15391,7 +15391,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               "key": "n_10",
               "name": "C",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "10",
@@ -15407,7 +15407,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 442,
+          "height": 420,
           "id": "5",
           "isHidden": true,
           "isPlaceholder": false,
@@ -15430,7 +15430,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -15443,7 +15443,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "y": 60,
         },
       ],
-      "height": 442,
+      "height": 420,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -15459,7 +15459,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -15478,7 +15478,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "12",
               "isPlaceholder": false,
               "key": "n_12",
@@ -15502,7 +15502,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "35",
                   "isParallel": true,
                   "isPlaceholder": false,
@@ -15525,14 +15525,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "36",
                   "isParallel": true,
                   "isPlaceholder": false,
                   "key": "n_36",
                   "name": "A2",
                   "shiftX": 0,
-                  "shiftY": 0,
+                  "shiftY": 22,
                   "stage": {
                     "children": [],
                     "id": "36",
@@ -15548,14 +15548,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "37",
                   "isParallel": true,
                   "isPlaceholder": false,
                   "key": "n_37",
                   "name": "A3",
                   "shiftX": 0,
-                  "shiftY": 0,
+                  "shiftY": 22,
                   "stage": {
                     "children": [],
                     "id": "37",
@@ -15571,7 +15571,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               ],
               "hasBigLabel": true,
               "hasParallel": true,
-              "height": 210,
+              "height": 188,
               "id": "26",
               "isHidden": true,
               "isPlaceholder": false,
@@ -15596,7 +15596,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "72",
                   "isParallel": true,
                   "isPlaceholder": false,
@@ -15619,14 +15619,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "73",
                   "isParallel": true,
                   "isPlaceholder": false,
                   "key": "n_73",
                   "name": "A2",
                   "shiftX": 0,
-                  "shiftY": 0,
+                  "shiftY": 22,
                   "stage": {
                     "children": [],
                     "id": "73",
@@ -15642,7 +15642,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               ],
               "hasBigLabel": true,
               "hasParallel": true,
-              "height": 140,
+              "height": 118,
               "id": "67",
               "isHidden": true,
               "isPlaceholder": false,
@@ -15665,7 +15665,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "99",
               "isPlaceholder": false,
               "key": "n_99",
@@ -15686,7 +15686,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             },
           ],
           "hasBranchLabel": true,
-          "height": 210,
+          "height": 188,
           "id": "8",
           "isHidden": true,
           "isParallel": true,
@@ -15712,7 +15712,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "14",
               "isPlaceholder": false,
               "key": "n_14",
@@ -15734,7 +15734,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "28",
               "isPlaceholder": false,
               "key": "n_28",
@@ -15758,7 +15758,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "51",
                   "isParallel": true,
                   "isPlaceholder": false,
@@ -15781,14 +15781,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "52",
                   "isParallel": true,
                   "isPlaceholder": false,
                   "key": "n_52",
                   "name": "B2",
                   "shiftX": 0,
-                  "shiftY": 0,
+                  "shiftY": 22,
                   "stage": {
                     "children": [],
                     "id": "52",
@@ -15804,7 +15804,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
               ],
               "hasBigLabel": true,
               "hasParallel": true,
-              "height": 140,
+              "height": 118,
               "id": "49",
               "isHidden": true,
               "isPlaceholder": false,
@@ -15827,7 +15827,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "85",
               "isPlaceholder": false,
               "key": "n_85",
@@ -15848,7 +15848,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             },
           ],
           "hasBranchLabel": true,
-          "height": 140,
+          "height": 118,
           "id": "9",
           "isHidden": true,
           "isParallel": true,
@@ -15856,7 +15856,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "key": "n_9",
           "name": "B",
           "shiftX": 0,
-          "shiftY": 22,
+          "shiftY": 44,
           "stage": {
             "children": [],
             "id": "9",
@@ -15874,7 +15874,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "16",
               "isPlaceholder": false,
               "key": "n_16",
@@ -15896,7 +15896,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "31",
               "isPlaceholder": false,
               "key": "n_31",
@@ -15918,7 +15918,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "57",
               "isPlaceholder": false,
               "key": "n_57",
@@ -15940,7 +15940,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "76",
               "isPlaceholder": false,
               "key": "n_76",
@@ -15962,7 +15962,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "92",
               "isPlaceholder": false,
               "key": "n_92",
@@ -15984,7 +15984,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "104",
               "isPlaceholder": false,
               "key": "n_104",
@@ -16006,7 +16006,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "111",
               "isPlaceholder": false,
               "key": "n_111",
@@ -16027,7 +16027,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             },
           ],
           "hasBranchLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "10",
           "isHidden": true,
           "isParallel": true,
@@ -16035,7 +16035,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           "key": "n_10",
           "name": "C",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "10",
@@ -16051,7 +16051,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 442,
+      "height": 420,
       "id": "5",
       "isHidden": true,
       "isPlaceholder": false,
@@ -16076,7 +16076,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "12",
           "isPlaceholder": false,
           "key": "n_12",
@@ -16100,7 +16100,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "35",
               "isParallel": true,
               "isPlaceholder": false,
@@ -16123,14 +16123,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "36",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_36",
               "name": "A2",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "36",
@@ -16146,14 +16146,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "37",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_37",
               "name": "A3",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "37",
@@ -16169,7 +16169,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 210,
+          "height": 188,
           "id": "26",
           "isHidden": true,
           "isPlaceholder": false,
@@ -16194,7 +16194,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "72",
               "isParallel": true,
               "isPlaceholder": false,
@@ -16217,14 +16217,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "73",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_73",
               "name": "A2",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "73",
@@ -16240,7 +16240,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 140,
+          "height": 118,
           "id": "67",
           "isHidden": true,
           "isPlaceholder": false,
@@ -16263,7 +16263,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "99",
           "isPlaceholder": false,
           "key": "n_99",
@@ -16284,7 +16284,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         },
       ],
       "hasBranchLabel": true,
-      "height": 210,
+      "height": 188,
       "id": "8",
       "isHidden": true,
       "isParallel": true,
@@ -16308,7 +16308,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "12",
       "isPlaceholder": false,
       "key": "n_12",
@@ -16332,7 +16332,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "35",
           "isParallel": true,
           "isPlaceholder": false,
@@ -16355,14 +16355,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "36",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_36",
           "name": "A2",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "36",
@@ -16378,14 +16378,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "37",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_37",
           "name": "A3",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "37",
@@ -16401,7 +16401,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 210,
+      "height": 188,
       "id": "26",
       "isHidden": true,
       "isPlaceholder": false,
@@ -16424,7 +16424,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "35",
       "isParallel": true,
       "isPlaceholder": false,
@@ -16447,14 +16447,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "36",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_36",
       "name": "A2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "36",
@@ -16470,14 +16470,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "37",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_37",
       "name": "A3",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "37",
@@ -16495,7 +16495,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "72",
           "isParallel": true,
           "isPlaceholder": false,
@@ -16518,14 +16518,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "73",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_73",
           "name": "A2",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "73",
@@ -16541,7 +16541,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 140,
+      "height": 118,
       "id": "67",
       "isHidden": true,
       "isPlaceholder": false,
@@ -16564,7 +16564,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "72",
       "isParallel": true,
       "isPlaceholder": false,
@@ -16587,14 +16587,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "73",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_73",
       "name": "A2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "73",
@@ -16610,7 +16610,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "99",
       "isPlaceholder": false,
       "key": "n_99",
@@ -16634,7 +16634,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "14",
           "isPlaceholder": false,
           "key": "n_14",
@@ -16656,7 +16656,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "28",
           "isPlaceholder": false,
           "key": "n_28",
@@ -16680,7 +16680,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "51",
               "isParallel": true,
               "isPlaceholder": false,
@@ -16703,14 +16703,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "52",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_52",
               "name": "B2",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "52",
@@ -16726,7 +16726,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 140,
+          "height": 118,
           "id": "49",
           "isHidden": true,
           "isPlaceholder": false,
@@ -16749,7 +16749,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "85",
           "isPlaceholder": false,
           "key": "n_85",
@@ -16770,7 +16770,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         },
       ],
       "hasBranchLabel": true,
-      "height": 140,
+      "height": 118,
       "id": "9",
       "isHidden": true,
       "isParallel": true,
@@ -16778,7 +16778,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "key": "n_9",
       "name": "B",
       "shiftX": 0,
-      "shiftY": 22,
+      "shiftY": 44,
       "stage": {
         "children": [],
         "id": "9",
@@ -16794,7 +16794,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "14",
       "isPlaceholder": false,
       "key": "n_14",
@@ -16816,7 +16816,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "28",
       "isPlaceholder": false,
       "key": "n_28",
@@ -16840,7 +16840,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "51",
           "isParallel": true,
           "isPlaceholder": false,
@@ -16863,14 +16863,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "52",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_52",
           "name": "B2",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "52",
@@ -16886,7 +16886,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 140,
+      "height": 118,
       "id": "49",
       "isHidden": true,
       "isPlaceholder": false,
@@ -16909,7 +16909,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "51",
       "isParallel": true,
       "isPlaceholder": false,
@@ -16932,14 +16932,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "52",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_52",
       "name": "B2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "52",
@@ -16955,7 +16955,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "85",
       "isPlaceholder": false,
       "key": "n_85",
@@ -16979,7 +16979,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "16",
           "isPlaceholder": false,
           "key": "n_16",
@@ -17001,7 +17001,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "31",
           "isPlaceholder": false,
           "key": "n_31",
@@ -17023,7 +17023,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "57",
           "isPlaceholder": false,
           "key": "n_57",
@@ -17045,7 +17045,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "76",
           "isPlaceholder": false,
           "key": "n_76",
@@ -17067,7 +17067,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "92",
           "isPlaceholder": false,
           "key": "n_92",
@@ -17089,7 +17089,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "104",
           "isPlaceholder": false,
           "key": "n_104",
@@ -17111,7 +17111,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "111",
           "isPlaceholder": false,
           "key": "n_111",
@@ -17132,7 +17132,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
         },
       ],
       "hasBranchLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isHidden": true,
       "isParallel": true,
@@ -17140,7 +17140,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       "key": "n_10",
       "name": "C",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "10",
@@ -17156,7 +17156,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "16",
       "isPlaceholder": false,
       "key": "n_16",
@@ -17178,7 +17178,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "31",
       "isPlaceholder": false,
       "key": "n_31",
@@ -17200,7 +17200,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "57",
       "isPlaceholder": false,
       "key": "n_57",
@@ -17222,7 +17222,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "76",
       "isPlaceholder": false,
       "key": "n_76",
@@ -17244,7 +17244,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "92",
       "isPlaceholder": false,
       "key": "n_92",
@@ -17266,7 +17266,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "104",
       "isPlaceholder": false,
       "key": "n_104",
@@ -17288,7 +17288,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "111",
       "isPlaceholder": false,
       "key": "n_111",
@@ -17310,7 +17310,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -17835,13 +17835,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
       ],
     },
   ],
-  "measuredHeight": 502,
+  "measuredHeight": 480,
   "measuredWidth": 1246,
   "nodes": [
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -17856,7 +17856,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "12",
       "isPlaceholder": false,
       "key": "n_12",
@@ -17878,7 +17878,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "35",
       "isParallel": true,
       "isPlaceholder": false,
@@ -17901,14 +17901,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "36",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_36",
       "name": "A2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "36",
@@ -17924,14 +17924,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "37",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_37",
       "name": "A3",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "37",
@@ -17947,7 +17947,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "72",
       "isParallel": true,
       "isPlaceholder": false,
@@ -17970,14 +17970,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "73",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_73",
       "name": "A2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "73",
@@ -17993,7 +17993,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "99",
       "isPlaceholder": false,
       "key": "n_99",
@@ -18015,7 +18015,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "14",
       "isPlaceholder": false,
       "key": "n_14",
@@ -18037,7 +18037,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "28",
       "isPlaceholder": false,
       "key": "n_28",
@@ -18059,7 +18059,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "51",
       "isParallel": true,
       "isPlaceholder": false,
@@ -18082,14 +18082,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "52",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_52",
       "name": "B2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "52",
@@ -18105,7 +18105,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "85",
       "isPlaceholder": false,
       "key": "n_85",
@@ -18127,7 +18127,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "16",
       "isPlaceholder": false,
       "key": "n_16",
@@ -18149,7 +18149,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "31",
       "isPlaceholder": false,
       "key": "n_31",
@@ -18171,7 +18171,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "57",
       "isPlaceholder": false,
       "key": "n_57",
@@ -18193,7 +18193,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "76",
       "isPlaceholder": false,
       "key": "n_76",
@@ -18215,7 +18215,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "92",
       "isPlaceholder": false,
       "key": "n_92",
@@ -18237,7 +18237,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "104",
       "isPlaceholder": false,
       "key": "n_104",
@@ -18259,7 +18259,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "111",
       "isPlaceholder": false,
       "key": "n_111",
@@ -18281,7 +18281,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1155_smokeTest.jenkin
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -18611,7 +18611,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       "children": [
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -18626,7 +18626,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "4",
           "isPlaceholder": false,
           "key": "n_4",
@@ -18648,7 +18648,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "6",
           "isPlaceholder": false,
           "key": "n_6",
@@ -18670,7 +18670,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "10",
           "isPlaceholder": false,
           "key": "n_10",
@@ -18692,7 +18692,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "17",
           "isPlaceholder": false,
           "key": "n_17",
@@ -18713,7 +18713,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -18726,7 +18726,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "y": 16,
         },
       ],
-      "height": 70,
+      "height": 48,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -18741,7 +18741,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -18756,7 +18756,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "4",
       "isPlaceholder": false,
       "key": "n_4",
@@ -18778,7 +18778,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -18800,7 +18800,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isPlaceholder": false,
       "key": "n_10",
@@ -18822,7 +18822,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isPlaceholder": false,
       "key": "n_17",
@@ -18843,7 +18843,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -18952,12 +18952,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       ],
     },
   ],
-  "measuredHeight": 86,
+  "measuredHeight": 64,
   "measuredWidth": 686,
   "nodes": [
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -18972,7 +18972,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "4",
       "isPlaceholder": false,
       "key": "n_4",
@@ -18994,7 +18994,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -19016,7 +19016,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isPlaceholder": false,
       "key": "n_10",
@@ -19038,7 +19038,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isPlaceholder": false,
       "key": "n_17",
@@ -19059,7 +19059,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -19150,7 +19150,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -19167,7 +19167,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
             {
               "children": [],
               "hasBigLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "6",
               "isPlaceholder": false,
               "isSkipped": true,
@@ -19190,7 +19190,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "10",
               "isPlaceholder": false,
               "key": "n_10",
@@ -19212,7 +19212,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           ],
           "firstChildIsSkipped": true,
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "4",
           "isHidden": true,
           "isPlaceholder": false,
@@ -19235,7 +19235,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "17",
           "isPlaceholder": false,
           "key": "n_17",
@@ -19257,7 +19257,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -19270,7 +19270,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
           "y": 60,
         },
       ],
-      "height": 70,
+      "height": 48,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -19286,7 +19286,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -19303,7 +19303,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "6",
           "isPlaceholder": false,
           "isSkipped": true,
@@ -19326,7 +19326,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "10",
           "isPlaceholder": false,
           "key": "n_10",
@@ -19348,7 +19348,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       ],
       "firstChildIsSkipped": true,
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "4",
       "isHidden": true,
       "isPlaceholder": false,
@@ -19371,7 +19371,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -19394,7 +19394,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isPlaceholder": false,
       "key": "n_10",
@@ -19416,7 +19416,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isPlaceholder": false,
       "key": "n_17",
@@ -19438,7 +19438,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -19593,13 +19593,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
       ],
     },
   ],
-  "measuredHeight": 130,
+  "measuredHeight": 108,
   "measuredWidth": 546,
   "nodes": [
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -19614,7 +19614,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -19637,7 +19637,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isPlaceholder": false,
       "key": "n_10",
@@ -19659,7 +19659,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isPlaceholder": false,
       "key": "n_17",
@@ -19681,7 +19681,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_1st_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -19739,7 +19739,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       "children": [
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -19754,7 +19754,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "4",
           "isPlaceholder": false,
           "key": "n_4",
@@ -19776,7 +19776,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "6",
           "isPlaceholder": false,
           "key": "n_6",
@@ -19798,7 +19798,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "11",
           "isPlaceholder": false,
           "key": "n_11",
@@ -19820,7 +19820,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "17",
           "isPlaceholder": false,
           "key": "n_17",
@@ -19841,7 +19841,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -19854,7 +19854,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "y": 16,
         },
       ],
-      "height": 70,
+      "height": 48,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -19869,7 +19869,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -19884,7 +19884,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "4",
       "isPlaceholder": false,
       "key": "n_4",
@@ -19906,7 +19906,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -19928,7 +19928,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "11",
       "isPlaceholder": false,
       "key": "n_11",
@@ -19950,7 +19950,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isPlaceholder": false,
       "key": "n_17",
@@ -19971,7 +19971,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -20080,12 +20080,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       ],
     },
   ],
-  "measuredHeight": 86,
+  "measuredHeight": 64,
   "measuredWidth": 686,
   "nodes": [
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -20100,7 +20100,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "4",
       "isPlaceholder": false,
       "key": "n_4",
@@ -20122,7 +20122,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -20144,7 +20144,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "11",
       "isPlaceholder": false,
       "key": "n_11",
@@ -20166,7 +20166,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isPlaceholder": false,
       "key": "n_17",
@@ -20187,7 +20187,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -20278,7 +20278,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -20295,7 +20295,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "6",
               "isPlaceholder": false,
               "key": "n_6",
@@ -20317,7 +20317,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
             {
               "children": [],
               "hasBigLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "11",
               "isPlaceholder": false,
               "isSkipped": true,
@@ -20339,7 +20339,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
             },
           ],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "4",
           "isHidden": true,
           "isPlaceholder": false,
@@ -20362,7 +20362,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "17",
           "isPlaceholder": false,
           "key": "n_17",
@@ -20384,7 +20384,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -20397,7 +20397,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
           "y": 60,
         },
       ],
-      "height": 70,
+      "height": 48,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -20413,7 +20413,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -20430,7 +20430,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "6",
           "isPlaceholder": false,
           "key": "n_6",
@@ -20452,7 +20452,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "11",
           "isPlaceholder": false,
           "isSkipped": true,
@@ -20474,7 +20474,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
         },
       ],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "4",
       "isHidden": true,
       "isPlaceholder": false,
@@ -20497,7 +20497,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -20519,7 +20519,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "11",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -20542,7 +20542,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isPlaceholder": false,
       "key": "n_17",
@@ -20564,7 +20564,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -20697,13 +20697,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
       ],
     },
   ],
-  "measuredHeight": 130,
+  "measuredHeight": 108,
   "measuredWidth": 546,
   "nodes": [
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -20718,7 +20718,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -20740,7 +20740,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "11",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -20763,7 +20763,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isPlaceholder": false,
       "key": "n_17",
@@ -20785,7 +20785,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_2nd_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -20843,7 +20843,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       "children": [
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -20858,7 +20858,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "4",
           "isPlaceholder": false,
           "key": "n_4",
@@ -20880,7 +20880,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "6",
           "isPlaceholder": false,
           "key": "n_6",
@@ -20902,7 +20902,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "10",
           "isPlaceholder": false,
           "key": "n_10",
@@ -20924,7 +20924,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "16",
           "isPlaceholder": false,
           "key": "n_16",
@@ -20945,7 +20945,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -20958,7 +20958,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "y": 16,
         },
       ],
-      "height": 70,
+      "height": 48,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -20973,7 +20973,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -20988,7 +20988,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "4",
       "isPlaceholder": false,
       "key": "n_4",
@@ -21010,7 +21010,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -21032,7 +21032,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isPlaceholder": false,
       "key": "n_10",
@@ -21054,7 +21054,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "16",
       "isPlaceholder": false,
       "key": "n_16",
@@ -21075,7 +21075,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -21184,12 +21184,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       ],
     },
   ],
-  "measuredHeight": 86,
+  "measuredHeight": 64,
   "measuredWidth": 686,
   "nodes": [
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -21204,7 +21204,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "4",
       "isPlaceholder": false,
       "key": "n_4",
@@ -21226,7 +21226,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -21248,7 +21248,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isPlaceholder": false,
       "key": "n_10",
@@ -21270,7 +21270,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "16",
       "isPlaceholder": false,
       "key": "n_16",
@@ -21291,7 +21291,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -21382,7 +21382,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -21399,7 +21399,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
             {
               "children": [],
               "hasBigLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "6",
               "isPlaceholder": false,
               "isSkipped": true,
@@ -21422,7 +21422,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
             {
               "children": [],
               "hasBigLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "10",
               "isPlaceholder": false,
               "isSkipped": true,
@@ -21445,7 +21445,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           ],
           "firstChildIsSkipped": true,
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "4",
           "isHidden": true,
           "isPlaceholder": false,
@@ -21468,7 +21468,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "16",
           "isPlaceholder": false,
           "key": "n_16",
@@ -21490,7 +21490,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -21503,7 +21503,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
           "y": 60,
         },
       ],
-      "height": 70,
+      "height": 48,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -21519,7 +21519,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -21536,7 +21536,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "6",
           "isPlaceholder": false,
           "isSkipped": true,
@@ -21559,7 +21559,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "10",
           "isPlaceholder": false,
           "isSkipped": true,
@@ -21582,7 +21582,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       ],
       "firstChildIsSkipped": true,
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "4",
       "isHidden": true,
       "isPlaceholder": false,
@@ -21605,7 +21605,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -21628,7 +21628,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -21651,7 +21651,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "16",
       "isPlaceholder": false,
       "key": "n_16",
@@ -21673,7 +21673,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -21832,13 +21832,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
       ],
     },
   ],
-  "measuredHeight": 130,
+  "measuredHeight": 108,
   "measuredWidth": 546,
   "nodes": [
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -21853,7 +21853,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -21876,7 +21876,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -21899,7 +21899,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "16",
       "isPlaceholder": false,
       "key": "n_16",
@@ -21921,7 +21921,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_all_skip
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -21963,7 +21963,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "children": [
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -21978,7 +21978,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "4",
           "isPlaceholder": false,
           "key": "n_4",
@@ -22000,7 +22000,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "9",
           "isPlaceholder": false,
           "key": "n_9",
@@ -22022,7 +22022,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "10",
           "isPlaceholder": false,
           "key": "n_10",
@@ -22044,7 +22044,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "20",
           "isPlaceholder": false,
           "key": "n_20",
@@ -22066,7 +22066,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "21",
           "isPlaceholder": false,
           "key": "n_21",
@@ -22088,7 +22088,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "children": [],
           "hasTiming": true,
-          "height": 70,
+          "height": 48,
           "id": "38",
           "isPlaceholder": false,
           "key": "n_38",
@@ -22109,7 +22109,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         },
         {
           "children": [],
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -22122,7 +22122,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "y": 16,
         },
       ],
-      "height": 70,
+      "height": 48,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -22137,7 +22137,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -22152,7 +22152,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "4",
       "isPlaceholder": false,
       "key": "n_4",
@@ -22174,7 +22174,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "9",
       "isPlaceholder": false,
       "key": "n_9",
@@ -22196,7 +22196,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isPlaceholder": false,
       "key": "n_10",
@@ -22218,7 +22218,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "20",
       "isPlaceholder": false,
       "key": "n_20",
@@ -22240,7 +22240,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "21",
       "isPlaceholder": false,
       "key": "n_21",
@@ -22262,7 +22262,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "38",
       "isPlaceholder": false,
       "key": "n_38",
@@ -22283,7 +22283,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -22428,12 +22428,12 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       ],
     },
   ],
-  "measuredHeight": 86,
+  "measuredHeight": 64,
   "measuredWidth": 966,
   "nodes": [
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -22448,7 +22448,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "4",
       "isPlaceholder": false,
       "key": "n_4",
@@ -22470,7 +22470,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "9",
       "isPlaceholder": false,
       "key": "n_9",
@@ -22492,7 +22492,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isPlaceholder": false,
       "key": "n_10",
@@ -22514,7 +22514,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "20",
       "isPlaceholder": false,
       "key": "n_20",
@@ -22536,7 +22536,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "21",
       "isPlaceholder": false,
       "key": "n_21",
@@ -22558,7 +22558,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasTiming": true,
-      "height": 70,
+      "height": 48,
       "id": "38",
       "isPlaceholder": false,
       "key": "n_38",
@@ -22579,7 +22579,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     },
     {
       "children": [],
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -22702,7 +22702,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -22721,7 +22721,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "9",
                   "isParallel": true,
                   "isPlaceholder": false,
@@ -22744,14 +22744,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "10",
                   "isParallel": true,
                   "isPlaceholder": false,
                   "key": "n_10",
                   "name": "nested 2",
                   "shiftX": 0,
-                  "shiftY": 0,
+                  "shiftY": 22,
                   "stage": {
                     "children": [],
                     "id": "10",
@@ -22767,7 +22767,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
               ],
               "hasBigLabel": true,
               "hasParallel": true,
-              "height": 140,
+              "height": 118,
               "id": "6",
               "isHidden": true,
               "isPlaceholder": false,
@@ -22793,7 +22793,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "20",
                   "isParallel": true,
                   "isPlaceholder": false,
@@ -22817,7 +22817,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
                 {
                   "children": [],
                   "hasSmallLabel": true,
-                  "height": 70,
+                  "height": 48,
                   "id": "21",
                   "isParallel": true,
                   "isPlaceholder": false,
@@ -22825,7 +22825,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
                   "key": "n_21",
                   "name": "Skipped 2",
                   "shiftX": 0,
-                  "shiftY": 0,
+                  "shiftY": 22,
                   "stage": {
                     "children": [],
                     "id": "21",
@@ -22842,7 +22842,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
               "firstChildIsSkipped": true,
               "hasBigLabel": true,
               "hasParallel": true,
-              "height": 140,
+              "height": 118,
               "id": "17",
               "isHidden": true,
               "isPlaceholder": false,
@@ -22864,7 +22864,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
             },
           ],
           "hasBigLabel": true,
-          "height": 140,
+          "height": 118,
           "id": "4",
           "isHidden": true,
           "isPlaceholder": false,
@@ -22887,7 +22887,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "38",
           "isPlaceholder": false,
           "key": "n_38",
@@ -22909,7 +22909,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -22922,7 +22922,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "y": 60,
         },
       ],
-      "height": 140,
+      "height": 118,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -22938,7 +22938,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -22957,7 +22957,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "9",
               "isParallel": true,
               "isPlaceholder": false,
@@ -22980,14 +22980,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "10",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_10",
               "name": "nested 2",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "10",
@@ -23003,7 +23003,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 140,
+          "height": 118,
           "id": "6",
           "isHidden": true,
           "isPlaceholder": false,
@@ -23029,7 +23029,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "20",
               "isParallel": true,
               "isPlaceholder": false,
@@ -23053,7 +23053,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "21",
               "isParallel": true,
               "isPlaceholder": false,
@@ -23061,7 +23061,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
               "key": "n_21",
               "name": "Skipped 2",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "21",
@@ -23078,7 +23078,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "firstChildIsSkipped": true,
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 140,
+          "height": 118,
           "id": "17",
           "isHidden": true,
           "isPlaceholder": false,
@@ -23100,7 +23100,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         },
       ],
       "hasBigLabel": true,
-      "height": 140,
+      "height": 118,
       "id": "4",
       "isHidden": true,
       "isPlaceholder": false,
@@ -23125,7 +23125,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "9",
           "isParallel": true,
           "isPlaceholder": false,
@@ -23148,14 +23148,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "10",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_10",
           "name": "nested 2",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "10",
@@ -23171,7 +23171,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 140,
+      "height": 118,
       "id": "6",
       "isHidden": true,
       "isPlaceholder": false,
@@ -23194,7 +23194,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "9",
       "isParallel": true,
       "isPlaceholder": false,
@@ -23217,14 +23217,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_10",
       "name": "nested 2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "10",
@@ -23243,7 +23243,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "20",
           "isParallel": true,
           "isPlaceholder": false,
@@ -23267,7 +23267,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "21",
           "isParallel": true,
           "isPlaceholder": false,
@@ -23275,7 +23275,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
           "key": "n_21",
           "name": "Skipped 2",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "21",
@@ -23292,7 +23292,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "firstChildIsSkipped": true,
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 140,
+      "height": 118,
       "id": "17",
       "isHidden": true,
       "isPlaceholder": false,
@@ -23315,7 +23315,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "20",
       "isParallel": true,
       "isPlaceholder": false,
@@ -23339,7 +23339,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "21",
       "isParallel": true,
       "isPlaceholder": false,
@@ -23347,7 +23347,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "key": "n_21",
       "name": "Skipped 2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "21",
@@ -23363,7 +23363,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "38",
       "isPlaceholder": false,
       "key": "n_38",
@@ -23385,7 +23385,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -23583,13 +23583,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       ],
     },
   ],
-  "measuredHeight": 200,
+  "measuredHeight": 178,
   "measuredWidth": 546,
   "nodes": [
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -23604,7 +23604,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "9",
       "isParallel": true,
       "isPlaceholder": false,
@@ -23627,14 +23627,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "10",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_10",
       "name": "nested 2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "10",
@@ -23650,7 +23650,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "20",
       "isParallel": true,
       "isPlaceholder": false,
@@ -23674,7 +23674,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "21",
       "isParallel": true,
       "isPlaceholder": false,
@@ -23682,7 +23682,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
       "key": "n_21",
       "name": "Skipped 2",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "21",
@@ -23698,7 +23698,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "38",
       "isPlaceholder": false,
       "key": "n_38",
@@ -23720,7 +23720,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > gh1286_wrapped_two_para
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -23827,7 +23827,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -23842,7 +23842,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "6",
           "isPlaceholder": false,
           "key": "n_6",
@@ -23866,7 +23866,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "16",
               "isParallel": true,
               "isPlaceholder": false,
@@ -23889,14 +23889,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "17",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_17",
               "name": "Branch B",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "id": "17",
@@ -23912,14 +23912,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
             {
               "children": [],
               "hasSmallLabel": true,
-              "height": 70,
+              "height": 48,
               "id": "18",
               "isParallel": true,
               "isPlaceholder": false,
               "key": "n_18",
               "name": "Branch C",
               "shiftX": 0,
-              "shiftY": 0,
+              "shiftY": 22,
               "stage": {
                 "children": [],
                 "collapsedChildCount": 2,
@@ -23936,7 +23936,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           ],
           "hasBigLabel": true,
           "hasParallel": true,
-          "height": 210,
+          "height": 188,
           "id": "12",
           "isHidden": true,
           "isPlaceholder": false,
@@ -23959,7 +23959,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "54",
           "isPlaceholder": false,
           "isSkipped": true,
@@ -23982,7 +23982,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -23995,7 +23995,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "y": 38,
         },
       ],
-      "height": 210,
+      "height": 188,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -24011,7 +24011,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -24026,7 +24026,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -24050,7 +24050,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "16",
           "isParallel": true,
           "isPlaceholder": false,
@@ -24073,14 +24073,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "17",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_17",
           "name": "Branch B",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "id": "17",
@@ -24096,14 +24096,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "18",
           "isParallel": true,
           "isPlaceholder": false,
           "key": "n_18",
           "name": "Branch C",
           "shiftX": 0,
-          "shiftY": 0,
+          "shiftY": 22,
           "stage": {
             "children": [],
             "collapsedChildCount": 2,
@@ -24120,7 +24120,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       ],
       "hasBigLabel": true,
       "hasParallel": true,
-      "height": 210,
+      "height": 188,
       "id": "12",
       "isHidden": true,
       "isPlaceholder": false,
@@ -24143,7 +24143,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "16",
       "isParallel": true,
       "isPlaceholder": false,
@@ -24166,14 +24166,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_17",
       "name": "Branch B",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "17",
@@ -24189,14 +24189,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "18",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_18",
       "name": "Branch C",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "collapsedChildCount": 2,
@@ -24213,7 +24213,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "54",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -24236,7 +24236,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -24389,13 +24389,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       ],
     },
   ],
-  "measuredHeight": 248,
+  "measuredHeight": 226,
   "measuredWidth": 546,
   "nodes": [
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -24410,7 +24410,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -24432,7 +24432,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "16",
       "isParallel": true,
       "isPlaceholder": false,
@@ -24455,14 +24455,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "17",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_17",
       "name": "Branch B",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "id": "17",
@@ -24478,14 +24478,14 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "18",
       "isParallel": true,
       "isPlaceholder": false,
       "key": "n_18",
       "name": "Branch C",
       "shiftX": 0,
-      "shiftY": 0,
+      "shiftY": 22,
       "stage": {
         "children": [],
         "collapsedChildCount": 2,
@@ -24502,7 +24502,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "54",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -24525,7 +24525,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -24617,7 +24617,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -1,
           "isPlaceholder": true,
           "key": "start-node",
@@ -24632,7 +24632,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "6",
           "isPlaceholder": false,
           "key": "n_6",
@@ -24654,7 +24654,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "children": [],
           "hasSmallLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "12",
           "isPlaceholder": false,
           "key": "n_12",
@@ -24677,7 +24677,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": "54",
           "isPlaceholder": false,
           "isSkipped": true,
@@ -24700,7 +24700,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
         {
           "children": [],
           "hasBigLabel": true,
-          "height": 70,
+          "height": 48,
           "id": -3,
           "isPlaceholder": true,
           "key": "end-node",
@@ -24713,7 +24713,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
           "y": 38,
         },
       ],
-      "height": 70,
+      "height": 48,
       "id": -42,
       "isHidden": true,
       "isPlaceholder": true,
@@ -24729,7 +24729,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -24744,7 +24744,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -24766,7 +24766,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "12",
       "isPlaceholder": false,
       "key": "n_12",
@@ -24789,7 +24789,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "54",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -24812,7 +24812,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",
@@ -24929,13 +24929,13 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
       ],
     },
   ],
-  "measuredHeight": 108,
+  "measuredHeight": 86,
   "measuredWidth": 546,
   "nodes": [
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -1,
       "isPlaceholder": true,
       "key": "start-node",
@@ -24950,7 +24950,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "6",
       "isPlaceholder": false,
       "key": "n_6",
@@ -24972,7 +24972,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasSmallLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "12",
       "isPlaceholder": false,
       "key": "n_12",
@@ -24995,7 +24995,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": "54",
       "isPlaceholder": false,
       "isSkipped": true,
@@ -25018,7 +25018,7 @@ exports[`NestedPipelineGraphLayout > nestedGraphLayout > selective collapse > sh
     {
       "children": [],
       "hasBigLabel": true,
-      "height": 70,
+      "height": 48,
       "id": -3,
       "isPlaceholder": true,
       "key": "end-node",

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.spec.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/labels.spec.tsx
@@ -20,6 +20,10 @@ const layout: LayoutInfo = {
   labelOffsetV: 20,
   smallLabelOffsetV: 15,
   ypStart: 55,
+  graphSpacingTop: 0,
+  graphSpacingRight: 0,
+  graphSpacingBottom: 0,
+  graphSpacingLeft: 0,
 };
 
 function makeStage(overrides: Partial<StageInfo> = {}): StageInfo {

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.spec.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/nodes.spec.tsx
@@ -24,6 +24,10 @@ describe("Counter node with 50+ parallel stages", () => {
     labelOffsetV: 20,
     smallLabelOffsetV: 15,
     ypStart: 55,
+    graphSpacingTop: 0,
+    graphSpacingRight: 0,
+    graphSpacingBottom: 0,
+    graphSpacingLeft: 0,
   };
 
   const baseStage: StageInfo = {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- Related to https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/1348

This PR is refining the graph spacing and adjusting the graph height to match the auto-scaling:

- Avoid spurious space below graph: Instead of reserving space for a big label on the next row by default, the extra space is only added when stacking the next parallel node below.

- Resetting the position restores automatic centering again. Previously it would recenter once.

- Double click on the height resizer (border between graph and stages details) now restores to the automatic height rather than a fixed 250px.

- The upper limit for resizing has been bumped from a fixed 1500px to 3x the graph height (maximum height that is sensible with 3x zoom active). The lower limit is `min(actualHeight, layout.nodeHeightV)`.

- The start/end big label is always visible again (regression from #1349).

- Remove excessive spacing from job UI/collapsed listing (regression from #1349)

### Testing done


https://github.com/user-attachments/assets/ca3ca6d6-f5f2-4c0e-88cd-354f37d829c3

- start with previous resized height
- centering is active by default, resize to demo this
- double click restores full height
- move to cancel centering
- reset centers again, resize to demo this


before | after | comment
--- | --- | ---
<img width="1920" height="1052" alt="image" src="https://github.com/user-attachments/assets/8732d9e3-21ab-44c3-98d8-f2606ee84122" /> | <img width="1920" height="1052" alt="image" src="https://github.com/user-attachments/assets/9a51a44e-25ce-4d41-a740-603d1a23dc19" /> | height adjusted from scaling 
<img width="1920" height="1052" alt="image" src="https://github.com/user-attachments/assets/9297574e-543f-4f30-8835-ccc6635ada47" /> | <img width="1920" height="1052" alt="image" src="https://github.com/user-attachments/assets/c5901bfe-6007-41c2-8eae-25101924af70" /> | fix excessive spacing from https://github.com/jenkinsci/pipeline-graph-view-plugin/pull/1349
<img width="1920" height="1052" alt="image" src="https://github.com/user-attachments/assets/a2d8b334-22e7-4f75-9069-a869d66874c2" /> | <img width="1920" height="1052" alt="image" src="https://github.com/user-attachments/assets/c62ed98c-f92f-4ccf-8c49-33c2d7850efa" /> | start always visible (regression from #1349)
<img width="1920" height="1052" alt="image" src="https://github.com/user-attachments/assets/91be6e35-70da-4ef1-b01b-30a84c0dfc02" /> | <img width="1920" height="1052" alt="image" src="https://github.com/user-attachments/assets/566d4ce4-e191-4676-a336-d7582b601e6c" /> | end always visible (regression from #1349)



<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
