### PR TITLE
Do not mark an initialising run without an execution as complete

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
@@ -68,9 +68,13 @@ public class PipelineGraphApi {
             @CheckForNull Map<String, List<String>> enclosingIdsByNodeId) {
         FlowExecution execution = run.getExecution();
         if (execution == null) {
-            // If we don't have an execution - e.g. if the Pipeline has a syntax error -
-            // then return an empty graph.
-            return new PipelineGraph(new ArrayList<>(), true);
+            // No execution either means the run finished without one (e.g. a syntax error),
+            // where the empty graph is final, or the run is still initialising (e.g. checking
+            // out the Jenkinsfile) and the execution doesn't exist yet. Only the former may be
+            // marked complete: complete=true responses are served with immutable cache headers
+            // and stop frontend polling, so marking an initialising run complete freezes its
+            // view empty forever.
+            return new PipelineGraph(new ArrayList<>(), !run.isBuilding());
         }
         // Look up completed state before computing tree.
         boolean complete = execution.isComplete();

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
@@ -5,8 +5,10 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
+import hudson.model.Action;
 import hudson.model.Queue;
 import hudson.model.Result;
+import hudson.model.TaskListener;
 import hudson.model.labels.LabelAtom;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.slaves.DumbSlave;
@@ -17,9 +19,14 @@ import io.jenkins.plugins.pipelinegraphview.treescanner.PipelineNodeTreeScanner;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
@@ -393,6 +400,42 @@ class PipelineGraphApiTest {
         PipelineGraph tree = new PipelineGraphApi(run).createTree();
         assertThat(tree.complete, equalTo(true));
         assertThat(tree.stages, empty());
+    }
+
+    @Issue("GH#1382")
+    @Test
+    void initialisingRunWithoutExecutionIsNotComplete() throws Exception {
+        WorkflowJob job = j.createProject(WorkflowJob.class, "initialisingRun");
+        BlockingFlowDefinition definition = new BlockingFlowDefinition();
+        job.setDefinition(definition);
+
+        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0);
+        assertThat(future, notNullValue());
+        WorkflowRun run = future.waitForStart();
+        definition.creating.await(30, TimeUnit.SECONDS);
+        assertThat(run.getExecution(), nullValue());
+        assertThat(run.isBuilding(), equalTo(true));
+
+        PipelineGraph tree = new PipelineGraphApi(run).createTree();
+        assertThat(tree.complete, equalTo(false));
+        assertThat(tree.stages, empty());
+
+        definition.release.countDown();
+        j.assertBuildStatusSuccess(j.waitForCompletion(run));
+        assertThat(new PipelineGraphApi(run).createTree().complete, equalTo(true));
+    }
+
+    private static class BlockingFlowDefinition extends FlowDefinition {
+        final CountDownLatch creating = new CountDownLatch(1);
+        final CountDownLatch release = new CountDownLatch(1);
+
+        @Override
+        public FlowExecution create(FlowExecutionOwner owner, TaskListener listener, List<? extends Action> actions)
+                throws Exception {
+            creating.countDown();
+            release.await();
+            return new CpsFlowDefinition("echo 'done'", true).create(owner, listener, actions);
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #1382, fixes #1385.

### The bug

While a run is initialising — e.g. a multibranch job checking out its Jenkinsfile, which can take several seconds — `run.getExecution()` is still `null` but the run is already building and its page is reachable. Since #1364, `PipelineGraphApi.createTree()` returns `complete=true` with empty stages for a null execution. That change was made for runs that *finished* without an execution (syntax error), but it cannot distinguish that from an execution that simply doesn't exist *yet*.

The consequences of the early `complete=true`:

1. `PipelineConsoleViewAction.getTree` serves complete trees with `Cache-Control: private, immutable, max-age=86400`, so the browser caches the empty graph for a day.
2. The frontend poller stops on `complete: true`, so even the open page never recovers.

Any browser that fetches `stages/tree` during the initialisation window therefore renders a blank Pipeline Overview for that run from then on ("stays broken forever" in #1382), even though the run goes on to store a perfectly good flow graph. It also explains #1385: clicking the Rebuild plugin's action lands the user on the new run's page immediately, inside the checkout window, so rebuilt runs were reliably blank for the person who triggered them — the `RebuildCause` itself was never relevant. It equally explains why unchecking the appearance options (job-page stages / build-page graph) "fixed" it for some users: those views poll the tree endpoint during the earliest seconds of a run.

### The fix

When there is no execution, report `complete = !run.isBuilding()` instead of a hardcoded `true` — the same semantics `PipelineStepApi` already uses for `runIsComplete`. An initialising run now gets `complete=false` (→ `Cache-Control: private, no-store`, polling continues), while the syntax-error case from #1364 keeps reporting `complete=true` because the run has finished by the time it is queried.

### Testing done

Added a JenkinsRule regression test that reproduces the initialisation window deterministically with a `FlowDefinition` blocking in `create()`: it asserts the tree is `complete=false`/empty stages while `getExecution()` is null and the run is building, then releases the build and asserts the tree becomes complete. The existing `pipelineWithSyntaxError` test still covers the finished-without-execution case.

I don't have a local JDK on this machine, so I'm relying on CI to run the suite — happy to iterate if anything is red.
