### PR TITLE
Show paused stages in the stage tree and status filter

### DIFF
--- a/src/main/frontend/common/components/filter.tsx
+++ b/src/main/frontend/common/components/filter.tsx
@@ -33,6 +33,11 @@ export default function Filter({ disabled }: FilterProps) {
       status: Result.queued,
     },
     {
+      key: "paused",
+      text: "Paused",
+      status: Result.paused,
+    },
+    {
       key: "success",
       text: "Successful",
       status: Result.success,

--- a/src/main/frontend/pipeline-console-view/pipeline-console/main/providers/filter-provider.tsx
+++ b/src/main/frontend/pipeline-console-view/pipeline-console/main/providers/filter-provider.tsx
@@ -18,6 +18,7 @@ const FilterContext = createContext<FilterContextType | undefined>(undefined);
 const defaultStatuses: Result[] = [
   Result.running,
   Result.queued,
+  Result.paused,
   Result.success,
   Result.failure,
   Result.unstable,


### PR DESCRIPTION
Fixes #1435

Stages in the `paused` state (waiting for `input`) were invisible in the Stages view tree: `filterStageTree()` drops any stage whose state is not in `visibleStatuses`, and `paused` was missing from both `defaultStatuses` (`filter-provider.tsx`) and the status filter dropdown (`filter.tsx`). Because a paused stage's ancestors are also `paused`, whole parallel branches vanished from the tree exactly while they awaited approval.

This adds `Result.paused` to the default visible statuses and a "Paused" entry to the filter dropdown, making paused stages behave like every other state — visible by default, filterable on demand.

### Testing done

`npm run format:check`, `npm run lint`, `npm test` (172/172) pass. Verified against a production build with 18 paused approval stages: with this change the paused branches render in the tree and match via search; the pause icon already exists in `StatusIcon`, so the dropdown entry renders correctly.
