### PR TITLE
Add collapseByDefault pipeline step

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ pipeline {
 }
 ```
 
+### Collapsing Stages by Default
+
+In Scripted Pipelines, you can mark a stage as initially collapsed by wrapping it with the `collapseByDefault` step:
+
+```groovy
+collapseByDefault {
+    stage('Tests') {
+        parallel tests
+    }
+}
+```
+
+The setting applies only to stages directly enclosed by the `collapseByDefault` block. Nested stages are unaffected unless they are wrapped in their own `collapseByDefault` block.
+
+Users can still expand or collapse the stage manually. Their choice is preserved across page reloads for the current build, while each new build starts from the pipeline-defined defaults again.
+
 ## REST API
 
 The REST API documentation can be found [here](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/jenkinsci/pipeline-graph-view-plugin/refs/heads/main/openapi.yaml).

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -400,6 +400,9 @@ components:
         placeholder:
           type: boolean
           description: Whether this is a placeholder stage
+        defaultCollapsed:
+          type: boolean
+          description: Whether this stage is collapsed by default
         agent:
           types:
             - string
@@ -620,6 +623,7 @@ components:
               isSequential: false
               synthetic: false
               placeholder: false
+              defaultCollapsed: false
               agent: "linux"
               url: "/job/my-pipeline/1/stages/?selected-node=6"
 

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/PipelineGraphModel.tsx
@@ -48,6 +48,7 @@ export interface StageInfo {
   isSequential?: boolean;
   placeholder?: boolean;
   synthetic?: boolean;
+  defaultCollapsed?: boolean;
   pauseDurationMillis: number;
   startTimeMillis: number;
   totalDurationMillis?: number; // will be null if the stage is still running

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/useCollapsedStages.spec.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/useCollapsedStages.spec.ts
@@ -1,7 +1,11 @@
+import { act, renderHook } from "@testing-library/react";
+
 import { Result, StageInfo } from "../PipelineGraphModel.tsx";
 import {
   collapseSelectiveStages,
+  collectDefaultCollapsedStageIds,
   collectParentStageIds,
+  useCollapsedStages,
 } from "./useCollapsedStages.ts";
 
 describe("collapseSelectiveStages", () => {
@@ -245,5 +249,133 @@ describe("collectParentStageIds", () => {
     ];
     const result = collectParentStageIds(stages);
     expect(result).toEqual(new Set([1, 2]));
+  });
+});
+
+describe("useCollapsedStages", () => {
+  const stages: StageInfo[] = [
+    {
+      name: "Default parent",
+      state: Result.success,
+      id: 1,
+      type: "STAGE",
+      defaultCollapsed: true,
+      children: [
+        {
+          name: "Default child",
+          state: Result.success,
+          id: 2,
+          type: "STAGE",
+          children: [],
+        } as unknown as StageInfo,
+      ],
+    } as unknown as StageInfo,
+    {
+      name: "Normal parent",
+      state: Result.success,
+      id: 3,
+      type: "STAGE",
+      children: [
+        {
+          name: "Normal child",
+          state: Result.success,
+          id: 4,
+          type: "STAGE",
+          children: [],
+        } as unknown as StageInfo,
+      ],
+    } as unknown as StageInfo,
+  ];
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("should collapse default-collapsed stages initially", () => {
+    const { result } = renderHook(() => useCollapsedStages("job/test", stages));
+
+    expect(result.current.collapsedStageIds).toEqual(new Set([1]));
+    expect(result.current.effectiveStages[0].children).toHaveLength(0);
+    expect(result.current.effectiveStages[1].children).toHaveLength(1);
+  });
+
+  it("should persist explicit expansion of a default-collapsed stage", () => {
+    const first = renderHook(() => useCollapsedStages("job/test", stages));
+
+    act(() => {
+      first.result.current.toggleCollapseStage(1);
+    });
+
+    expect(first.result.current.collapsedStageIds).toEqual(new Set());
+    first.unmount();
+
+    const second = renderHook(() => useCollapsedStages("job/test", stages));
+    expect(second.result.current.collapsedStageIds).toEqual(new Set());
+  });
+
+  it("should apply defaults again for a different build", () => {
+    const first = renderHook(() => useCollapsedStages("job/test/1", stages));
+
+    act(() => {
+      first.result.current.toggleCollapseStage(1);
+    });
+
+    expect(first.result.current.collapsedStageIds).toEqual(new Set());
+    first.unmount();
+
+    const second = renderHook(() => useCollapsedStages("job/test/2", stages));
+
+    expect(second.result.current.collapsedStageIds).toEqual(new Set([1]));
+  });
+
+  it("should persist expand all for default-collapsed stages", () => {
+    const first = renderHook(() => useCollapsedStages("job/test", stages));
+
+    act(() => {
+      first.result.current.expandAll();
+    });
+
+    first.unmount();
+
+    const second = renderHook(() => useCollapsedStages("job/test", stages));
+    expect(second.result.current.collapsedStageIds).toEqual(new Set());
+  });
+
+  it("should restore the default after explicitly collapsing it again", () => {
+    const first = renderHook(() => useCollapsedStages("job/test", stages));
+
+    act(() => {
+      first.result.current.toggleCollapseStage(1);
+    });
+    act(() => {
+      first.result.current.toggleCollapseStage(1);
+    });
+
+    first.unmount();
+
+    const second = renderHook(() => useCollapsedStages("job/test", stages));
+    expect(second.result.current.collapsedStageIds).toEqual(new Set([1]));
+  });
+});
+
+describe("collectDefaultCollapsedStageIds", () => {
+  it("should collect only collapsible stages marked as default collapsed", () => {
+    const stages: StageInfo[] = [
+      {
+        id: 1,
+        type: "STAGE",
+        defaultCollapsed: true,
+        children: [
+          {
+            id: 2,
+            type: "STAGE",
+            defaultCollapsed: false,
+            children: [],
+          } as unknown as StageInfo,
+        ],
+      } as unknown as StageInfo,
+    ];
+
+    expect(collectDefaultCollapsedStageIds(stages)).toEqual(new Set([1]));
   });
 });

--- a/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/useCollapsedStages.ts
+++ b/src/main/frontend/pipeline-graph-view/pipeline-graph/main/support/useCollapsedStages.ts
@@ -134,6 +134,24 @@ export function collectParentStageIds(stages: StageInfo[]): Set<number> {
   return ids;
 }
 
+export function collectDefaultCollapsedStageIds(
+  stages: StageInfo[],
+): Set<number> {
+  const ids = new Set<number>();
+  function walk(list: StageInfo[]) {
+    for (const stage of list) {
+      if (stage.children.length > 0) {
+        if (stage.defaultCollapsed) {
+          ids.add(stage.id);
+        }
+        walk(stage.children);
+      }
+    }
+  }
+  walk(stages);
+  return ids;
+}
+
 /**
  * Walk the original (uncollapsed) stage tree and return the IDs of any
  * collapsed ancestors of the stage with the given id (plus the target
@@ -176,9 +194,33 @@ export function useCollapsedStages(
   selectedStageId?: number,
 ) {
   const storageKey = `pgv.collapsedStages/${normalizedParentJobPath}`;
-  const [collapsedStageIds, setCollapsedStageIds] = useState<Set<number>>(() =>
-    loadFromStorage(storageKey),
+  const expandedDefaultsStorageKey = `pgv.expandedDefaultStages/${normalizedParentJobPath}`;
+
+  const [storedCollapsedStageIds, setStoredCollapsedStageIds] = useState<
+    Set<number>
+  >(() => loadFromStorage(storageKey));
+  const [expandedDefaultStageIds, setExpandedDefaultStageIds] = useState<
+    Set<number>
+  >(() => loadFromStorage(expandedDefaultsStorageKey));
+
+  const defaultCollapsedStageIds = useMemo(
+    () => collectDefaultCollapsedStageIds(stages),
+    [stages],
   );
+
+  const collapsedStageIds = useMemo(() => {
+    const ids = new Set(storedCollapsedStageIds);
+    for (const id of defaultCollapsedStageIds) {
+      if (!expandedDefaultStageIds.has(id)) {
+        ids.add(id);
+      }
+    }
+    return ids;
+  }, [
+    storedCollapsedStageIds,
+    defaultCollapsedStageIds,
+    expandedDefaultStageIds,
+  ]);
 
   useEffect(() => {
     garbageCollectLocalStorage();
@@ -186,7 +228,34 @@ export function useCollapsedStages(
 
   const toggleCollapseStage = useCallback(
     (stageId: number) => {
-      setCollapsedStageIds((prev) => {
+      const isCollapsed = collapsedStageIds.has(stageId);
+      const isDefaultCollapsed = defaultCollapsedStageIds.has(stageId);
+
+      if (isDefaultCollapsed) {
+        setExpandedDefaultStageIds((prev) => {
+          const next = new Set(prev);
+          if (isCollapsed) {
+            next.add(stageId);
+          } else {
+            next.delete(stageId);
+          }
+          saveToStorage(expandedDefaultsStorageKey, next);
+          return next;
+        });
+
+        if (isCollapsed) {
+          setStoredCollapsedStageIds((prev) => {
+            if (!prev.has(stageId)) return prev;
+            const next = new Set(prev);
+            next.delete(stageId);
+            saveToStorage(storageKey, next);
+            return next;
+          });
+        }
+        return;
+      }
+
+      setStoredCollapsedStageIds((prev) => {
         const next = new Set(prev);
         if (next.has(stageId)) {
           next.delete(stageId);
@@ -197,24 +266,33 @@ export function useCollapsedStages(
         return next;
       });
     },
-    [storageKey],
-  );
-
-  const setCollapsedIds = useCallback(
-    (ids: Set<number>) => {
-      setCollapsedStageIds(ids);
-      saveToStorage(storageKey, ids);
-    },
-    [storageKey],
+    [
+      collapsedStageIds,
+      defaultCollapsedStageIds,
+      expandedDefaultsStorageKey,
+      storageKey,
+    ],
   );
 
   const collapseAll = useCallback(() => {
-    setCollapsedIds(collectParentStageIds(stages));
-  }, [stages, setCollapsedIds]);
+    const ids = collectParentStageIds(stages);
+    setStoredCollapsedStageIds(ids);
+    saveToStorage(storageKey, ids);
+
+    const expanded = new Set<number>();
+    setExpandedDefaultStageIds(expanded);
+    saveToStorage(expandedDefaultsStorageKey, expanded);
+  }, [stages, storageKey, expandedDefaultsStorageKey]);
 
   const expandAll = useCallback(() => {
-    setCollapsedIds(new Set());
-  }, [setCollapsedIds]);
+    const collapsed = new Set<number>();
+    setStoredCollapsedStageIds(collapsed);
+    saveToStorage(storageKey, collapsed);
+
+    const expanded = new Set(defaultCollapsedStageIds);
+    setExpandedDefaultStageIds(expanded);
+    saveToStorage(expandedDefaultsStorageKey, expanded);
+  }, [defaultCollapsedStageIds, storageKey, expandedDefaultsStorageKey]);
 
   const hasCollapsibleStages = useMemo(
     () => collectParentStageIds(stages).size > 0,
@@ -239,12 +317,23 @@ export function useCollapsedStages(
       collapsedStageIds,
     );
     if (ancestors.length === 0) return;
-    setCollapsedStageIds((prev) => {
+    setStoredCollapsedStageIds((prev) => {
       const next = new Set(prev);
       for (const id of ancestors) {
         next.delete(id);
       }
       saveToStorage(storageKey, next);
+      return next;
+    });
+
+    setExpandedDefaultStageIds((prev) => {
+      const next = new Set(prev);
+      for (const id of ancestors) {
+        if (defaultCollapsedStageIds.has(id)) {
+          next.add(id);
+        }
+      }
+      saveToStorage(expandedDefaultsStorageKey, next);
       return next;
     });
   }, [selectedStageId]); // eslint-disable-line react-hooks/exhaustive-deps -- only react to selection changes

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/steps/CollapseByDefaultStep.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/steps/CollapseByDefaultStep.java
@@ -1,0 +1,57 @@
+package io.jenkins.plugins.pipelinegraphview.steps;
+
+import hudson.Extension;
+import io.jenkins.plugins.pipelinegraphview.Messages;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Set;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Pipeline step that marks directly enclosed stages as collapsed by default.
+ *
+ * <p>Nested stages are unaffected unless they are enclosed by their own
+ * {@code collapseByDefault} block.</p>
+ */
+public class CollapseByDefaultStep extends Step implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @DataBoundConstructor
+    public CollapseByDefaultStep() {
+        // No parameters needed - the step itself is the marker
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new CollapseByDefaultStepExecution(context);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public String getFunctionName() {
+            return "collapseByDefault";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.CollapseByDefaultStep_displayName();
+        }
+
+        @Override
+        public boolean takesImplicitBlockArgument() {
+            return true;
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.emptySet();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/steps/CollapseByDefaultStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/steps/CollapseByDefaultStepExecution.java
@@ -1,0 +1,29 @@
+package io.jenkins.plugins.pipelinegraphview.steps;
+
+import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+
+/**
+ * Execution for {@link CollapseByDefaultStep}.
+ *
+ * <p>This execution simply runs the enclosed body block. The step's presence in the
+ * flow graph serves as a marker for the Pipeline Graph View plugin.</p>
+ */
+public class CollapseByDefaultStepExecution extends StepExecution {
+
+    private static final long serialVersionUID = 1L;
+
+    protected CollapseByDefaultStepExecution(StepContext context) {
+        super(context);
+    }
+
+    @Override
+    public boolean start() throws Exception {
+        getContext()
+                .newBodyInvoker()
+                .withCallback(BodyExecutionCallback.wrap(getContext()))
+                .start();
+        return false;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/FlowNodeWrapper.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/FlowNodeWrapper.java
@@ -8,6 +8,7 @@ import hudson.model.Result;
 import hudson.model.Run;
 import io.jenkins.plugins.pipelinegraphview.Messages;
 import io.jenkins.plugins.pipelinegraphview.analysis.TimingInfo;
+import io.jenkins.plugins.pipelinegraphview.steps.CollapseByDefaultStep;
 import io.jenkins.plugins.pipelinegraphview.steps.HideFromViewStep;
 import io.jenkins.plugins.pipelinegraphview.treescanner.PipelineNodeGraphAdapter;
 import io.jenkins.plugins.pipelinegraphview.utils.BlueRun.BlueRunResult;
@@ -441,6 +442,28 @@ public class FlowNodeWrapper {
 
     public boolean isUnhandledException() {
         return PipelineNodeUtil.isUnhandledException(node);
+    }
+
+    public boolean isCollapsedByDefault() {
+        if (!PipelineNodeUtil.isStage(this.node)) {
+            return false;
+        }
+
+        for (BlockStartNode block : this.node.iterateEnclosingBlocks()) {
+            if (PipelineNodeUtil.isStage(block)) {
+                return false;
+            }
+
+            if (!(block instanceof StepStartNode stepStartNode)) {
+                continue;
+            }
+
+            StepDescriptor descriptor = stepStartNode.getDescriptor();
+            if (descriptor != null && CollapseByDefaultStep.class.getName().equals(descriptor.getId())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApi.java
@@ -45,6 +45,7 @@ public class PipelineGraphApi {
                         flowNodeWrapper.getType(),
                         flowNodeWrapper.getDisplayName(), // TODO blue ocean uses timing information: "Passed in 0s"
                         flowNodeWrapper.isSynthetic(),
+                        flowNodeWrapper.isCollapsedByDefault(),
                         flowNodeWrapper.getTiming(),
                         getStageNode(flowNodeWrapper, workspaceNodes, enclosingIdsByNodeId),
                         flowNodeWrapper.getCauseOfBlockage()))

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphViewCache.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphViewCache.java
@@ -37,7 +37,7 @@ import tools.jackson.databind.json.JsonMapper;
  */
 public class PipelineGraphViewCache {
 
-    public static final int SCHEMA_VERSION = 3;
+    public static final int SCHEMA_VERSION = 4;
 
     public static final String TREE_FILE_NAME = "pipeline-graph-view-tree.v" + SCHEMA_VERSION + ".json";
     public static final String ALL_STEPS_FILE_NAME = "pipeline-graph-view-allsteps.v" + SCHEMA_VERSION + ".json";

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStage.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStage.java
@@ -18,6 +18,7 @@ public class PipelineStage extends AbstractPipelineNode {
     private final boolean sequential;
 
     final boolean synthetic;
+    final boolean defaultCollapsed;
     private final boolean placeholder;
     final String agent;
     private final String url;
@@ -34,6 +35,7 @@ public class PipelineStage extends AbstractPipelineNode {
             boolean sequential,
             boolean synthetic,
             boolean placeholder,
+            boolean defaultCollapsed,
             TimingInfo timingInfo,
             String agent,
             String runUrl,
@@ -44,6 +46,7 @@ public class PipelineStage extends AbstractPipelineNode {
         this.nextSibling = nextSibling;
         this.sequential = sequential;
         this.synthetic = synthetic;
+        this.defaultCollapsed = defaultCollapsed;
         this.placeholder = placeholder;
         this.agent = agent;
         this.url = "/" + runUrl + URL_NAME + "/?selected-node=" + id;
@@ -62,6 +65,7 @@ public class PipelineStage extends AbstractPipelineNode {
             @JsonProperty("isSequential") boolean sequential,
             boolean synthetic,
             boolean placeholder,
+            boolean defaultCollapsed,
             long pauseDurationMillis,
             Long totalDurationMillis,
             long startTimeMillis,
@@ -74,6 +78,7 @@ public class PipelineStage extends AbstractPipelineNode {
         this.nextSibling = nextSibling;
         this.sequential = sequential;
         this.synthetic = synthetic;
+        this.defaultCollapsed = defaultCollapsed;
         this.placeholder = placeholder;
         this.agent = agent;
         this.url = url;

--- a/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStageInternal.java
+++ b/src/main/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineStageInternal.java
@@ -23,6 +23,7 @@ class PipelineStageInternal {
     private String causeOfBlockage;
     private PipelineStepBuilderApi builder;
     private InputAction inputAction;
+    private boolean defaultCollapsed;
 
     public PipelineStageInternal(
             String id,
@@ -32,6 +33,7 @@ class PipelineStageInternal {
             FlowNodeWrapper.NodeType type,
             String title,
             boolean synthetic,
+            boolean defaultCollapsed,
             TimingInfo times,
             String agent,
             String causeOfBlockage) {
@@ -42,6 +44,7 @@ class PipelineStageInternal {
         this.type = type;
         this.title = title;
         this.synthetic = synthetic;
+        this.defaultCollapsed = defaultCollapsed;
         this.timingInfo = times;
         this.agent = agent;
         this.causeOfBlockage = causeOfBlockage;
@@ -190,6 +193,7 @@ class PipelineStageInternal {
                 sequential,
                 synthetic,
                 synthetic && name.equals(Messages.FlowNodeWrapper_noStage()),
+                defaultCollapsed,
                 timingInfo,
                 agent,
                 runUrl,

--- a/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/pipelinegraphview/Messages.properties
@@ -50,3 +50,4 @@ collapse.expandAll=Expand all stages
 collapse.collapseAll=Collapse all stages
 
 HideFromViewStep.displayName=Hide from View
+CollapseByDefaultStep.displayName=Collapse by Default

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineGraphApiTest.java
@@ -111,6 +111,24 @@ class PipelineGraphApiTest {
     }
 
     @Test
+    void createTree_collapseByDefault() throws Exception {
+        WorkflowRun run =
+                TestUtils.createAndRunJob(j, "collapseByDefault", "collapseByDefault.jenkinsfile", Result.SUCCESS);
+
+        List<PipelineStage> stages = new PipelineGraphApi(run).createTree().stages;
+        String stagesString = TestUtils.collectStagesAsString(
+                stages, stage -> String.format("%s{%s}", stage.name, stage.defaultCollapsed));
+
+        assertThat(
+                stagesString,
+                equalTo(
+                        String.join(
+                                "",
+                                "Normal parent{false}[Normal A{false}[Normal child A{false}],Normal B{false}[Normal child B{false}]],",
+                                "Default parent{true}[Default A{false}[Default child A{false}],Default B{false}[Default child B{false}]]")));
+    }
+
+    @Test
     @DisplayName("When no stage synthetic stage is used")
     void noStage() throws Exception {
         WorkflowRun run = TestUtils.createAndRunJob(j, "noStage", "noStage.jenkinsfile", Result.SUCCESS);

--- a/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineJsonWriterTest.java
+++ b/src/test/java/io/jenkins/plugins/pipelinegraphview/utils/PipelineJsonWriterTest.java
@@ -122,6 +122,7 @@ class PipelineJsonWriterTest {
                 true,
                 false,
                 false,
+                true,
                 new TimingInfo(500, 0, 1_700_000_002_000L),
                 "built-in",
                 "job/example/1/",
@@ -134,6 +135,7 @@ class PipelineJsonWriterTest {
         assertThat(s, is(notNullValue()));
         assertThat(s.getBoolean("isSequential"), is(true));
         assertThat(s.has("sequential"), is(false));
+        assertThat(s.getBoolean("defaultCollapsed"), is(true));
         assertThat(s.has("nextSibling"), is(false));
         assertThat(s.has("seqContainerName"), is(false));
         assertThat(s.getString("agent"), is("built-in"));

--- a/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/collapseByDefault.jenkinsfile
+++ b/src/test/resources/io/jenkins/plugins/pipelinegraphview/utils/collapseByDefault.jenkinsfile
@@ -1,0 +1,31 @@
+stage('Normal parent') {
+    parallel(
+        'Normal A': {
+            stage('Normal child A') {
+                echo ''
+            }
+        },
+        'Normal B': {
+            stage('Normal child B') {
+                echo ''
+            }
+        },
+    )
+}
+
+collapseByDefault {
+    stage('Default parent') {
+        parallel(
+            'Default A': {
+                stage('Default child A') {
+                    echo ''
+                }
+            },
+            'Default B': {
+                stage('Default child B') {
+                    echo ''
+                }
+            },
+        )
+    }
+}


### PR DESCRIPTION
## Add collapseByDefault pipeline step

Adds a `collapseByDefault` Pipeline step for Scripted Pipelines, allowing stages to be initially collapsed in Pipeline Graph View.

```groovy
collapseByDefault {
    stage('Tests') {
        parallel tests
    }
}
```

The setting applies only to stages directly enclosed by the `collapseByDefault` block. Nested stages are unaffected unless they are wrapped in their own `collapseByDefault` block.

The pipeline-defined value is used only as the initial state. Users can still expand or collapse a stage manually, and that choice is preserved across page reloads for the current build. A new build starts from the pipeline-defined defaults again.

### Changes

* add the `collapseByDefault` Pipeline step
* expose the default-collapse state through the Pipeline Graph API
* initialize the frontend collapse state from the pipeline-defined default
* preserve explicit user expand/collapse decisions per build
* add backend and frontend tests
* document the new Pipeline DSL extension
* update the OpenAPI specification

### Testing

* `mvn clean test-compile`
* `mvn -Dtest=PipelineGraphApiTest,PipelineJsonWriterTest surefire:test`
* `mvn frontend:npm -Dfrontend.npm.arguments="exec vitest run pipeline-graph-view/pipeline-graph/main/support/useCollapsedStages.spec.ts"`
* `git diff --check`

The change has also been exercised in a production Pipeline Graph View installation before opening the PR.
