### PR TITLE
Use Jenkins core variables where possible

### DIFF
--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/data-tree-view.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/data-tree-view.scss
@@ -12,7 +12,7 @@ $pgv-item-padding-inline: 0.7rem;
     position: absolute;
     inset: 0;
     background: var(--card-background);
-    border: var(--card-border-width) solid var(--card-border-color);
+    border: var(--jenkins-border);
     border-radius: var(--form-input-border-radius);
     box-shadow: var(--form-input-glow);
     transition: var(--standard-transition);

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.scss
@@ -6,7 +6,7 @@
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 0 0.5rem;
-  padding: 0.125rem 0.75rem 0.125rem calc(1rem + var(--jenkins-border-width));
+  padding: 0.125rem 0.7rem 0.125rem calc(1rem + var(--jenkins-border-width));
   border-radius: var(--form-input-border-radius);
   margin-bottom: 0.75rem;
   z-index: 101;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.scss
@@ -16,8 +16,7 @@
     position: absolute;
     inset: 0;
     background: oklch(from var(--bg-color) l c h / 0.075);
-    border: var(--jenkins-border-width) solid
-      oklch(from var(--bg-color) l c h / 0.1);
+    border: var(--jenkins-border-width) solid var(--jenkins-border-color--inherit-subtle);
     border-radius: inherit;
     transition: var(--standard-transition);
     pointer-events: none;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.scss
@@ -16,7 +16,8 @@
     position: absolute;
     inset: 0;
     background: oklch(from var(--bg-color) l c h / 0.075);
-    border: var(--jenkins-border-width) solid var(--jenkins-border-color--inherit-subtle);
+    border: var(--jenkins-border-width) solid
+      var(--jenkins-border-color--inherit-subtle);
     border-radius: inherit;
     transition: var(--standard-transition);
     pointer-events: none;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-details.scss
@@ -6,7 +6,7 @@
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 0 0.5rem;
-  padding: 0.125rem 0.7rem 0.125rem calc(1rem + var(--jenkins-border-width));
+  padding: 0.125rem 0.75rem 0.125rem calc(1rem + var(--jenkins-border-width));
   border-radius: var(--form-input-border-radius);
   margin-bottom: 0.75rem;
   z-index: 101;

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-steps.scss
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/stage-steps.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: 0.375rem;
   background: var(--card-background);
-  border: var(--card-border-width) solid var(--card-border-color);
+  border: var(--jenkins-border);
   border-radius: var(--form-input-border-radius);
   padding: 0.375rem;
 }


### PR DESCRIPTION
Rather than using the deprecated `--card-border-*` variables lets use `--jenkins-border-*`. Slightly punchier lines in dark mode, less difference in light.

### Testing done

#### Before

<img width="430" height="355" alt="image" src="https://github.com/user-attachments/assets/90695647-c035-4183-a9c7-e760011fa5c1" />

#### After

<img width="430" height="355" alt="Screenshot 2026-07-06 at 18 00 35" src="https://github.com/user-attachments/assets/280eb954-eb18-46d4-afcd-8f4e4fd9605f" />

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
