### PR TITLE
Show fallback UI for build with syntax error

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
@@ -69,9 +69,8 @@ public class PipelineGraphApi {
         FlowExecution execution = run.getExecution();
         if (execution == null) {
             // If we don't have an execution - e.g. if the Pipeline has a syntax error -
-            // then return an
-            // empty graph.
-            return new PipelineGraph(new ArrayList<>(), false);
+            // then return an empty graph.
+            return new PipelineGraph(new ArrayList<>(), true);
         }
         // Look up completed state before computing tree.
         boolean complete = execution.isComplete();

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphViewCache.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphViewCache.java
@@ -37,7 +37,7 @@ import tools.jackson.databind.json.JsonMapper;
  */
 public class PipelineGraphViewCache {
 
-    public static final int SCHEMA_VERSION = 4;
+    public static final int SCHEMA_VERSION = 3;
 
     public static final String TREE_FILE_NAME = "pipeline-graph-view-tree.v" + SCHEMA_VERSION + ".json";
     public static final String ALL_STEPS_FILE_NAME = "pipeline-graph-view-allsteps.v" + SCHEMA_VERSION + ".json";

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphViewCache.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphViewCache.java
@@ -37,7 +37,7 @@ import tools.jackson.databind.json.JsonMapper;
  */
 public class PipelineGraphViewCache {
 
-    public static final int SCHEMA_VERSION = 3;
+    public static final int SCHEMA_VERSION = 4;
 
     public static final String TREE_FILE_NAME = "pipeline-graph-view-tree.v" + SCHEMA_VERSION + ".json";
     public static final String ALL_STEPS_FILE_NAME = "pipeline-graph-view-allsteps.v" + SCHEMA_VERSION + ".json";

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
@@ -372,14 +372,27 @@ class PipelineGraphApiTest {
     }
 
     @Test
+    void pipelineWithEarlyFailure() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "pipelineWithEarlyFailure", "pipelineWithEarlyFailure.jenkinsfile", Result.FAILURE);
+
+        assertThat(run.getExecution(), notNullValue());
+        PipelineGraph tree = new PipelineGraphApi(run).createTree();
+        assertThat(tree.complete, equalTo(true));
+        String stagesString = TestUtils.collectStagesAsString(tree.stages, TestUtils::nodeNameAndStatus);
+
+        assertThat(stagesString, equalTo("%s{failure}".formatted(Messages.FlowNodeWrapper_noStage())));
+    }
+
+    @Test
     void pipelineWithSyntaxError() throws Exception {
         WorkflowRun run = TestUtils.createAndRunJob(
                 j, "pipelineWithSyntaxError", "pipelineWithSyntaxError.jenkinsfile", Result.FAILURE);
 
-        List<PipelineStage> stages = new PipelineGraphApi(run).createTree().stages;
-        String stagesString = TestUtils.collectStagesAsString(stages, TestUtils::nodeNameAndStatus);
-
-        assertThat(stagesString, equalTo("%s{failure}".formatted(Messages.FlowNodeWrapper_noStage())));
+        assertThat(run.getExecution(), nullValue());
+        PipelineGraph tree = new PipelineGraphApi(run).createTree();
+        assertThat(tree.complete, equalTo(true));
+        assertThat(tree.stages, empty());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStepApiTest.java
@@ -2,12 +2,14 @@ package io.jenkins.plugins.pipelinegraphview.utils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 import hudson.model.Result;
 import hudson.model.queue.QueueTaskFuture;
@@ -482,14 +484,27 @@ class PipelineStepApiTest {
     }
 
     @Test
+    void pipelineWithEarlyFailure() throws Exception {
+        WorkflowRun run = TestUtils.createAndRunJob(
+                j, "pipelineWithEarlyFailure", "pipelineWithEarlyFailure.jenkinsfile", Result.FAILURE);
+
+        assertThat(run.getExecution(), notNullValue());
+        PipelineStepList stepList = new PipelineStepApi(run).getAllSteps();
+        assertThat(stepList.runIsComplete, equalTo(true));
+        String stepsString = TestUtils.collectStepsAsString(stepList.steps, TestUtils::nodeNameAndStatus);
+
+        assertThat(stepsString, equalTo("Pipeline error{failure}"));
+    }
+
+    @Test
     void pipelineWithSyntaxError() throws Exception {
         WorkflowRun run = TestUtils.createAndRunJob(
                 j, "pipelineWithSyntaxError", "pipelineWithSyntaxError.jenkinsfile", Result.FAILURE);
 
-        List<PipelineStep> steps = new PipelineStepApi(run).getAllSteps().steps;
-        String stepsString = TestUtils.collectStepsAsString(steps, TestUtils::nodeNameAndStatus);
-
-        assertThat(stepsString, equalTo("Pipeline error{failure}"));
+        assertThat(run.getExecution(), nullValue());
+        PipelineStepList stepList = new PipelineStepApi(run).getAllSteps();
+        assertThat(stepList.runIsComplete, equalTo(true));
+        assertThat(stepList.steps, empty());
     }
 
     @Test

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/pipelineWithEarlyFailure.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/pipelineWithEarlyFailure.jenkinsfile
@@ -1,0 +1,1 @@
+propertyDoesNotExist

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/pipelineWithSyntaxError.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/pipelineWithSyntaxError.jenkinsfile
@@ -1,5 +1,6 @@
 pipeline {
   stages {
+    // The pipeline fails as no stage is included below here.
     script {
       echo '1'
     }

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/pipelineWithSyntaxError.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/pipelineWithSyntaxError.jenkinsfile
@@ -1,1 +1,7 @@
-shouldNotCompile
+pipeline {
+  stages {
+    script {
+      echo '1'
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Builds that failed with a syntax error are "complete" and should just display the fallback UI.

In not flagging them as complete, we merge in the stages of the previous build and keep polling them.

### Testing done

Left: fixed; right: main

<img width="1920" height="1052" alt="Screenshot at 2026-07-04 17-58-06" src="https://github.com/user-attachments/assets/412b1488-612f-45f0-b852-a0f331898ef5" />
<img width="1920" height="1052" alt="Screenshot at 2026-07-04 17-57-42" src="https://github.com/user-attachments/assets/72190205-6199-40fb-838a-73cc53b9f883" />

The tests used a pipeline that did not produce an actual syntax error, but rather a pipeline error "No such property: shouldNotCompile ... ". I've added a pipeline that produces an actual compile error with no execution and extended the tests to check on that.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
